### PR TITLE
CI: bump actions off deprecated Node 20; drop unused App.tsx destructures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,12 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -58,12 +58,12 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -81,10 +81,10 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './dist'
 
@@ -98,4 +98,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/firebase.yml
+++ b/.github/workflows/firebase.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install Firebase CLI
         run: npm install -g firebase-tools

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -39,7 +39,7 @@ jobs:
           npx wait-on http://localhost:4000/TwilightGame/ --timeout 60000
 
       - name: Download baseline (if exists)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: perf-baseline
           path: .
@@ -85,7 +85,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -120,7 +120,7 @@ jobs:
             }
 
       - name: Upload results as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: perf-results
           path: |
@@ -133,7 +133,7 @@ jobs:
 
       - name: Update baseline on main
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: perf-baseline
           path: perf-results.json

--- a/App.tsx
+++ b/App.tsx
@@ -296,16 +296,13 @@ const App: React.FC = () => {
     playerScale,
     playerSizeTier,
     isFairyForm,
-    isPathing,
     clickToMoveDestination,
     clickToMoveTargetNPC,
     playerPosRef,
     isMovingRef,
     updateMovement,
     setDestination: setClickToMoveDestination,
-    cancelPath,
     setPlayerPos,
-    setDirection,
     setPlayerScale,
     setPlayerSizeTier,
     setFairyForm,
@@ -334,14 +331,11 @@ const App: React.FC = () => {
     setRadialMenuVisible,
     farmActionAnimation,
     farmActionKey,
-    waterSparklePos,
-    waterSparkleKey,
     showSplashEffect,
     splashKey,
     handleCanvasClick,
     handleFarmActionAnimation,
     handleAnimationComplete,
-    clearWaterSparkle,
     hideSplashEffect,
   } = useInteractionController({
     playerPos,
@@ -453,7 +447,6 @@ const App: React.FC = () => {
   };
 
   // Farm update handler - no-op since EventBus handles this now
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   const handleFarmUpdate = useCallback(() => {
     // Events are now emitted by FarmManager via EventBus
   }, []);
@@ -1451,8 +1444,6 @@ const App: React.FC = () => {
   // PixiJS renderer hook - manages all PixiJS rendering layers
   const {
     isPixiInitialized,
-    pixiAppRef,
-    npcLayerRef,
     backgroundImageLayerRef,
     weatherManagerRef,
     weatherLayerRef,


### PR DESCRIPTION
Two follow-ups from the PR #7 deploy logs. tsc clean, 0 lint errors, 431 tests pass.

## CI runner deprecation (Node 20 → 24)
Every workflow action targeted Node 20, which GitHub is retiring — runners already force them onto Node 24 and log a deprecation notice on every run. Bumped all first-party actions to their current majors across `deploy.yml`, `firebase.yml`, `performance.yml`:

| action | was | now |
|---|---|---|
| checkout | v4 | v7 |
| setup-node | v4 | v7 |
| configure-pages | v4 | v6 |
| upload-pages-artifact | v3 | v5 |
| deploy-pages | v4 | v5 |
| upload-artifact | v4 | v7 |
| download-artifact | v4 | v8 |
| github-script | v7 | v9 |

Usage is vanilla (no changed inputs). Also bumped the build's own `node-version` 20 → 22 — Node 20 reached end-of-life, 22 is the current LTS.

⚠️ **Review note:** the `verify` job cannot exercise the Pages/deploy actions (build + deploy are guarded to non-PR events), so those bumps are only validated on the merge deploy. If the deploy job fails, the previously-deployed site stays live — I'll watch the run and fix forward if needed.

## App.tsx unused-var warnings
Removed 8 properties destructured from controller hooks but never used (`isPathing`, `cancelPath`, `setDirection`, `waterSparklePos`, `waterSparkleKey`, `clearWaterSparkle`, `pixiAppRef`, `npcLayerRef`) and one stale `eslint-disable` directive. 19 → 11 warnings in App.tsx.

The remaining 11 are all `react-hooks/exhaustive-deps` and are **left deliberately** — adding those deps can change runtime behaviour (extra renders, stale closures) in a file nothing tests at runtime, so they need a playtested change, not a blind edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)