### PR TITLE
Fix 'this.mask is null' weather fog crash

### DIFF
--- a/docs/ARCHITECTURE_GOTCHAS.md
+++ b/docs/ARCHITECTURE_GOTCHAS.md
@@ -299,7 +299,35 @@ Background-image rooms use pre-drawn artwork instead of tile-by-tile rendering. 
 
 ---
 
-## 6. Quick Debugging Checklist
+## 6. PixiJS Mask Lifecycle — destroy order matters
+
+**Symptom:** the game white-screens into the ErrorBoundary with
+`can't access property "measurable", this.mask is null` (Firefox wording; other browsers phrase
+it differently). It comes from deep inside PixiJS — `AlphaMask.addLocalBounds` → `addMaskLocalBounds`,
+which does `mask.measurable = true` on a mask that is gone.
+
+**Root cause:** assigning `sprite.mask = maskSprite` attaches an `AlphaMask` **effect** to `sprite`
+that holds a reference to `maskSprite`. If you then `maskSprite.destroy()` **without** first setting
+`sprite.mask = null`, the effect is left pointing at freed memory, and Pixi's next bounds/culling
+pass dereferences it and throws. The only user of masks today is `utils/pixi/WeatherLayer.ts` (the
+feathered fog edge), so this surfaces as a weather/fog crash — often after a weather transition or a
+resize while fog is active.
+
+**The rules (whenever you use `.mask`):**
+- **Null the reference before destroying the mask sprite:** `sprite.mask = null;` *then*
+  `maskSprite.destroy();` — never the reverse.
+- **Never overwrite a masked sprite reference without tearing the old one down first.** If a setup
+  function reassigns `this.fooSprite = new Sprite(...)`, call the teardown (which nulls the mask and
+  destroys both sprites) at the *top* of setup. Teardown must be null-safe so calling it twice is fine.
+- **Add the mask to the display tree before assigning it:** `container.addChild(maskSprite);` *then*
+  `sprite.mask = maskSprite;` — Pixi measures the mask through the scene graph.
+
+`WeatherLayer.clearFog()` is the reference implementation; `setupFog()` calls it first and
+`_applyFogMask()` nulls the ref before destroying. Follow that shape for any new masked layer.
+
+---
+
+## 7. Quick Debugging Checklist
 
 When something feels "off" with interactions:
 

--- a/utils/pixi/WeatherLayer.ts
+++ b/utils/pixi/WeatherLayer.ts
@@ -288,6 +288,13 @@ export class WeatherLayer {
       return;
     }
 
+    // Tear down any previous fog + mask first. Overwriting this.fogSprite below without this
+    // would leak the old (still-masked) sprite; _applyFogMask would then destroy its mask
+    // sprite out from under it, and Pixi's next bounds/cull pass crashes in
+    // AlphaMask.addLocalBounds ("this.mask is null"). clearFog() is null-safe, so calling it
+    // here is harmless on the paths that already cleared.
+    this.clearFog();
+
     // Create tiling fog sprite (seamless scrolling)
     this.fogSprite = new PIXI.TilingSprite({
       texture,
@@ -301,7 +308,6 @@ export class WeatherLayer {
 
     // Apply feathered edge mask to prevent sharp rectangular cutoff
     this._applyFogMask();
-
   }
 
   /**
@@ -317,6 +323,9 @@ export class WeatherLayer {
       this.fogMaskTexture = null;
     }
     if (this.fogMaskSprite) {
+      // Clear the mask reference BEFORE destroying the sprite, or the fogSprite keeps an
+      // AlphaMask effect pointing at freed memory and Pixi crashes on the next bounds pass.
+      this.fogSprite.mask = null;
       this.fogMaskSprite.destroy();
       this.fogMaskSprite = null;
     }
@@ -327,8 +336,10 @@ export class WeatherLayer {
       FOG_EDGE_FEATHER
     );
     this.fogMaskSprite = new PIXI.Sprite(this.fogMaskTexture);
-    this.fogSprite.mask = this.fogMaskSprite;
+    // Add to the display tree before assigning as a mask (Pixi v8 measures the mask via the
+    // scene graph; assigning first can warn/misbehave).
     this.fogContainer.addChild(this.fogMaskSprite);
+    this.fogSprite.mask = this.fogMaskSprite;
   }
 
   /**


### PR DESCRIPTION
## The crash
A player hit a full white-screen (caught by the ErrorBoundary — "progress has been saved"):

> can't access property "measurable", this.mask is null

It comes from inside PixiJS: `AlphaMask.addLocalBounds` → `addMaskLocalBounds`, which does `mask.measurable = true` on a mask that has been freed.

## Root cause
`utils/pixi/WeatherLayer.ts` is the only user of `.mask` (the feathered fog edge). Assigning `fogSprite.mask = fogMaskSprite` attaches an AlphaMask **effect** holding a reference to the mask sprite. Two paths destroyed the mask sprite while the effect still pointed at it:

- `setupFog()` overwrites `this.fogSprite` with a fresh sprite; if it ever ran without a preceding `clearFog()`, the old **masked** sprite leaked and `_applyFogMask()` then destroyed its mask sprite out from under it.
- `_applyFogMask()` destroyed the previous mask sprite **without** first setting `fogSprite.mask = null`.

Either way, the next bounds/culling pass dereferenced a dead mask and threw. It surfaces on weather transitions or a resize while fog/mist is active.

## Fix — correct-by-construction
- `setupFog()` calls `clearFog()` first (null-safe) → can never leak or overwrite a masked sprite.
- `_applyFogMask()` nulls `fogSprite.mask` before destroying the old mask sprite.
- Mask sprite is added to the container before being assigned as a mask (Pixi v8 measures via the scene graph).

## Verification
tsc clean, lint clean, 431 tests pass. **WeatherLayer needs WebGL/canvas, so it is not unit-testable in the node suite** — the fix targets the exact Pixi crash path (traced through the installed pixi source) and holds the mask invariant unconditionally. Documented the pattern in `docs/ARCHITECTURE_GOTCHAS.md` for the next masked layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)