### PR TITLE
Make the PixiJS mask crash hard to reintroduce (helper + guard test)

### DIFF
--- a/docs/ARCHITECTURE_GOTCHAS.md
+++ b/docs/ARCHITECTURE_GOTCHAS.md
@@ -313,17 +313,28 @@ pass dereferences it and throws. The only user of masks today is `utils/pixi/Wea
 feathered fog edge), so this surfaces as a weather/fog crash — often after a weather transition or a
 resize while fog is active.
 
-**The rules (whenever you use `.mask`):**
-- **Null the reference before destroying the mask sprite:** `sprite.mask = null;` *then*
-  `maskSprite.destroy();` — never the reverse.
-- **Never overwrite a masked sprite reference without tearing the old one down first.** If a setup
-  function reassigns `this.fooSprite = new Sprite(...)`, call the teardown (which nulls the mask and
-  destroys both sprites) at the *top* of setup. Teardown must be null-safe so calling it twice is fine.
-- **Add the mask to the display tree before assigning it:** `container.addChild(maskSprite);` *then*
-  `sprite.mask = maskSprite;` — Pixi measures the mask through the scene graph.
+**Don't hand-roll it — use the helper.** All mask assignment goes through
+[`utils/pixi/maskUtils.ts`](../utils/pixi/maskUtils.ts):
 
-`WeatherLayer.clearFog()` is the reference implementation; `setupFog()` calls it first and
-`_applyFogMask()` nulls the ref before destroying. Follow that shape for any new masked layer.
+```typescript
+import { attachMask, disposeMask } from './maskUtils';
+
+attachMask(target, maskSprite, parent);          // addChild(mask) THEN target.mask = mask
+this.maskSprite = disposeMask(target, maskSprite); // target.mask = null THEN mask.destroy(); returns null
+```
+
+`tests/pixiMaskSafety.test.ts` fails the build if any file outside `maskUtils.ts` assigns `.mask =`
+directly, so the funnel can't be bypassed.
+
+**The rules these helpers encode (why they exist):**
+- **Null the reference before destroying the mask sprite** — never the reverse (`disposeMask`).
+- **Never overwrite a masked sprite without tearing the old one down first.** A setup function that
+  reassigns `this.fooSprite = new Sprite(...)` must call its null-safe teardown at the *top*.
+- **Add the mask to the display tree before assigning it** — Pixi measures it through the scene
+  graph (`attachMask`).
+
+`WeatherLayer` is the reference user: `setupFog()` calls `clearFog()` first, and both `clearFog()`
+and `_applyFogMask()` go through `disposeMask`/`attachMask`.
 
 ---
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,6 +68,7 @@ box, an out-of-bounds transition dumps the player somewhere arbitrary. Nothing t
 | `minigameRequirements.test.ts` | Required items not actually gating play; a game being unreachable | Adding a mini-game with requirements |
 | `interactionProviders.test.ts` | Provider registry wiring and the `exclusive` short-circuit | Adding a click interaction |
 | `wreathWorkshop.test.ts` | Capture geometry, pointer maths under `transform: scale()`, decoration instance matching | Touching the wreath workshop or custom decorations |
+| `pixiMaskSafety.test.ts` | Raw `.mask =` assignment outside `maskUtils` (guards the "this.mask is null" crash) | Adding/using a PixiJS mask (fog, lighting, spotlights) |
 | `colorResolver.test.ts` | Colour resolution behaviour through map schemes | Touching tile colours or palettes |
 | `palette.test.ts` | Palette definitions stay consistent | Changing the colour palette |
 | `farmManager.test.ts` / `cropGrowth.test.ts` | Planting, watering, growth stages, crop economics | Touching farming |

--- a/tests/pixiMaskSafety.test.ts
+++ b/tests/pixiMaskSafety.test.ts
@@ -1,0 +1,91 @@
+/** @vitest-environment node */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, dirname, relative, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Guards against the "this.mask is null" PixiJS crash (docs/ARCHITECTURE_GOTCHAS.md §6).
+ *
+ * Assigning `target.mask = maskSprite` attaches an effect holding a reference to the mask
+ * sprite. Destroying the mask sprite (or overwriting the target) without first clearing
+ * `target.mask` leaves that effect dangling, and Pixi's next bounds/cull pass throws. The safe
+ * order is encoded once in utils/pixi/maskUtils.ts (`attachMask` / `disposeMask`).
+ *
+ * This test fails the build if any OTHER file assigns `.mask =` directly, so the funnel cannot
+ * be bypassed. If it fires: route your mask through attachMask/disposeMask instead of assigning
+ * `.mask` by hand.
+ */
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** The one file allowed to assign `.mask` directly — the sanctioned helper. */
+const ALLOWED = 'utils/pixi/maskUtils.ts';
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  '.git',
+  'tests',
+  'coverage',
+  'public',
+  'assets-optimized',
+  'scratchpad',
+  '.claude',
+]);
+
+/** Matches a raw mask assignment `x.mask =` (but not `==` and not `.masked`). */
+const RAW_MASK_ASSIGN = /\.mask\s*=(?!=)/;
+
+function collectSourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) collectSourceFiles(join(dir, entry.name), out);
+    } else if (/\.(ts|tsx)$/.test(entry.name)) {
+      out.push(join(dir, entry.name));
+    }
+  }
+  return out;
+}
+
+/** True for lines that are entirely a comment, so a `.mask` mentioned in prose doesn't trip. */
+function isCommentLine(line: string): boolean {
+  const t = line.trim();
+  return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*');
+}
+
+describe('PixiJS mask assignment is funnelled through maskUtils', () => {
+  it('no source file outside maskUtils.ts assigns `.mask` directly', () => {
+    const violations: string[] = [];
+
+    for (const file of collectSourceFiles(REPO_ROOT)) {
+      const rel = relative(REPO_ROOT, file);
+      if (rel === ALLOWED) continue;
+
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        if (isCommentLine(line)) return;
+        if (RAW_MASK_ASSIGN.test(line)) {
+          violations.push(`${rel}:${i + 1}  ${line.trim()}`);
+        }
+      });
+    }
+
+    if (violations.length > 0) {
+      console.error(
+        `Raw \`.mask =\` assignment found outside ${ALLOWED}:\n` +
+          violations.join('\n') +
+          `\n\nFIX: assign Pixi masks only via attachMask()/disposeMask() from ${ALLOWED}. ` +
+          `A hand-rolled \`.mask =\` risks the "this.mask is null" crash — see ` +
+          `docs/ARCHITECTURE_GOTCHAS.md §6.`
+      );
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('maskUtils exports the sanctioned helpers', () => {
+    const src = readFileSync(resolve(REPO_ROOT, ALLOWED), 'utf8');
+    expect(src).toMatch(/export function attachMask\b/);
+    expect(src).toMatch(/export function disposeMask\b/);
+  });
+});

--- a/utils/pixi/WeatherLayer.ts
+++ b/utils/pixi/WeatherLayer.ts
@@ -20,6 +20,7 @@
  */
 
 import * as PIXI from 'pixi.js';
+import { attachMask, disposeMask } from './maskUtils';
 import { TIMING } from '../../constants';
 import { textureManager } from '../TextureManager';
 import { particleAssets } from '../../assets';
@@ -317,18 +318,12 @@ export class WeatherLayer {
   private _applyFogMask(): void {
     if (!this.fogSprite) return;
 
-    // Clean up old mask
+    // Clean up old mask (disposeMask clears fogSprite.mask before destroying the sprite).
     if (this.fogMaskTexture) {
       this.fogMaskTexture.destroy(true);
       this.fogMaskTexture = null;
     }
-    if (this.fogMaskSprite) {
-      // Clear the mask reference BEFORE destroying the sprite, or the fogSprite keeps an
-      // AlphaMask effect pointing at freed memory and Pixi crashes on the next bounds pass.
-      this.fogSprite.mask = null;
-      this.fogMaskSprite.destroy();
-      this.fogMaskSprite = null;
-    }
+    this.fogMaskSprite = disposeMask(this.fogSprite, this.fogMaskSprite);
 
     this.fogMaskTexture = createFogEdgeMask(
       this.viewportWidth,
@@ -336,10 +331,7 @@ export class WeatherLayer {
       FOG_EDGE_FEATHER
     );
     this.fogMaskSprite = new PIXI.Sprite(this.fogMaskTexture);
-    // Add to the display tree before assigning as a mask (Pixi v8 measures the mask via the
-    // scene graph; assigning first can warn/misbehave).
-    this.fogContainer.addChild(this.fogMaskSprite);
-    this.fogSprite.mask = this.fogMaskSprite;
+    attachMask(this.fogSprite, this.fogMaskSprite, this.fogContainer);
   }
 
   /**
@@ -603,14 +595,11 @@ export class WeatherLayer {
    * Clear fog overlay and its edge mask
    */
   private clearFog(): void {
+    // Detach + destroy the mask first (clears fogSprite.mask safely), then the fog sprite.
+    this.fogMaskSprite = disposeMask(this.fogSprite, this.fogMaskSprite);
     if (this.fogSprite) {
-      this.fogSprite.mask = null;
       this.fogSprite.destroy();
       this.fogSprite = null;
-    }
-    if (this.fogMaskSprite) {
-      this.fogMaskSprite.destroy();
-      this.fogMaskSprite = null;
     }
     if (this.fogMaskTexture) {
       this.fogMaskTexture.destroy(true);

--- a/utils/pixi/maskUtils.ts
+++ b/utils/pixi/maskUtils.ts
@@ -1,0 +1,39 @@
+/**
+ * Safe PixiJS mask attach/detach.
+ *
+ * PixiJS masking has one non-obvious ordering rule that, if broken, causes a hard
+ * white-screen crash — `can't access property "measurable", this.mask is null` — from deep
+ * inside Pixi's bounds/cull pass (AlphaMask.addLocalBounds). See docs/ARCHITECTURE_GOTCHAS.md §6.
+ *
+ * Assigning `target.mask = maskSprite` attaches an effect to `target` that holds a reference to
+ * `maskSprite`. Destroying `maskSprite` — or overwriting `target` — without first clearing
+ * `target.mask` leaves that effect pointing at freed memory.
+ *
+ * ALWAYS route mask assignment through these helpers. `tests/pixiMaskSafety.test.ts` fails the
+ * build if any other file assigns `.mask =` directly.
+ */
+
+import type { Container } from 'pixi.js';
+
+/**
+ * Attach `mask` to `target` in the order Pixi needs: the mask must be in the display tree (so
+ * it can be measured) BEFORE it is assigned. Adds it to `parent`, then sets it as the mask.
+ */
+export function attachMask(target: Container, mask: Container, parent: Container): void {
+  parent.addChild(mask);
+  target.mask = mask;
+}
+
+/**
+ * Detach and destroy a mask safely: clear `target.mask` BEFORE destroying the mask sprite.
+ * Both arguments are nullable so callers can pass possibly-cleared state without guards.
+ * Returns `null` so the caller can reassign in one line:
+ *   `this.maskSprite = disposeMask(this.target, this.maskSprite);`
+ */
+export function disposeMask(target: Container | null, mask: Container | null): null {
+  if (mask) {
+    if (target) target.mask = null;
+    mask.destroy();
+  }
+  return null;
+}


### PR DESCRIPTION
Follow-up to #9 (the fog "this.mask is null" crash). Rather than rely on everyone remembering the mask ordering rule, this makes the correct way the only way and enforces it.

## What
- **`utils/pixi/maskUtils.ts`** — `attachMask()` / `disposeMask()` encode the safe order once:
  - attach: `addChild(mask)` **then** `target.mask = mask` (Pixi measures via the scene graph)
  - dispose: `target.mask = null` **then** `mask.destroy()` (never the reverse)
- **`WeatherLayer`** routes all masking through them — it now contains **zero raw `.mask =`** assignments. Behaviour-identical to the #9 fix.
- **`tests/pixiMaskSafety.test.ts`** fails the build if any file *outside* `maskUtils.ts` assigns `.mask =` directly. Verified it actually catches an injected violation (not a vacuous pass).
- **`docs/ARCHITECTURE_GOTCHAS.md` §6** now points at the helper as the required API.

## Why this is the right shape
`.mask` is used in exactly one place in the codebase (the fog edge), so funnelling it is clean and false-positive-free. The next masked layer (lighting, spotlights — both in the Pixi migration plans) physically can't recreate the crash without the guard going red first.

tsc clean, lint clean, 433 tests pass (2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)