### PR TITLE
Fix stray village grid char and the two "known failing" tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1069,15 +1069,15 @@ npm run test:run   # same, if make is unavailable
 blocks it lives at `.claude/hooks/guard-test-command.sh` (not registered by default; see
 [`tests/README.md`](tests/README.md) to enable).
 
-**Expected baseline:** two tests currently fail on `main` (`cropGrowth`, `eventChains`) for
-reasons unrelated to most work. Treat "2 failed" as green; investigate only if the count rises
-or a *different* file fails.
+**Expected baseline: the suite is fully green.** Every test passes on `main`. Any failure is a
+real regression — yours or one you have just surfaced — so do not wave it through. (This used
+to read "treat 2 failed as green"; those two were test bugs, not data bugs, and are fixed.)
 
 **What the tests guard:** see [`tests/README.md`](tests/README.md) — it maps each test file to
 the mistake it catches, so a failure tells you what to fix.
 
 **Before Committing:**
-1. Run `make verify` - typecheck must be clean, tests at or below the known baseline
+1. Run `make verify` - typecheck must be clean and every test must pass
 2. Test in browser - Game must run without console errors
 3. Check HMR - Changes should hot-reload
 4. Review self-tests - Startup sanity checks must pass

--- a/maps/definitions/village.ts
+++ b/maps/definitions/village.ts
@@ -98,7 +98,7 @@ LG,,GXXXXXX,G,lP,,G,,,,,G,e,GL
 JG,GG,,G,,GGG,,P,,GXXXXXG,5eGt
 LG,,,G,G,,;;G8,PG,GXXXXXeG,,GU
 oGoc,,;;,G,,,G,P,,G,G,,l,U,,,,
-tLoGG,l,,lGL,´GLG,,L,L,LUoLL,,
+tLoGG,l,,lGL,GGLG,,L,L,LUoLL,,
 `;
 
 export const village: MapDefinition = {

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,15 +22,27 @@ npm run test:run   # same, if make is unavailable
 > ]
 > ```
 
-## The baseline is "2 failed"
+## The baseline is green
 
-Two tests fail on `main` for reasons unrelated to most work:
+Every test passes on `main`. **Any** failure is a real regression — do not wave one through as
+"pre-existing".
 
-- `cropGrowth.test.ts` — a crop ROI/profitability assertion
-- `eventChains.test.ts` — YAML chain validation expects the category list to include `romance`
+This section used to document two permanent failures (`cropGrowth`, `eventChains`). Both turned
+out to be bugs in the *tests*, not the game data, and are fixed:
 
-Treat **2 failed / 422 passed** as green. Investigate only if the count rises or a *different*
-file fails. To confirm something is genuinely pre-existing, run it against a clean tree:
+- `cropGrowth.test.ts` judged every crop on a single harvest, which is the wrong model for a
+  perennial. Mint (`isHerb: true`) breaks even on harvest one and profits from harvest two
+  onwards — healthy, but it scored `profit === 0`. Annuals and perennials are now asserted
+  separately.
+- `eventChains.test.ts` kept its own copy of the valid chain-type list, which went stale when
+  `romance` was added to the loader. It now imports `VALID_EVENT_TYPES` from
+  `utils/eventChainLoader.ts` so the list cannot drift again.
+
+The lesson worth keeping: a long-lived "known failure" is worth re-reading before trusting it —
+both of these were masking a stale test, and a standing "treat N failed as green" rule will hide
+the next real regression too.
+
+To confirm something is genuinely pre-existing, run it against a clean tree:
 
 ```bash
 git worktree add /tmp/baseline HEAD

--- a/tests/cropGrowth.test.ts
+++ b/tests/cropGrowth.test.ts
@@ -149,17 +149,73 @@ describe('Crop Growth System', () => {
   });
 
   describe('Crop ROI (Return on Investment)', () => {
-    it('all harvestable crops should be profitable', () => {
+    /**
+     * A perennial herb is planted once and harvested repeatedly (`harvestCooldownDays`),
+     * so its seed cost is a one-off spread across every future harvest. Mint breaking even
+     * on harvest one (2 × 5g against a 10g seed) and turning pure profit from harvest two
+     * onwards is a healthy perennial, not a broken one — so demanding profit from a single
+     * harvest is the wrong model for herbs. What *would* be broken is a seed so expensive
+     * it never realistically pays back, so we bound the payback period instead.
+     */
+    const HERB_PAYBACK_HARVESTS = 3;
+
+    it('annual crops should profit from their single harvest', () => {
+      const unprofitable: string[] = [];
+
       Object.entries(CROPS).forEach(([id, crop]) => {
         // Skip decorative crops (e.g. fairy_bluebell) — not harvestable
         if (crop.harvestYield === 0) return;
+        // Perennials are covered by the payback test below
+        if (crop.isHerb) return;
 
         const revenue = crop.sellPrice * crop.harvestYield;
-        const cost = crop.seedCost;
-        const profit = revenue - cost;
+        const profit = revenue - crop.seedCost;
 
-        expect(profit).toBeGreaterThan(0);
+        if (profit <= 0) {
+          unprofitable.push(
+            `${id}: ${crop.harvestYield} × ${crop.sellPrice}g = ${revenue}g revenue ` +
+              `vs ${crop.seedCost}g seed (profit ${profit}g)`
+          );
+        }
       });
+
+      if (unprofitable.length > 0) {
+        console.error(
+          `Annual crops that return no more than they cost to plant:\n  ${unprofitable.join('\n  ')}\n\n` +
+            'FIX: raise sellPrice/harvestYield or lower seedCost in data/crops.ts. ' +
+            'A crop that cannot turn a profit is a crop nobody will plant twice. ' +
+            'If it is meant to regrow, set isHerb: true so it is judged on payback instead.'
+        );
+      }
+      expect(unprofitable).toEqual([]);
+    });
+
+    it('perennial herbs should repay their seed within a few harvests', () => {
+      const slowPayback: string[] = [];
+
+      Object.entries(CROPS).forEach(([id, crop]) => {
+        if (!crop.isHerb || crop.harvestYield === 0) return;
+
+        const revenuePerHarvest = crop.sellPrice * crop.harvestYield;
+        const harvestsToPayback =
+          revenuePerHarvest > 0 ? crop.seedCost / revenuePerHarvest : Infinity;
+
+        if (harvestsToPayback > HERB_PAYBACK_HARVESTS) {
+          slowPayback.push(
+            `${id}: ${revenuePerHarvest}g per harvest vs ${crop.seedCost}g seed ` +
+              `= ${harvestsToPayback.toFixed(1)} harvests to break even`
+          );
+        }
+      });
+
+      if (slowPayback.length > 0) {
+        console.error(
+          `Herbs whose seed takes more than ${HERB_PAYBACK_HARVESTS} harvests to repay:\n  ` +
+            `${slowPayback.join('\n  ')}\n\n` +
+            'FIX: lower seedCost or raise sellPrice/harvestYield in data/crops.ts.'
+        );
+      }
+      expect(slowPayback).toEqual([]);
     });
 
     it('should calculate profit margins correctly', () => {

--- a/tests/eventChains.test.ts
+++ b/tests/eventChains.test.ts
@@ -192,7 +192,8 @@ describe('YAML Event Chain Files', () => {
   });
 
   it('should load and validate all chain definitions', async () => {
-    const { loadAllEventChains } = await import('../utils/eventChainLoader');
+    // Assert against the loader's own set, not a copy — see VALID_EVENT_TYPES.
+    const { loadAllEventChains, VALID_EVENT_TYPES } = await import('../utils/eventChainLoader');
     const chains = loadAllEventChains();
 
     expect(chains.length).toBeGreaterThanOrEqual(3);
@@ -204,7 +205,7 @@ describe('YAML Event Chain Files', () => {
       expect(def.id).toBeTruthy();
       expect(def.title).toBeTruthy();
       expect(def.description).toBeTruthy();
-      expect(['discovery', 'achievement', 'seasonal', 'community', 'mystery']).toContain(def.type);
+      expect([...VALID_EVENT_TYPES]).toContain(def.type);
       expect(def.trigger.type).toBeTruthy();
       expect(def.stages.length).toBeGreaterThan(0);
 

--- a/tests/tileRegistration.test.ts
+++ b/tests/tileRegistration.test.ts
@@ -287,14 +287,14 @@ describe('Tile Registration - No Silently Dropped Duplicates', () => {
  * `customCodes`, parseGrid silently substitutes GRASS and logs a warning nobody reads —
  * so a typo becomes a permanent, invisible patch of grass.
  *
- * `´` (U+00B4) in village.ts is almost certainly a slipped keystroke: on a Mac it is what
- * Option+E produces. Which tile actually belongs there is a judgement call about how that
- * spot in the village should look, so it is recorded rather than guessed at.
+ * This list is empty, and should stay that way. It previously held `´` (U+00B4) at village
+ * (13, 29) — a slipped dead-key keystroke that had been rendering as fallback GRASS since it
+ * was typed. It is now an explicit `G`, which is what that spot always looked like.
  *
  * ⚠️ Do NOT add characters here to silence a grid you are editing. Use a real code, or
  * register one — either in GRID_CODES (maps/gridParser.ts) or in that map's customCodes.
  */
-const KNOWN_UNKNOWN_GRID_CHARS = ['´'];
+const KNOWN_UNKNOWN_GRID_CHARS: string[] = [];
 
 describe('Map grids use only recognised grid codes', () => {
   it('parsing every map definition produces no "Unknown grid code" warnings', async () => {
@@ -316,7 +316,9 @@ describe('Map grids use only recognised grid codes', () => {
     }
 
     const unexpected = [
-      ...new Set(unknown.filter((w) => !KNOWN_UNKNOWN_GRID_CHARS.some((c) => w.includes(`'${c}'`)))),
+      ...new Set(
+        unknown.filter((w) => !KNOWN_UNKNOWN_GRID_CHARS.some((c) => w.includes(`'${c}'`)))
+      ),
     ];
 
     if (unexpected.length > 0) {

--- a/utils/eventChainLoader.ts
+++ b/utils/eventChainLoader.ts
@@ -23,7 +23,19 @@ const yamlModules = import.meta.glob('/data/eventChains/*.yaml', {
 // Validation
 // ============================================
 
-const VALID_EVENT_TYPES = new Set(['discovery', 'achievement', 'seasonal', 'community', 'mystery', 'romance']);
+/**
+ * The authoritative set of chain `type` values. Exported so tests assert against this
+ * rather than keeping their own copy — a duplicated list silently goes stale the moment
+ * a new type is added here (which is exactly how 'romance' came to fail the suite).
+ */
+export const VALID_EVENT_TYPES = new Set([
+  'discovery',
+  'achievement',
+  'seasonal',
+  'community',
+  'mystery',
+  'romance',
+]);
 const VALID_TRIGGER_TYPES = new Set([
   'manual',
   'event_count',


### PR DESCRIPTION
Two small, independent fixes on top of `main` (which now includes the refactor + guardrail tests from #5).

## 1. Stray grid character in the village map

`maps/definitions/village.ts` carried a `´` (U+00B4) at grid position **(13, 29)** — in neither `GRID_CODES` nor the village's `customCodes`. `parseGrid` fell back to `GRASS` and logged `Unknown grid code` on every single map load.

It was a slipped dead-key keystroke from the commit that rewrote that row (on a US-International layout, `´` is what the `'` key produces). Notably `'` *was* a live grid code at the time — `ADDERSMEAT` — but that's a 3×3 night-blooming deep-forest forageable with `offsetY: -2`, so honouring the "intended" keystroke would have sprawled a glowing magical plant across rows 27–29 of the village edge. Clearly not the intent.

The tile is decorative only: bottom edge row, two columns west of the south exit at (15, 28). Replaced with `G` — **exactly what it has rendered as since it was typed**, so no visual change, just explicit intent and no more warning.

This also empties `KNOWN_UNKNOWN_GRID_CHARS`, which had recorded the character as an open judgement call. The allowlist is now empty, making the guardrail **strictly stronger**: any unrecognised grid code in any map now fails.

## 2. The two "known failing" tests — both were test bugs, not data bugs

The suite is now fully green, so the standing "treat 2 failed as green" advice is removed from `CLAUDE.md` and `tests/README.md`. A rule that trains you to skip past red tests will hide the next real regression too.

**`cropGrowth`** judged every crop on a single harvest, which is the wrong model for a perennial. Mint (`isHerb: true`, `harvestCooldownDays: 1`) returns 2 × 5g against a 10g seed, so it scored `profit === 0` despite its own description saying it *"regrows after harvesting"* — the seed is a one-off amortised across every later harvest, so breaking even on harvest one is healthy. Annuals and perennials are now asserted separately: annuals must profit from their single harvest (unchanged rule, still covers all 17), perennials must repay their seed within `HERB_PAYBACK_HARVESTS = 3`. Current herbs sit at 0.33 / 1.00 / 0.36, leaving headroom for an expensive rare herb without letting a never-pays-back seed through.

**`eventChains`** kept its own copy of the valid chain-type list, which went stale when `romance` was added to the loader (`mr_fox_picnic.yaml` uses it, and it has a matching cutscene). Rather than patch the copy so it can drift again, `VALID_EVENT_TYPES` is now exported from `utils/eventChainLoader.ts` and the test asserts against that single source of truth.

Both rewritten assertions follow the `tests/itemSSoT.test.ts` house style — collect every violation, assert once, fail with a message naming the offender and the fix.

## Verification

`make verify` — typecheck clean, **425 passed, 0 failed**.

Guardrails were mutation-tested rather than trusted on a green run:

| Mutation | Result |
|---|---|
| mint seed `10g → 500g` | caught — *"50.0 harvests to break even"* |
| radish sell `10g → 1g` | caught — *"1g revenue vs 5g seed (profit -4g)"* |
| re-introduce `´` in the village grid | caught — *"Unrecognised grid codes"* |

## Note for the reviewer

⚠️ `.github/workflows/deploy.yml` gates on `tsc --noEmit` and the build only — **it never runs the test suite**, so none of these guardrails can block a deploy. Worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)