### PR TITLE
Fix a second batch of correctness bugs found across the codebase

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -19,7 +19,7 @@ import DevTools from './components/DevTools';
 import SpriteMetadataEditor from './components/SpriteMetadataEditor/SpriteMetadataEditor';
 import Bookshelf from './components/Bookshelf';
 import { initializeGameCore, initializeGameAssets } from './utils/gameInitializer';
-import { mapManager } from './maps';
+import { mapManager, transitionToMap } from './maps';
 import { getValidationErrors, hasValidationErrors, MapValidationError } from './maps/gridParser';
 import { gameState, CharacterCustomization } from './GameState';
 import { useTouchDevice } from './hooks/useTouchDevice';
@@ -184,6 +184,11 @@ const App: React.FC = () => {
   // Load player location from saved state
   const savedLocation = gameState.getPlayerLocation();
   const [currentMapId, setCurrentMapId] = useState<string>(savedLocation.mapId);
+  // Always-fresh mirror of currentMapId for closures captured once at mount (e.g. the
+  // stamina-exhaustion teleportHome callback below), which would otherwise keep reading
+  // the boot-time map id forever instead of the player's actual map when they collapse.
+  const currentMapIdRef = useRef(currentMapId);
+  currentMapIdRef.current = currentMapId;
   const [isDebugOpen, setDebugOpen] = useState(false);
   const [showCollisionBoxes, setShowCollisionBoxes] = useState(false); // Toggle collision box overlay
   const [inventoryItems, setInventoryItems] = useState<InventoryItem[]>([]); // Player inventory items
@@ -408,22 +413,28 @@ const App: React.FC = () => {
 
   // Map transition handler
   const handleMapTransition = (mapId: string, spawnPos: Position) => {
-    const oldMapId = currentMapId;
-    // Load the new map in MapManager so collision, tile data, and getTransitionAt() all
-    // reflect the target map immediately (before React batches the state update).
-    mapManager.loadMap(mapId);
-    setCurrentMapId(mapId);
-    teleportPlayer(spawnPos);
+    // Read via the ref, not the closed-over `currentMapId` state, since some callers
+    // (e.g. the stamina-exhaustion teleportHome callback) capture this function once at
+    // mount — the state value would stay frozen at whatever map was current at mount.
+    const oldMapId = currentMapIdRef.current;
+    // Route through transitionToMap (the same validated entry point door-based
+    // transitions use) so hardcoded destinations — cutscenes, the stamina-exhaustion
+    // teleport-home, "sent to bed" — get wall/bounds validation and a safe-spawn
+    // fallback too. A stale or mistyped coordinate here must never drop the player
+    // inside a solid tile with no way to recover.
+    const { map, spawn } = transitionToMap(mapId, spawnPos);
+    setCurrentMapId(map.id);
+    teleportPlayer(spawn);
     lastTransitionTime.current = Date.now();
 
     // End Yule celebration BEFORE updating the NPC manager's map, so that
     // removeDynamicNPC() still targets 'village' (its currentMapId at this point).
-    if (mapId !== 'village' && yuleCelebrationManager.isActive()) {
+    if (map.id !== 'village' && yuleCelebrationManager.isActive()) {
       yuleCelebrationManager.forceEnd();
     }
 
     // Update NPC manager's current map
-    npcManager.setCurrentMap(mapId);
+    npcManager.setCurrentMap(map.id);
 
     // Reset fairy attraction manager when changing maps
     fairyAttractionManager.reset();
@@ -432,13 +443,13 @@ const App: React.FC = () => {
     resetZoom();
 
     // Play Mr. Fox greeting when entering the shop
-    if (mapId.includes('shop')) {
+    if (map.id.includes('shop')) {
       setTimeout(() => audioManager.playSfx('sfx_mr_fox'), 800);
     }
 
     // Shared farm sync: start/stop when entering/leaving shared maps
     const wasShared = SHARED_FARM_MAP_IDS.has(oldMapId);
-    const isShared = SHARED_FARM_MAP_IDS.has(mapId);
+    const isShared = SHARED_FARM_MAP_IDS.has(map.id);
     if (isShared && !wasShared) {
       farmManager.startSharedSync();
     } else if (wasShared && !isShared) {
@@ -2651,20 +2662,20 @@ const App: React.FC = () => {
                             },
                           ]
                         : isSkis
-                        ? []
-                        : [
-                            {
-                              id: 'place',
-                              label: 'Place in World',
-                              icon: '🌍',
-                              color: '#3b82f6',
-                              onSelect: () => {
-                                setSelectedItemSlot(inventoryRadialMenu.slotIndex);
-                                closeUI('inventory');
-                                setInventoryRadialMenu(null);
+                          ? []
+                          : [
+                              {
+                                id: 'place',
+                                label: 'Place in World',
+                                icon: '🌍',
+                                color: '#3b82f6',
+                                onSelect: () => {
+                                  setSelectedItemSlot(inventoryRadialMenu.slotIndex);
+                                  closeUI('inventory');
+                                  setInventoryRadialMenu(null);
+                                },
                               },
-                            },
-                          ]),
+                            ]),
                       ...(isSkis
                         ? [
                             {
@@ -2676,7 +2687,8 @@ const App: React.FC = () => {
                                 setInventoryRadialMenu(null);
                                 const currentMapId = mapManager.getCurrentMapId() ?? '';
                                 const isForest =
-                                  currentMapId.startsWith('forest') || currentMapId === 'deep_forest';
+                                  currentMapId.startsWith('forest') ||
+                                  currentMapId === 'deep_forest';
                                 const isWinter =
                                   TimeManager.getCurrentTime().season === Season.WINTER;
                                 if (isForest && isWinter) {

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -31,7 +31,7 @@ class ErrorBoundary extends React.Component<{ children: React.ReactNode }, Error
 
   handleClearAndReload = () => {
     try {
-      localStorage.removeItem('gameState');
+      localStorage.removeItem('twilight_game_state');
     } catch {
       // Ignore storage errors during cleanup
     }

--- a/components/GiftModal.tsx
+++ b/components/GiftModal.tsx
@@ -37,9 +37,7 @@ interface GiftModalProps {
 }
 
 // Categories of items that cannot be gifted (tools only)
-const NON_GIFTABLE_CATEGORIES = [
-  ItemCategory.TOOL,
-];
+const NON_GIFTABLE_CATEGORIES = [ItemCategory.TOOL];
 
 // Get display name for recipe category
 const CATEGORY_DISPLAY_NAMES: Record<RecipeCategory, string> = {
@@ -52,6 +50,9 @@ const CATEGORY_DISPLAY_NAMES: Record<RecipeCategory, string> = {
 
 const GiftModal: React.FC<GiftModalProps> = ({ npcId, onClose, onGiftGiven }) => {
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
+  // Guards against a double-tap/double-click submitting the gift twice
+  // (awarding friendship points twice) before onClose() unmounts the modal.
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Get NPC data
   const npc = useMemo(() => npcManager.getNPCById(npcId), [npcId]);
@@ -107,10 +108,12 @@ const GiftModal: React.FC<GiftModalProps> = ({ npcId, onClose, onGiftGiven }) =>
 
   // Handle gift confirmation
   const handleGiveGift = () => {
-    if (!selectedItemId) return;
+    if (!selectedItemId || isSubmitting) return;
 
     const itemDef = getItem(selectedItemId);
     if (!itemDef) return;
+
+    setIsSubmitting(true);
 
     // Give the gift via FriendshipManager
     const result = friendshipManager.giveGift(npcId, selectedItemId, npc || undefined);
@@ -287,17 +290,18 @@ const GiftModal: React.FC<GiftModalProps> = ({ npcId, onClose, onGiftGiven }) =>
           </div>
           <button
             onClick={handleGiveGift}
-            disabled={!selectedItemId}
+            disabled={!selectedItemId || isSubmitting}
             className={`
               px-6 py-2 rounded-lg font-bold transition-all
               ${
-                selectedItemId
+                selectedItemId && !isSubmitting
                   ? 'bg-pink-600 hover:bg-pink-500 text-white cursor-pointer'
                   : 'bg-pink-800 text-pink-500 cursor-not-allowed'
               }
             `}
           >
-            Give Gift <GameIcon icon="🎁" size={20} alt="Gift" className="inline-block align-middle ml-1" />
+            Give Gift{' '}
+            <GameIcon icon="🎁" size={20} alt="Gift" className="inline-block align-middle ml-1" />
           </button>
         </div>
       </div>

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -24,18 +24,39 @@ interface ToastProps {
  * Messages auto-dismiss after 3 seconds
  */
 const Toast: React.FC<ToastProps> = ({ messages, onDismiss, playerScreenX, playerScreenY }) => {
+  // Track one dismiss timer per message id so a newly-arriving toast doesn't
+  // reset the countdown for toasts that are already on screen.
+  const timersRef = React.useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
+
   useEffect(() => {
-    // Auto-dismiss messages after 3 seconds
-    const timers = messages.map((msg) => {
-      return setTimeout(() => {
-        onDismiss(msg.id);
-      }, 3000);
+    const timers = timersRef.current;
+    const currentIds = new Set(messages.map((msg) => msg.id));
+
+    messages.forEach((msg) => {
+      if (!timers.has(msg.id)) {
+        const timer = setTimeout(() => {
+          timers.delete(msg.id);
+          onDismiss(msg.id);
+        }, 3000);
+        timers.set(msg.id, timer);
+      }
     });
 
+    timers.forEach((timer, id) => {
+      if (!currentIds.has(id)) {
+        clearTimeout(timer);
+        timers.delete(id);
+      }
+    });
+  }, [messages, onDismiss]);
+
+  useEffect(() => {
+    const timers = timersRef.current;
     return () => {
       timers.forEach((timer) => clearTimeout(timer));
+      timers.clear();
     };
-  }, [messages, onDismiss]);
+  }, []);
 
   if (messages.length === 0) return null;
 
@@ -98,7 +119,12 @@ const Toast: React.FC<ToastProps> = ({ messages, onDismiss, playerScreenX, playe
             boxShadow: '0 4px 12px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.1)',
           }}
         >
-          <GameIcon icon={getIcon(msg.type)} size={16} className="mr-2" style={{ display: 'inline-block', verticalAlign: 'middle' }} />
+          <GameIcon
+            icon={getIcon(msg.type)}
+            size={16}
+            className="mr-2"
+            style={{ display: 'inline-block', verticalAlign: 'middle' }}
+          />
           <span className="text-sm font-medium italic">{msg.message}</span>
         </div>
       ))}

--- a/data/items.ts
+++ b/data/items.ts
@@ -108,10 +108,14 @@ export function getCropItemId(cropId: string): string {
 }
 
 /**
- * Get seed item ID from crop definition ID
+ * Get seed item ID from crop definition ID.
+ * Looks up the actual registered seed item rather than guessing `seed_${cropId}`,
+ * since some seeds (e.g. `seed_wild_strawberry` for crop `strawberry`) don't follow
+ * that naming pattern.
  */
 export function getSeedItemId(cropId: string): string {
-  return `seed_${cropId}`;
+  const seedItem = getSeedForCrop(cropId);
+  return seedItem ? seedItem.id : `seed_${cropId}`;
 }
 
 /**

--- a/hooks/useEnvironmentController.ts
+++ b/hooks/useEnvironmentController.ts
@@ -24,6 +24,7 @@ import {
 import { mapManager } from '../maps/MapManager';
 import { npcManager } from '../NPCManager';
 import { yuleCelebrationManager } from '../utils/YuleCelebrationManager';
+import { eventChainManager } from '../utils/EventChainManager';
 import { TileType } from '../types';
 import type { WeatherManager } from '../utils/WeatherManager';
 import type { WeatherLayer } from '../utils/pixi/WeatherLayer';
@@ -657,6 +658,10 @@ export function useEnvironmentController(
       if (weatherManagerRef.current) {
         weatherManagerRef.current.checkWeatherUpdate();
       }
+
+      // Auto-advance event chain stages that have waited long enough
+      // (waitDays stages with no player choices — see EventChainManager.checkAutoAdvance)
+      eventChainManager.checkAutoAdvance();
     }, 10000); // Check every 10 seconds
 
     return () => clearInterval(interval);

--- a/hooks/usePixiRenderer.ts
+++ b/hooks/usePixiRenderer.ts
@@ -32,7 +32,14 @@ import { HighlightLayer } from '../utils/pixi/HighlightLayer';
 import { ThoughtBubbleLayer } from '../utils/pixi/ThoughtBubbleLayer';
 import { WeatherManager } from '../utils/WeatherManager';
 import { shouldShowWeather } from '../data/weatherConfig';
-import { tileAssets, farmingAssets, cookingAssets, npcAssets, itemAssets, orchardAssets } from '../assets';
+import {
+  tileAssets,
+  farmingAssets,
+  cookingAssets,
+  npcAssets,
+  itemAssets,
+  orchardAssets,
+} from '../assets';
 import { mapManager } from '../maps';
 import { gameState } from '../GameState';
 import { npcManager } from '../NPCManager';
@@ -311,7 +318,9 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
         placedItemsLayerRef.current = placedItemsLayer;
         placedItemsLayer.setDepthContainer(depthSortedContainer);
         placedItemsLayer.setOnTextureLoaded(() => {
-          eventBus.emit(GameEvent.PLACED_ITEMS_CHANGED, { mapId: mapManager.getCurrentMapId() ?? 'village' });
+          eventBus.emit(GameEvent.PLACED_ITEMS_CHANGED, {
+            mapId: mapManager.getCurrentMapId() ?? 'village',
+          });
         });
         app.stage.addChild(placedItemsLayer.getContainer());
 
@@ -459,6 +468,14 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
         pixiAppRef.current.destroy(true);
         pixiAppRef.current = null;
       }
+      // initPixi() below creates a fresh BackgroundImageLayer with its own EventBus
+      // subscriptions — dispose the old one first or its listeners leak forever
+      // (this effect's own cleanup never runs here, since isPixiInitialized isn't
+      // one of its dependencies).
+      if (backgroundImageLayerRef.current) {
+        backgroundImageLayerRef.current.dispose();
+        backgroundImageLayerRef.current = null;
+      }
       // The effect will re-run because isPixiInitialized changed
       setTimeout(() => initPixi(), 100);
     };
@@ -479,7 +496,7 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
         tileLayerRef.current = null;
       }
       if (backgroundImageLayerRef.current) {
-        backgroundImageLayerRef.current.clear();
+        backgroundImageLayerRef.current.dispose();
         backgroundImageLayerRef.current = null;
       }
       if (spriteLayerRef.current) {

--- a/maps/MapManager.ts
+++ b/maps/MapManager.ts
@@ -2,6 +2,7 @@ import { MapDefinition, Position, TileType, ColorScheme, isTileSolid, Transition
 import { npcManager } from '../NPCManager';
 import { validateMapDefinition } from './gridParser';
 import { TILE_LEGEND, PLAYER_SIZE } from '../constants';
+import { metadataCache } from '../utils/MetadataCache';
 
 /**
  * MapManager - Single Source of Truth for all map data
@@ -130,6 +131,46 @@ class MapManager {
         }
       }
     }
+
+    // Also check multi-tile sprite footprints (furniture, trees, buildings). Their solid
+    // collision box extends well beyond the single anchor tile marked in the grid — e.g.
+    // WITCH_HUT is 11 tiles wide from one anchor — so a spawn point can land on a plain,
+    // walkable-looking grid cell while actually sitting inside a large structure. This
+    // mirrors the second pass in hooks/useCollisionDetection.ts.
+    const searchRadius = Math.ceil(metadataCache.maxSpriteSize) + 1;
+    for (let tileY = minTileY - searchRadius; tileY <= maxTileY + searchRadius; tileY++) {
+      if (tileY < 0 || tileY >= map.grid.length) continue;
+      for (let tileX = minTileX - searchRadius; tileX <= maxTileX + searchRadius; tileX++) {
+        if (tileX < 0 || tileX >= map.grid[0].length) continue;
+
+        const tileType = map.grid[tileY][tileX];
+        const spriteMetadata = metadataCache.getMetadata(tileType);
+        if (!spriteMetadata) continue;
+
+        const tileData = TILE_LEGEND[tileType];
+        if (!tileData || !isTileSolid(tileData.collisionType)) continue;
+
+        const collisionWidth = spriteMetadata.collisionWidth ?? spriteMetadata.spriteWidth;
+        const collisionHeight = spriteMetadata.collisionHeight ?? spriteMetadata.spriteHeight;
+        const collisionOffsetX = spriteMetadata.collisionOffsetX ?? spriteMetadata.offsetX;
+        const collisionOffsetY = spriteMetadata.collisionOffsetY ?? spriteMetadata.offsetY;
+
+        const spriteLeft = tileX + collisionOffsetX;
+        const spriteRight = spriteLeft + collisionWidth;
+        const spriteTop = tileY + collisionOffsetY;
+        const spriteBottom = spriteTop + collisionHeight;
+
+        if (
+          pos.x + halfSize > spriteLeft &&
+          pos.x - halfSize < spriteRight &&
+          pos.y + halfSize > spriteTop &&
+          pos.y - halfSize < spriteBottom
+        ) {
+          return false; // Position would collide with a multi-tile sprite
+        }
+      }
+    }
+
     return true; // Position is safe
   }
 

--- a/tests/eventChains.test.ts
+++ b/tests/eventChains.test.ts
@@ -377,3 +377,81 @@ describe('EventChainManager - getDaysSinceStageEntered', () => {
     expect(eventChainManager.getDaysSinceStageEntered(CHAIN_ID)).toBe(7);
   });
 });
+
+// ============================================
+// EventChainManager - checkAutoAdvance()
+// ============================================
+
+describe('EventChainManager - checkAutoAdvance()', () => {
+  // Real, shipped content: mysterious_lights' "wait and see" choice leads to a
+  // waitDays:2 stage with no player choices. checkAutoAdvance() is what's
+  // supposed to move it on — it used to never be called anywhere in the app
+  // (see hooks/useEnvironmentController.ts), so this path was a permanent
+  // dead end for any player who picked it.
+  const CHAIN_ID = 'mysterious_lights';
+  const CAUTIOUS_CHOICE_INDEX = 1; // "Let's wait and see what happens" -> cautious_path
+
+  afterAll(async () => {
+    const { TimeManager } = await import('../utils/TimeManager');
+    TimeManager.clearTimeOverride();
+  });
+
+  beforeEach(async () => {
+    const { eventChainManager } = await import('../utils/EventChainManager');
+    const { TimeManager, Season } = await import('../utils/TimeManager');
+
+    eventChainManager.initialise();
+    eventChainManager.resetChain(CHAIN_ID);
+    TimeManager.setTimeOverride({ season: Season.SPRING, year: 1, day: 1 });
+  });
+
+  it('does not advance a waitDays stage before enough days have passed', async () => {
+    const { eventChainManager } = await import('../utils/EventChainManager');
+    const { TimeManager } = await import('../utils/TimeManager');
+
+    await eventChainManager.startChain(CHAIN_ID);
+    await eventChainManager.makeChoice(CHAIN_ID, CAUTIOUS_CHOICE_INDEX);
+    expect(eventChainManager.getProgress(CHAIN_ID)?.currentStageId).toBe('cautious_path');
+
+    TimeManager.setTimeOverride({ day: 2 }); // only 1 day elapsed, waitDays is 2
+    await eventChainManager.checkAutoAdvance();
+
+    expect(eventChainManager.getProgress(CHAIN_ID)?.currentStageId).toBe('cautious_path');
+  });
+
+  it('advances a waitDays stage with no choices once enough days have passed, and grants its rewards', async () => {
+    const { eventChainManager } = await import('../utils/EventChainManager');
+    const { TimeManager } = await import('../utils/TimeManager');
+    const { inventoryManager } = await import('../utils/inventoryManager');
+
+    while (inventoryManager.hasItem('moonpetal', 1)) {
+      inventoryManager.removeItem('moonpetal', 1);
+    }
+
+    await eventChainManager.startChain(CHAIN_ID);
+    await eventChainManager.makeChoice(CHAIN_ID, CAUTIOUS_CHOICE_INDEX);
+    expect(eventChainManager.getProgress(CHAIN_ID)?.currentStageId).toBe('cautious_path');
+
+    TimeManager.setTimeOverride({ day: 3 }); // 2 days elapsed, meets waitDays: 2
+    await eventChainManager.checkAutoAdvance();
+
+    expect(eventChainManager.getProgress(CHAIN_ID)?.currentStageId).toBe('resolution');
+    expect(eventChainManager.isChainCompleted(CHAIN_ID)).toBe(true);
+    // resolution stage grants 3x moonpetal — confirms auto-advance actually
+    // runs the stage-entry side effects, not just moving the pointer.
+    expect(inventoryManager.hasItem('moonpetal', 3)).toBe(true);
+  });
+
+  it('does not touch stages that still have player choices pending', async () => {
+    const { eventChainManager } = await import('../utils/EventChainManager');
+    const { TimeManager } = await import('../utils/TimeManager');
+
+    await eventChainManager.startChain(CHAIN_ID);
+    expect(eventChainManager.getProgress(CHAIN_ID)?.currentStageId).toBe('rumours');
+
+    TimeManager.setTimeOverride({ day: 30 }); // plenty of days, but 'rumours' has choices
+    await eventChainManager.checkAutoAdvance();
+
+    expect(eventChainManager.getProgress(CHAIN_ID)?.currentStageId).toBe('rumours');
+  });
+});

--- a/tests/inventoryManager.test.ts
+++ b/tests/inventoryManager.test.ts
@@ -1,0 +1,50 @@
+/** @vitest-environment node */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { inventoryManager } from '../utils/inventoryManager';
+
+/**
+ * Regression: inventoryManager.removeItem() must be atomic.
+ *
+ * The old implementation mutated the live instance array in place while walking
+ * it, and only checked afterwards whether it had removed enough. Requesting more
+ * than was held drained all existing stock, then returned `false` — the caller saw
+ * "failed", but the item was gone anyway. Reachable via MiniGameManager.processResult(),
+ * which calls removeItem() for `consumeOn: 'onComplete'` requirements without
+ * re-checking availability at completion time, and ignores the return value.
+ */
+
+const STACKABLE_ITEM = 'crop_potato'; // stackable, per data/items/crops.ts
+
+describe('inventoryManager.removeItem() atomicity', () => {
+  beforeEach(() => {
+    // Start from a clean slate for this item so each test controls its own stock.
+    while (inventoryManager.hasItem(STACKABLE_ITEM, 1)) {
+      inventoryManager.removeItem(STACKABLE_ITEM, 1);
+    }
+  });
+
+  it('does not remove anything when the requested quantity exceeds stock', () => {
+    inventoryManager.addItem(STACKABLE_ITEM, 3);
+
+    const result = inventoryManager.removeItem(STACKABLE_ITEM, 5);
+
+    expect(result).toBe(false);
+    expect(inventoryManager.getQuantity(STACKABLE_ITEM)).toBe(3); // stock preserved, not drained
+  });
+
+  it('succeeds and removes exactly the requested quantity when enough stock exists', () => {
+    inventoryManager.addItem(STACKABLE_ITEM, 5);
+
+    const result = inventoryManager.removeItem(STACKABLE_ITEM, 3);
+
+    expect(result).toBe(true);
+    expect(inventoryManager.getQuantity(STACKABLE_ITEM)).toBe(2);
+  });
+
+  it('reports failure without removing anything when the item is not held at all', () => {
+    const result = inventoryManager.removeItem(STACKABLE_ITEM, 1);
+
+    expect(result).toBe(false);
+    expect(inventoryManager.getQuantity(STACKABLE_ITEM)).toBe(0);
+  });
+});

--- a/tests/itemSSoT.test.ts
+++ b/tests/itemSSoT.test.ts
@@ -15,9 +15,10 @@
 
 /** @vitest-environment node */
 import { describe, it, expect } from 'vitest';
-import { ITEMS, getItem, ItemCategory } from '../data/items';
+import { ITEMS, getItem, getSeedItemId, ItemCategory } from '../data/items';
 import { RECIPES } from '../data/recipes';
 import { GENERAL_STORE_INVENTORY } from '../data/shopInventory';
+import { CROPS } from '../data/crops';
 
 // ============================================================================
 // AUTOMATIC SSoT CHECKS - These catch future violations
@@ -196,6 +197,33 @@ describe('Item SSoT - Recipe Ingredients Exist', () => {
 
     const potatoIngredient = recipe.ingredients.find((ing) => ing.itemId === 'crop_potato');
     expect(potatoIngredient).toBeDefined();
+  });
+});
+
+describe('Item SSoT - Regression: getSeedItemId resolves to a real item', () => {
+  it('getSeedItemId(cropId) must return an item id that exists in ITEMS for every crop with seed drops', () => {
+    // Regression for a bug where harvesting strawberries silently destroyed their
+    // seed drops: getSeedItemId() guessed `seed_${cropId}` ('seed_strawberry'),
+    // but the registered item is 'seed_wild_strawberry'. inventoryManager.addItem()
+    // logs "Unknown item" and no-ops on an unrecognised id, so the drop vanished
+    // with no player-visible error.
+    const brokenSeedIds: string[] = [];
+
+    Object.entries(CROPS).forEach(([cropId, crop]) => {
+      if (crop.seedDropMax <= 0) return; // Crop never drops seeds; no id needed
+      const seedItemId = getSeedItemId(cropId);
+      if (!getItem(seedItemId)) {
+        brokenSeedIds.push(
+          `Crop "${cropId}" -> getSeedItemId() returned "${seedItemId}", which is not in ITEMS`
+        );
+      }
+    });
+
+    expect(brokenSeedIds).toEqual([]);
+  });
+
+  it('strawberry seed drops resolve to the registered seed_wild_strawberry item', () => {
+    expect(getSeedItemId('strawberry')).toBe('seed_wild_strawberry');
   });
 });
 

--- a/tests/mushraGhostQuestGift.test.ts
+++ b/tests/mushraGhostQuestGift.test.ts
@@ -1,0 +1,69 @@
+/** @vitest-environment node */
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { handleDialogueAction } from '../utils/dialogueHandlers';
+import { inventoryManager } from '../utils/inventoryManager';
+import { eventChainManager } from '../utils/EventChainManager';
+import { getDialogue } from '../services/dialogueService';
+import { createMushraNPC } from '../utils/npcs/forest/mushra';
+import {
+  GHOST_QUEEN_QUEST_ID,
+  isGhostQuestActive,
+  getGhostQuestStage,
+} from '../data/questHandlers/ghostQueenHandler';
+
+/**
+ * Regression: Mushra's "Do you know anything about a place called Nevarre?" dialogue
+ * option was only gated by requiredQuest/hiddenIfQuestCompleted, so it stayed visible
+ * for the ENTIRE ghost_queen quest (not just the 'searching' stage, before the book is
+ * obtained) — unlike Queen Avaricia's equivalent node, which correctly uses
+ * requiredQuestStage/maxQuestStage. A player could revisit Mushra and re-select it
+ * after already receiving the book, stacking duplicate (non-stackable) history_book
+ * items. handleMushraGhostQuestActions() also granted the item unconditionally, with
+ * no "already have it" guard (unlike every other one-shot quest grant in the same file).
+ */
+
+function clearHistoryBook(): void {
+  while (inventoryManager.hasItem('history_book', 1)) {
+    inventoryManager.removeItem('history_book', 1);
+  }
+}
+
+describe('Mushra ghost_queen book delivery', () => {
+  beforeEach(async () => {
+    eventChainManager.initialise();
+    eventChainManager.resetChain(GHOST_QUEEN_QUEST_ID);
+    clearHistoryBook();
+    await eventChainManager.startChain(GHOST_QUEEN_QUEST_ID, {});
+  });
+
+  afterAll(() => {
+    clearHistoryBook();
+  });
+
+  it('grants exactly one history_book even if the delivery node fires twice', () => {
+    handleDialogueAction('mushra', 'mushra_nevarre_book_given');
+    handleDialogueAction('mushra', 'mushra_nevarre_book_given');
+
+    expect(inventoryManager.getQuantity('history_book')).toBe(1);
+  });
+
+  it('advances the quest to has_book on first delivery, and stays there on a repeat', () => {
+    handleDialogueAction('mushra', 'mushra_nevarre_book_given');
+    expect(getGhostQuestStage()).toBe('has_book');
+
+    handleDialogueAction('mushra', 'mushra_nevarre_book_given');
+    expect(getGhostQuestStage()).toBe('has_book');
+    expect(isGhostQuestActive()).toBe(true);
+  });
+
+  it('hides the Nevarre dialogue option once the book has been delivered (stage advanced past searching)', async () => {
+    handleDialogueAction('mushra', 'mushra_nevarre_book_given');
+    expect(getGhostQuestStage()).toBe('has_book');
+
+    const npc = createMushraNPC('mushra_test', { x: 0, y: 0 });
+    const node = await getDialogue(npc, 'greeting');
+    const nevarreOption = node?.responses?.find((r) => r.nextId === 'nevarre_enquiry');
+
+    expect(nevarreOption).toBeUndefined();
+  });
+});

--- a/utils/dialogueHandlers.ts
+++ b/utils/dialogueHandlers.ts
@@ -212,7 +212,11 @@ function handleAltheaQuestItems(nodeId: string): string | void {
     if (sistersStage === SISTERS_STAGES.PHOTO_NEEDED) return 'sisters_awaiting_photo';
     if (sistersStage === SISTERS_STAGES.PHOTO_DELIVERED) return 'sisters_awaiting_meeting';
     // Althea's chores complete but estranged sisters not yet started — show the post-chores prompt
-    if (isAltheaChoresCompleted() && !isEstrangedSistersActive() && !isEstrangedSistersCompleted()) {
+    if (
+      isAltheaChoresCompleted() &&
+      !isEstrangedSistersActive() &&
+      !isEstrangedSistersCompleted()
+    ) {
       return 'post_chores_reminder';
     }
     return;
@@ -341,10 +345,7 @@ function handleWitchQuestActions(nodeId: string): string | void {
 
     // Quest complete — check if witch needs to congratulate level-up
     if (stage >= WITCH_GARDEN_STAGES.COMPLETED) {
-      if (
-        magicManager.getCurrentLevel() !== 'novice' &&
-        !magicManager.hasReceivedWitchCongrats()
-      ) {
+      if (magicManager.getCurrentLevel() !== 'novice' && !magicManager.hasReceivedWitchCongrats()) {
         return 'journeyman_congrats';
       }
       return; // Normal greeting
@@ -420,8 +421,7 @@ function handleRecipeTeaching(nodeId: string): void {
     inventoryManager.addItem('sourdough', 1);
     const inventoryData = inventoryManager.getInventoryData();
     characterData.saveInventory(inventoryData.items, inventoryData.tools);
-    if (DEBUG.QUEST)
-      console.log('[dialogueHandlers] 🍞 Mum gave you her Sourdough Starter!');
+    if (DEBUG.QUEST) console.log('[dialogueHandlers] 🍞 Mum gave you her Sourdough Starter!');
   }
 }
 
@@ -447,8 +447,7 @@ function handleFairyQuestActions(npcId: string, nodeId: string): void {
     const inventoryData = inventoryManager.getInventoryData();
     characterData.saveInventory(inventoryData.items, inventoryData.tools);
     markPotionReceived();
-    if (DEBUG.QUEST)
-      console.log(`[dialogueHandlers] 🧚 ${fairyName} gave Fairy Form Potion!`);
+    if (DEBUG.QUEST) console.log(`[dialogueHandlers] 🧚 ${fairyName} gave Fairy Form Potion!`);
   }
 
   // Give replacement potion when player requests one (Good Friends only)
@@ -700,20 +699,21 @@ function handleMrFoxPicnicActions(nodeId: string): string | void {
   if (nodeId === 'mfp_blanket_offer') {
     startMrFoxPicnic();
     eventChainManager.advanceToStage(MFP_QUEST_ID, 'ask_mum_blanket');
-    if (DEBUG.QUEST) console.log("[dialogueHandlers] 🦊 Mr Fox's Picnic quest started → ask_mum_blanket");
+    if (DEBUG.QUEST)
+      console.log("[dialogueHandlers] 🦊 Mr Fox's Picnic quest started → ask_mum_blanket");
   }
 
   // Player gives the blanket to Mr Fox
   if (nodeId === 'mfp_give_blanket') {
     handleBlanketGiven();
-    if (DEBUG.QUEST) console.log("[dialogueHandlers] 🧺 Blanket given to Mr Fox");
+    if (DEBUG.QUEST) console.log('[dialogueHandlers] 🧺 Blanket given to Mr Fox');
   }
 
   // Trigger the fox picnic cutscene when the basket is accepted
   if (nodeId === 'mfp_basket_accepted') {
     handleBasketGiven(); // Remove basket from inventory — returned empty on quest complete
     cutsceneManager.startCutscene('fox_picnic');
-    if (DEBUG.QUEST) console.log("[dialogueHandlers] 🎬 Fox picnic cutscene triggered");
+    if (DEBUG.QUEST) console.log('[dialogueHandlers] 🎬 Fox picnic cutscene triggered');
   }
 }
 
@@ -730,14 +730,18 @@ function handleMumQuestActions(nodeId: string): string | void {
   // Player agrees to tidy the shed — advance to shed_cleaning stage
   if (nodeId === 'mfp_blanket_agreed') {
     eventChainManager.advanceToStage(MFP_QUEST_ID, 'shed_cleaning');
-    if (DEBUG.QUEST) console.log("[dialogueHandlers] 🧹 Mum sent player to seed shed — advancing to shed_cleaning");
+    if (DEBUG.QUEST)
+      console.log(
+        '[dialogueHandlers] 🧹 Mum sent player to seed shed — advancing to shed_cleaning'
+      );
   }
 
   // Player asks Mum to help with food — advance to filling_basket stage
   // (the stage handler will spawn the picnic basket as a placed item)
   if (nodeId === 'mfp_food_agreed') {
     eventChainManager.advanceToStage(MFP_QUEST_ID, 'filling_basket');
-    if (DEBUG.QUEST) console.log("[dialogueHandlers] 🍱 Mum helping with food — advancing to filling_basket");
+    if (DEBUG.QUEST)
+      console.log('[dialogueHandlers] 🍱 Mum helping with food — advancing to filling_basket');
   }
 }
 
@@ -749,7 +753,10 @@ function handleMushraWreathActions(nodeId: string): string | void {
   if (nodeId === 'wreath_deliver_materials') {
     if (hasAllMaterials()) {
       deliverMaterials();
-      if (DEBUG.QUEST) console.log('[dialogueHandlers] 🌿 Wreath materials delivered — advancing to hanging stage');
+      if (DEBUG.QUEST)
+        console.log(
+          '[dialogueHandlers] 🌿 Wreath materials delivered — advancing to hanging stage'
+        );
       return 'wreath_materials_accepted';
     } else {
       return 'wreath_materials_missing';
@@ -763,11 +770,13 @@ function handleMushraWreathActions(nodeId: string): string | void {
  */
 function handleMushraGhostQuestActions(nodeId: string): string | void {
   if (nodeId === 'mushra_nevarre_book_given') {
-    inventoryManager.addItem('history_book', 1);
-    const inv = inventoryManager.getInventoryData();
-    characterData.saveInventory(inv.items, inv.tools);
-    advanceGhostQuestToHasBook();
-    if (DEBUG.QUEST) console.log('[dialogueHandlers] 📖 History book given by Mushra');
+    if (!inventoryManager.hasItem('history_book')) {
+      inventoryManager.addItem('history_book', 1);
+      const inv = inventoryManager.getInventoryData();
+      characterData.saveInventory(inv.items, inv.tools);
+      advanceGhostQuestToHasBook();
+      if (DEBUG.QUEST) console.log('[dialogueHandlers] 📖 History book given by Mushra');
+    }
     return 'mushra_nevarre_book_accepted';
   }
 }

--- a/utils/fruitTreeManager.ts
+++ b/utils/fruitTreeManager.ts
@@ -26,8 +26,8 @@ import { staminaManager } from './StaminaManager';
 // ============================================================================
 
 export interface FruitTreeState {
-  pruned: boolean;   // Pruned this winter (carries into spring/summer/autumn)
-  mulched: boolean;  // Mulched this spring (carries into summer/autumn)
+  pruned: boolean; // Pruned this winter (carries into spring/summer/autumn)
+  mulched: boolean; // Mulched this spring (carries into summer/autumn)
   harvested: boolean; // Already harvested this autumn
 }
 
@@ -45,10 +45,14 @@ const STORAGE_KEY = 'twilight_fruit_trees';
 class FruitTreeManager {
   private trees: Map<string, FruitTreeState> = new Map();
   private lastKnownSeason: string = '';
+  private initialised = false;
 
   // ── Initialisation ─────────────────────────────────────────────────────────
 
   initialise(): void {
+    if (this.initialised) return;
+    this.initialised = true;
+
     this.load();
 
     // Detect season transitions via TIME_CHANGED
@@ -155,7 +159,7 @@ class FruitTreeManager {
 
     const abundant = state.pruned && state.mulched;
     const quantity = abundant
-      ? Math.floor(Math.random() * 4) + 7  // 7–10
+      ? Math.floor(Math.random() * 4) + 7 // 7–10
       : Math.floor(Math.random() * 4) + 2; // 2–5
 
     state.harvested = true;

--- a/utils/inventoryManager.ts
+++ b/utils/inventoryManager.ts
@@ -247,6 +247,21 @@ class InventoryManager {
       return false;
     }
 
+    // Verify enough stock exists before mutating anything, so a shortfall
+    // never partially consumes stock while still reporting failure.
+    const totalAvailable = item.stackable
+      ? instances.reduce((sum, instance) => sum + (instance.quantity || 1), 0)
+      : instances.reduce(
+          (sum, instance) => sum + (item.maxUses && instance.uses ? instance.uses : 1),
+          0
+        );
+    if (totalAvailable < quantity) {
+      console.warn(
+        `[InventoryManager] Not enough ${item.displayName} (need ${quantity}, only had ${totalAvailable})`
+      );
+      return false;
+    }
+
     // For stackable items, remove from quantity (not uses)
     if (item.stackable) {
       let remaining = quantity;
@@ -272,25 +287,9 @@ class InventoryManager {
           );
         }
       }
-
-      if (remaining > 0) {
-        console.warn(
-          `[InventoryManager] Not enough ${item.displayName} (need ${quantity}, only had ${quantity - remaining})`
-        );
-        // Restore what we removed (transaction should be atomic)
-        // This is a safeguard - validation should prevent this
-        return false;
-      }
     } else {
       // Non-stackable items: process removal for each quantity requested
       for (let i = 0; i < quantity; i++) {
-        if (instances.length === 0) {
-          console.warn(
-            `[InventoryManager] Not enough ${item.displayName} (need ${quantity}, processed ${i})`
-          );
-          return false;
-        }
-
         // Get first instance
         const instance = instances[0];
 

--- a/utils/npcs/forest/mushra.ts
+++ b/utils/npcs/forest/mushra.ts
@@ -56,7 +56,7 @@ export function createMushraNPC(id: string, position: Position, name: string = '
           summer:
             '*She pats the grass beside her.* "Perfect timing! I just found the most wonderful mushroom and I wanted to show someone who\'d appreciate it."',
           autumn:
-            '*Her eyes sparkle.* "You\'re here! I\'ve been dying to show you — the autumn colours this year are extraordinary. I\'ve filled half a sketchbook already."',
+            "*Her eyes sparkle.* \"You're here! I've been dying to show you — the autumn colours this year are extraordinary. I've filled half a sketchbook already.\"",
           winter:
             '*She pulls her scarf tighter and smiles warmly.* "I\'m so glad you came! It\'s a bit chilly, but the frost patterns on the mushrooms are gorgeous today."',
         },
@@ -78,6 +78,8 @@ export function createMushraNPC(id: string, position: Position, name: string = '
             text: 'Do you know anything about a place called Nevarre?',
             nextId: 'nevarre_enquiry',
             requiredQuest: 'ghost_queen',
+            requiredQuestStage: 1,
+            maxQuestStage: 1,
             hiddenIfQuestCompleted: 'ghost_queen',
           },
         ],
@@ -114,6 +116,8 @@ export function createMushraNPC(id: string, position: Position, name: string = '
             text: 'Do you know anything about a place called Nevarre?',
             nextId: 'nevarre_enquiry',
             requiredQuest: 'ghost_queen',
+            requiredQuestStage: 1,
+            maxQuestStage: 1,
             hiddenIfQuestCompleted: 'ghost_queen',
           },
         ],
@@ -122,10 +126,10 @@ export function createMushraNPC(id: string, position: Position, name: string = '
         id: 'nevarre_enquiry',
         text: '"Nevarre! Oh, *yes* — I have been reading about the medieval kingdoms of this region! Such a fascinating period." *She rummages through a stack of books beside her.* "Here, take this — there is an entry on Nevarre somewhere in the middle, if I remember rightly."',
         requiredQuest: 'ghost_queen',
+        requiredQuestStage: 1,
+        maxQuestStage: 1,
         hiddenIfQuestCompleted: 'ghost_queen',
-        responses: [
-          { text: 'Thank you, Mushra!', nextId: 'mushra_nevarre_book_given' },
-        ],
+        responses: [{ text: 'Thank you, Mushra!', nextId: 'mushra_nevarre_book_given' }],
       },
       { id: 'mushra_nevarre_book_given', text: '' }, // intercepted by dialogueHandlers
       {
@@ -181,7 +185,7 @@ export function createMushraNPC(id: string, position: Position, name: string = '
       {
         id: 'fly_agaric',
         expression: 'smile',
-        text: '"Fly agaric! Amanita muscaria — the classic red cap with white spots. I just can\'t resist their cute polka dots!" *She clasps her hands together.* "They\'re terribly toxic, of course, but absolutely gorgeous. I\'ve painted dozens of them. There\'s something almost fairy-tale about them, isn\'t there?"',
+        text: "\"Fly agaric! Amanita muscaria — the classic red cap with white spots. I just can't resist their cute polka dots!\" *She clasps her hands together.* \"They're terribly toxic, of course, but absolutely gorgeous. I've painted dozens of them. There's something almost fairy-tale about them, isn't there?\"",
         responses: [
           { text: 'Have you ever tried to find a fairy?', nextId: 'have_you_seen_fairies' },
           { text: 'They are rather magical-looking.' },
@@ -237,8 +241,8 @@ export function createMushraNPC(id: string, position: Position, name: string = '
         text: '*She looks at you thoughtfully.* "I won\'t pretend the solitude isn\'t hard sometimes. There are days when I wish I had someone to share a cup of tea with, someone who appreciates the little things." *She smiles warmly.* "That\'s why I value friends like you. You understand."',
         requiredFriendshipTier: 'good_friend',
         responses: [
-          { text: 'I\'m glad we\'re friends too.', nextId: 'one_good_friend' },
-          { text: 'You\'re never alone with me around.' },
+          { text: "I'm glad we're friends too.", nextId: 'one_good_friend' },
+          { text: "You're never alone with me around." },
         ],
       },
       // Good Friends hub node - deeper personal conversation topics
@@ -248,10 +252,10 @@ export function createMushraNPC(id: string, position: Position, name: string = '
         text: '"Hi, there! I was hoping to see you. Would you keep me company for a bit? I love living in the forest, but sometimes I get a bit lonely."',
         requiredFriendshipTier: 'good_friend',
         responses: [
-          { text: 'Of course! I\'ll stay a while.', nextId: 'best_of_both_worlds' },
+          { text: "Of course! I'll stay a while.", nextId: 'best_of_both_worlds' },
           { text: 'Do you ever get lonely out here?', nextId: 'keep_company' },
           { text: 'What do you miss about the city?', nextId: 'cinema' },
-          { text: 'How\'s your family?', nextId: 'family_visit' },
+          { text: "How's your family?", nextId: 'family_visit' },
         ],
       },
       {
@@ -260,7 +264,7 @@ export function createMushraNPC(id: string, position: Position, name: string = '
         text: '*She flips through pages of delicate watercolours — mushrooms, trees, and tiny fairy portraits.* "I\'ve been experimenting with new techniques. What do you think?"',
         requiredFriendshipTier: 'good_friend',
         responses: [
-          { text: 'They\'re beautiful!', nextId: 'comfortable_silence' },
+          { text: "They're beautiful!", nextId: 'comfortable_silence' },
           { text: 'I love the fairy ones.' },
         ],
       },
@@ -271,7 +275,7 @@ export function createMushraNPC(id: string, position: Position, name: string = '
         requiredFriendshipTier: 'good_friend',
         responses: [
           { text: 'That makes me happy too.', nextId: 'one_good_friend' },
-          { text: 'Don\'t you miss having neighbours?', nextId: 'loneliness' },
+          { text: "Don't you miss having neighbours?", nextId: 'loneliness' },
         ],
       },
       {
@@ -281,7 +285,7 @@ export function createMushraNPC(id: string, position: Position, name: string = '
         requiredFriendshipTier: 'good_friend',
         responses: [
           { text: 'I feel the same way.', nextId: 'comfortable_silence' },
-          { text: 'You\'re a wonderful friend, Mushra.' },
+          { text: "You're a wonderful friend, Mushra." },
         ],
       },
       {
@@ -290,7 +294,7 @@ export function createMushraNPC(id: string, position: Position, name: string = '
         requiredFriendshipTier: 'good_friend',
         responses: [
           { text: 'I like the quiet too.', nextId: 'being_herself' },
-          { text: 'You\'re not strange at all.' },
+          { text: "You're not strange at all." },
         ],
       },
       {
@@ -307,7 +311,7 @@ export function createMushraNPC(id: string, position: Position, name: string = '
         text: '"I used to get so exhausted trying to pretend I was like everyone else. Now I\'m just me." *She shrugs.* "If they think I\'m weird, that\'s up to them."',
         requiredFriendshipTier: 'good_friend',
         responses: [
-          { text: 'I think you\'re brilliant.', nextId: 'being_herself' },
+          { text: "I think you're brilliant.", nextId: 'being_herself' },
           { text: 'Being yourself is the bravest thing.' },
         ],
       },
@@ -361,7 +365,7 @@ export function createMushraShopNPC(id: string, position: Position): NPC {
     // Each frame is 200ms, so 15 open frames = 3000ms open, 1 closed frame = 200ms closed
     state.sprites = [
       ...Array(15).fill(npcAssets.mushra_01), // open eyes
-      npcAssets.mushra_02,                    // blink
+      npcAssets.mushra_02, // blink
     ];
     state.animationSpeed = 200;
   }
@@ -440,11 +444,11 @@ export function createVillageMushraNPC(id: string, position: Position): NPC {
         maxQuestStage: 1,
         responses: [
           {
-            text: "Here are the materials!",
+            text: 'Here are the materials!',
             nextId: 'wreath_deliver_materials',
           },
           {
-            text: "Not quite yet.",
+            text: 'Not quite yet.',
             nextId: 'gathering_encouragement',
           },
         ],
@@ -483,7 +487,7 @@ export function createVillageMushraNPC(id: string, position: Position): NPC {
             nextId: 'hanging_houses',
           },
           {
-            text: 'Got it, I\'ll get to work!',
+            text: "Got it, I'll get to work!",
           },
         ],
       },

--- a/utils/npcs/forest/possum.ts
+++ b/utils/npcs/forest/possum.ts
@@ -68,8 +68,12 @@ export function createPossumNPC(id: string, position: Position, name: string = '
       playing_dead: {
         sprites: [npcAssets.possum_dead],
         animationSpeed: 1000,
-        // No duration/nextState - waits for player to leave
-        // Recovery handled by proximity trigger in roaming/sitting states
+        // Primary recovery is the proximity trigger in roaming/sitting once the
+        // player walks away. This duration is a fallback so the possum can't get
+        // stuck "dead" forever if the player leaves the map before that fires
+        // (proximity checks only run for NPCs on the player's current map).
+        duration: 8000,
+        nextState: 'roaming',
       },
     },
     dialogue: [

--- a/utils/pixi/BackgroundImageLayer.ts
+++ b/utils/pixi/BackgroundImageLayer.ts
@@ -72,7 +72,13 @@ export class BackgroundImageLayer {
   // Individual mess pile sprites tracked for dynamic show/hide on clean
   private messPileLayerEntries: Array<{ sprite: PIXI.Sprite; pileId: number }> = [];
   // Wallpaper overlay sprites tracked for dynamic show on apply
-  private wallpaperLayerEntries: Array<{ sprite: PIXI.Sprite; mapId: string; wallpaperId: string }> = [];
+  private wallpaperLayerEntries: Array<{
+    sprite: PIXI.Sprite;
+    mapId: string;
+    wallpaperId: string;
+  }> = [];
+  // Unsubscribe functions for this instance's EventBus listeners, released in dispose()
+  private eventUnsubscribers: Array<() => void> = [];
 
   constructor() {
     // Background container - behind all game content
@@ -81,40 +87,48 @@ export class BackgroundImageLayer {
     this.backgroundContainer.zIndex = Z_PARALLAX_FAR; // -100
 
     // Hide individual cobweb sprites when a cobweb is cleaned mid-room
-    eventBus.on(GameEvent.COBWEB_CLEANED, ({ cobwebId }) => {
-      for (const entry of this.cobwebLayerEntries) {
-        if (entry.cobwebId === cobwebId) {
-          entry.sprite.visible = false;
+    this.eventUnsubscribers.push(
+      eventBus.on(GameEvent.COBWEB_CLEANED, ({ cobwebId }) => {
+        for (const entry of this.cobwebLayerEntries) {
+          if (entry.cobwebId === cobwebId) {
+            entry.sprite.visible = false;
+          }
         }
-      }
-    });
+      })
+    );
 
     // Hide mess pile sprites when cleaned (Mr Fox's Picnic)
-    eventBus.on(GameEvent.MESS_PILE_CLEANED, ({ pileId }) => {
-      for (const entry of this.messPileLayerEntries) {
-        if (entry.pileId === pileId) {
-          entry.sprite.visible = false;
+    this.eventUnsubscribers.push(
+      eventBus.on(GameEvent.MESS_PILE_CLEANED, ({ pileId }) => {
+        for (const entry of this.messPileLayerEntries) {
+          if (entry.pileId === pileId) {
+            entry.sprite.visible = false;
+          }
         }
-      }
-    });
+      })
+    );
 
     // Show wallpaper overlay when applied (while player is already in the room)
-    eventBus.on(GameEvent.WALLPAPER_APPLIED, ({ mapId, wallpaperId }) => {
-      for (const entry of this.wallpaperLayerEntries) {
-        if (entry.mapId === mapId && entry.wallpaperId === wallpaperId) {
-          entry.sprite.visible = true;
+    this.eventUnsubscribers.push(
+      eventBus.on(GameEvent.WALLPAPER_APPLIED, ({ mapId, wallpaperId }) => {
+        for (const entry of this.wallpaperLayerEntries) {
+          if (entry.mapId === mapId && entry.wallpaperId === wallpaperId) {
+            entry.sprite.visible = true;
+          }
         }
-      }
-    });
+      })
+    );
 
     // Hide wallpaper overlay when removed
-    eventBus.on(GameEvent.WALLPAPER_REMOVED, ({ mapId }) => {
-      for (const entry of this.wallpaperLayerEntries) {
-        if (entry.mapId === mapId) {
-          entry.sprite.visible = false;
+    this.eventUnsubscribers.push(
+      eventBus.on(GameEvent.WALLPAPER_REMOVED, ({ mapId }) => {
+        for (const entry of this.wallpaperLayerEntries) {
+          if (entry.mapId === mapId) {
+            entry.sprite.visible = false;
+          }
         }
-      }
-    });
+      })
+    );
   }
 
   /**
@@ -563,6 +577,19 @@ export class BackgroundImageLayer {
     this.wallpaperLayerEntries = [];
 
     this.currentMapId = null;
+  }
+
+  /**
+   * Permanently discard this instance: clears sprites and unsubscribes its
+   * EventBus listeners. Use this (not clear()) when the instance itself is
+   * being thrown away — e.g. on WebGL context-loss re-initialization or
+   * component unmount — since clear() alone leaves the constructor's
+   * COBWEB_CLEANED/MESS_PILE_CLEANED/WALLPAPER_* listeners subscribed forever.
+   */
+  dispose(): void {
+    this.clear();
+    this.eventUnsubscribers.forEach((unsubscribe) => unsubscribe());
+    this.eventUnsubscribers = [];
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #11 (merged) — a second, independent batch of small correctness fixes found by auditing manager/state code for the same failure patterns that turned up there (wrong id lookups, non-atomic mutations, missing recovery paths, leaked subscriptions). Each commit is self-contained.

- **Strawberry seed drops silently destroyed on harvest** — `getSeedItemId()` guessed `seed_${cropId}`, but the registered item is `seed_wild_strawberry`. `inventoryManager.addItem()` no-ops on an unrecognised id, so the seed drop vanished with no error. Now looks up the real seed item via `getSeedForCrop()`; added a regression test covering every crop's seed id.
- **`inventoryManager.removeItem()` wasn't atomic** — it mutated the live instance array while walking it, then checked afterwards whether enough had been removed. Requesting more than was held drained all existing stock before returning `false`. Reachable via `MiniGameManager.processResult()`, which ignores the return value. Now checks total stock up front and bails before mutating anything if short.
- **Crash-recovery "Reset Save & Reload" cleared the wrong storage key** — removed `localStorage['gameState']`, but the save lives under `'twilight_game_state'` (`GameState.ts`'s `STORAGE_KEY`). The button was a total no-op; a player hitting a corrupted-save crash had no way out.
- **Toast dismiss timers reset on every new toast** — the auto-dismiss effect depended on the whole `messages` array, so a new toast restarted the 3-second countdown for *every* currently-shown toast. Now tracks one timer per message id, started once.
- **Possum's playing-dead state had no fallback recovery** — recovery only ran via `checkProximityTriggers()`, which only evaluates NPCs on the player's current map. Leaving the map while the possum was playing dead left it stuck indefinitely. Added a duration/nextState fallback matching the pattern already used by its other states.
- **Hardcoded map teleports skipped wall/bounds validation** — cutscene destinations, stamina-exhaustion teleport-home, and "sent to bed" all called a raw `mapManager.loadMap()` instead of the validated `transitionToMap()` entry point that door-based transitions use, so a stale/mistyped coordinate could drop the player inside a wall. Also fixed a stale `oldMapId` closure in the exhaustion teleport path (captured once at mount instead of read fresh).
- **Spawn/transition validation ignored multi-tile sprite footprints** — `isPositionValidForMap()` only checked the raw grid cell, not the collision box multi-tile sprites (furniture, buildings) extend beyond their anchor tile — e.g. the witch hut is 11 tiles wide from one anchor. Added the same second pass `useCollisionDetection.ts` already does; swept every registered map's spawn/transition targets to confirm no new fallbacks trigger.
- **`BackgroundImageLayer` leaked 4 EventBus subscriptions on WebGL context restore** — common on iPad Safari under memory pressure. `usePixiRenderer` destroys and recreates the layer on context loss, but nothing unsubscribed the old instance's listeners (the unmount cleanup path wasn't reached). Added a `dispose()` distinct from the room-transition `clear()`, called at both real teardown points.
- **`GiftModal` had no double-submit guard** — a fast double click could award friendship points twice while consuming only one item. Added an `isSubmitting` guard.
- **`FruitTreeManager.initialise()` had no idempotency guard** — unlike its sibling singletons (`FriendshipManager`, `GlobalEventManager`). Not currently reachable, but cheap defensive insurance.
- **`EventChainManager.checkAutoAdvance()` was never called anywhere** — it's fully implemented to auto-advance a chain stage once it has waited `waitDays` in-game days with no player choices pending, but nothing in the app ever invoked it. Two shipped quests depend on it: `mysterious_lights`' "wait and see" branch and all three branches of `autumn_harvest_festival`. Any player picking those paths got permanently stuck — no rewards, no completion, no way out short of a developer's manual DevTools override. Wired it into the existing 10-second time-of-day poll in `useEnvironmentController.ts`.
- **Mushra's Nevarre dialogue let players duplicate the `history_book` keepsake** — the option was only gated by `requiredQuest`/`hiddenIfQuestCompleted`, so it stayed visible for the whole `ghost_queen` quest instead of just the pre-book stage (Queen Avaricia's equivalent node correctly uses `requiredQuestStage`/`maxQuestStage`). Re-selecting it after already receiving the book stacked duplicate non-stackable items, and each extra copy silently doubled item removal the next time it was gifted. Added the same stage guard, plus a defensive `!hasItem(...)` check in the handler matching the pattern every other one-shot grant in `dialogueHandlers.ts` already uses.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 457/457 tests pass (added `tests/inventoryManager.test.ts`, extended `tests/itemSSoT.test.ts` and `tests/eventChains.test.ts`, added `tests/mushraGhostQuestGift.test.ts`)
