### PR TITLE
Fix a third batch of correctness bugs found across the codebase

### DIFF
--- a/hooks/usePixiRenderer.ts
+++ b/hooks/usePixiRenderer.ts
@@ -476,6 +476,13 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
         backgroundImageLayerRef.current.dispose();
         backgroundImageLayerRef.current = null;
       }
+      // Same leak risk as BackgroundImageLayer above: initPixi() creates a fresh
+      // DarknessLayer with its own setInterval-based flicker/transition timers —
+      // dispose the old one first or those timers run forever on an orphaned instance.
+      if (darknessLayerRef.current) {
+        darknessLayerRef.current.destroy();
+        darknessLayerRef.current = null;
+      }
       // The effect will re-run because isPixiInitialized changed
       setTimeout(() => initPixi(), 100);
     };
@@ -522,6 +529,10 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
       if (weatherLayerRef.current) {
         weatherLayerRef.current.destroy();
         weatherLayerRef.current = null;
+      }
+      if (darknessLayerRef.current) {
+        darknessLayerRef.current.destroy();
+        darknessLayerRef.current = null;
       }
     };
   }, [enabled, isMapInitialized]); // Only initialize once when map is ready

--- a/minigames/skiing/SkiingGame.tsx
+++ b/minigames/skiing/SkiingGame.tsx
@@ -277,7 +277,9 @@ function getCollisionAnchorY(
   img: HTMLImageElement | undefined,
   kind: ObjKind
 ): number {
-  const pad = img ? (drawWidth / (img.naturalWidth / img.naturalHeight)) * GROUND_PAD_RATIO[kind] : 0;
+  const pad = img
+    ? (drawWidth / (img.naturalWidth / img.naturalHeight)) * GROUND_PAD_RATIO[kind]
+    : 0;
   return rawAnchorY - pad;
 }
 
@@ -288,7 +290,11 @@ function getCollisionAnchorY(
  */
 function getPlayerCollisionAnchorY(canvasWidth: number, canvasHeight: number): number {
   const spriteDrawHeight = canvasWidth * PLAYER_SCREEN_WIDTH_RATIO; // player sprite is square
-  return canvasHeight - canvasHeight * PLAYER_BOTTOM_MARGIN_RATIO - spriteDrawHeight * PLAYER_GROUND_PAD_RATIO;
+  return (
+    canvasHeight -
+    canvasHeight * PLAYER_BOTTOM_MARGIN_RATIO -
+    spriteDrawHeight * PLAYER_GROUND_PAD_RATIO
+  );
 }
 
 function getPlayerCollisionWidth(canvasWidth: number): number {
@@ -378,6 +384,7 @@ export const SkiingGame: React.FC<MiniGameComponentProps> = ({ context, onComple
   const phaseRef = useRef<'playing' | 'crashed'>('playing');
   const heldRef = useRef({ left: false, right: false, boost: false });
   const rafRef = useRef(0);
+  const crashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const canvasWidthRef = useRef(0);
   const canvasHeightRef = useRef(0);
   // F3 collision-box overlay — self-contained like the rest of this minigame's input (see
@@ -418,7 +425,8 @@ export const SkiingGame: React.FC<MiniGameComponentProps> = ({ context, onComple
 
   // ─── Load assets (sky picked once, matching current weather) ───
   useEffect(() => {
-    const skySrc = gameState.getWeather() === 'clear' ? skiingAssets.skySunny : skiingAssets.skyOvercast;
+    const skySrc =
+      gameState.getWeather() === 'clear' ? skiingAssets.skySunny : skiingAssets.skyOvercast;
     const entries: Array<[ImageKey, string]> = [
       ['sky', skySrc],
       ['level1', skiingAssets.level1],
@@ -499,8 +507,21 @@ export const SkiingGame: React.FC<MiniGameComponentProps> = ({ context, onComple
     setPhase('crashed');
     // Firewood collected this run is forfeited on a crash — don't add anything to inventory.
     context.actions.triggerExhaustion();
-    setTimeout(() => finishRun(false), 700);
+    // triggerExhaustion() synchronously starts the exhaustion cutscene, which closes all UI
+    // and unmounts this component almost immediately — clear this on unmount so the stale
+    // finishRun/onComplete closure never fires a redundant, contradictory "crashed" result
+    // after the cutscene has already taken over.
+    crashTimeoutRef.current = setTimeout(() => {
+      crashTimeoutRef.current = null;
+      finishRun(false);
+    }, 700);
   }, [context, finishRun]);
+
+  useEffect(() => {
+    return () => {
+      if (crashTimeoutRef.current !== null) clearTimeout(crashTimeoutRef.current);
+    };
+  }, []);
 
   // ─── Spawning ───
   const spawnObject = useCallback(() => {
@@ -554,8 +575,7 @@ export const SkiingGame: React.FC<MiniGameComponentProps> = ({ context, onComple
       cameraZRef.current += speed * dt;
 
       const distance = cameraZRef.current;
-      const spawnIntervalMs =
-        distance < STAGE1_END ? 650 : distance < STAGE2_END ? 480 : 350;
+      const spawnIntervalMs = distance < STAGE1_END ? 650 : distance < STAGE2_END ? 480 : 350;
       spawnTimerRef.current -= dt * 1000;
       if (spawnTimerRef.current <= 0) {
         spawnObject();
@@ -586,7 +606,8 @@ export const SkiingGame: React.FC<MiniGameComponentProps> = ({ context, onComple
           );
           const playerAnchorY = getPlayerCollisionAnchorY(w, h);
           const screenSeparation = Math.abs((gap * (obj.worldX - cameraXRef.current)) / zDiff);
-          const objDrawWidth = rawDrawWidth * (COLLISION_WIDTH_SCALE[obj.kind] ?? COLLISION_WIDTH_SCALE_DEFAULT);
+          const objDrawWidth =
+            rawDrawWidth * (COLLISION_WIDTH_SCALE[obj.kind] ?? COLLISION_WIDTH_SCALE_DEFAULT);
           const playerCollisionWidth = getPlayerCollisionWidth(w);
           const hitThreshold = ((objDrawWidth + playerCollisionWidth) / 2) * COLLISION_FUDGE;
           if (objScreenY < playerAnchorY && screenSeparation < hitThreshold) {
@@ -678,7 +699,8 @@ export const SkiingGame: React.FC<MiniGameComponentProps> = ({ context, onComple
     if (images.level2) {
       const groundDrawWidth = w * GROUND_ZOOM;
       const groundMarginPx = (groundDrawWidth - w) / 2;
-      const groundShiftPx = -(cameraXRef.current / STEER_RANGE) * groundMarginPx * GROUND_PARALLAX_STRENGTH;
+      const groundShiftPx =
+        -(cameraXRef.current / STEER_RANGE) * groundMarginPx * GROUND_PARALLAX_STRENGTH;
       ctx.drawImage(images.level2, -groundMarginPx + groundShiftPx, 0, groundDrawWidth, h);
     }
 
@@ -711,7 +733,13 @@ export const SkiingGame: React.FC<MiniGameComponentProps> = ({ context, onComple
     if (images.player) {
       const pw = w * PLAYER_SCREEN_WIDTH_RATIO;
       const ph = pw / (images.player.naturalWidth / images.player.naturalHeight);
-      ctx.drawImage(images.player, playerScreenX - pw / 2, h - ph - h * PLAYER_BOTTOM_MARGIN_RATIO, pw, ph);
+      ctx.drawImage(
+        images.player,
+        playerScreenX - pw / 2,
+        h - ph - h * PLAYER_BOTTOM_MARGIN_RATIO,
+        pw,
+        ph
+      );
     }
 
     // Falling snow — reacts live to weather (unlike the sky image, which is only picked once at
@@ -725,10 +753,10 @@ export const SkiingGame: React.FC<MiniGameComponentProps> = ({ context, onComple
       for (const seed of SNOW_SEEDS) {
         const fallSpeed = SNOW_FALL_SPEED * seed.speedMul;
         const span = h + 20;
-        const y = (((seed.ySeed * span + snowT * fallSpeed) % span) + span) % span - 10;
+        const y = ((((seed.ySeed * span + snowT * fallSpeed) % span) + span) % span) - 10;
         const drift = Math.sin(snowT * seed.driftFreq + seed.driftPhase) * SNOW_DRIFT_AMPLITUDE;
         const xSpan = w + 20;
-        const x = (((seed.xSeed * xSpan + drift) % xSpan) + xSpan) % xSpan - 10;
+        const x = ((((seed.xSeed * xSpan + drift) % xSpan) + xSpan) % xSpan) - 10;
         ctx.beginPath();
         ctx.arc(x, y, SNOW_BASE_SIZE * seed.sizeMul, 0, Math.PI * 2);
         ctx.fill();
@@ -773,10 +801,12 @@ export const SkiingGame: React.FC<MiniGameComponentProps> = ({ context, onComple
           images[obj.kind],
           obj.kind
         );
-        const objDrawWidth = rawDrawWidth * (COLLISION_WIDTH_SCALE[obj.kind] ?? COLLISION_WIDTH_SCALE_DEFAULT);
+        const objDrawWidth =
+          rawDrawWidth * (COLLISION_WIDTH_SCALE[obj.kind] ?? COLLISION_WIDTH_SCALE_DEFAULT);
         const objHalfWidth = (objDrawWidth / 2) * COLLISION_FUDGE;
         const screenSeparation = Math.abs(objScreenX - playerScreenX);
-        const isHit = objScreenY < playerAnchorY && screenSeparation < playerHalfWidth + objHalfWidth;
+        const isHit =
+          objScreenY < playerAnchorY && screenSeparation < playerHalfWidth + objHalfWidth;
 
         const color = isHit
           ? '255, 60, 60'
@@ -786,7 +816,11 @@ export const SkiingGame: React.FC<MiniGameComponentProps> = ({ context, onComple
         ctx.strokeStyle = `rgba(${color}, 0.9)`;
         ctx.strokeRect(objScreenX - objHalfWidth, objScreenY - 24, objHalfWidth * 2, 24);
         ctx.fillStyle = `rgba(${color}, 0.9)`;
-        ctx.fillText(`${obj.kind} z=${Math.round(zDiff)}`, objScreenX - objHalfWidth, objScreenY - 26);
+        ctx.fillText(
+          `${obj.kind} z=${Math.round(zDiff)}`,
+          objScreenX - objHalfWidth,
+          objScreenY - 26
+        );
       }
 
       ctx.fillStyle = 'rgba(80, 180, 255, 0.9)';
@@ -927,7 +961,15 @@ export const SkiingGame: React.FC<MiniGameComponentProps> = ({ context, onComple
             {(['wood_poor', 'wood_medium', 'wood_fine'] as PickupKind[]).map((kind) => (
               <div key={kind} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                 <img
-                  src={skiingAssets[kind === 'wood_poor' ? 'woodPoor' : kind === 'wood_medium' ? 'woodMedium' : 'woodFine']}
+                  src={
+                    skiingAssets[
+                      kind === 'wood_poor'
+                        ? 'woodPoor'
+                        : kind === 'wood_medium'
+                          ? 'woodMedium'
+                          : 'woodFine'
+                    ]
+                  }
                   alt=""
                   style={{ width: 22, height: 22, objectFit: 'contain' }}
                 />

--- a/tests/farmManager.test.ts
+++ b/tests/farmManager.test.ts
@@ -218,6 +218,68 @@ describe('FarmManager', () => {
 
       expect(result).toBe(true);
     });
+
+    it('should refuse to water a dead crop', () => {
+      const position = { x: 5, y: 10 };
+      farmManager.tillSoil('test_map', position);
+      farmManager.plantSeed('test_map', position, 'radish', 'seed_radish');
+      const plot = farmManager.getPlot('test_map', position)!;
+      farmManager.loadPlots([{ ...plot, state: FarmPlotState.DEAD }]);
+
+      const result = farmManager.waterPlot('test_map', position);
+
+      expect(result).toBe(false);
+      expect(farmManager.getPlot('test_map', position)?.state).toBe(FarmPlotState.DEAD);
+    });
+  });
+
+  describe('reviveCrop', () => {
+    beforeEach(() => {
+      vi.mocked(inventoryManager.removeItem).mockReturnValue(true);
+      vi.mocked(inventoryManager.hasItem).mockReturnValue(true);
+    });
+
+    it('should revive a dead crop back to a watered, growing state', () => {
+      // waterPlot() intentionally refuses DEAD plots (there's nothing to "keep watered")
+      // — reviveCrop() exists specifically to bring a dead crop back to life, which the
+      // Root Revival potion relies on.
+      const position = { x: 5, y: 10 };
+      farmManager.tillSoil('test_map', position);
+      farmManager.plantSeed('test_map', position, 'radish', 'seed_radish');
+      const plot = farmManager.getPlot('test_map', position)!;
+      farmManager.loadPlots([{ ...plot, state: FarmPlotState.DEAD }]);
+
+      const result = farmManager.reviveCrop('test_map', position);
+
+      expect(result).toBe(true);
+      const updatedPlot = farmManager.getPlot('test_map', position);
+      expect(updatedPlot?.state).toBe(FarmPlotState.WATERED);
+      expect(updatedPlot?.cropType).toBe('radish');
+    });
+
+    it('should revive a wilting crop back to a watered state', () => {
+      const position = { x: 5, y: 10 };
+      farmManager.tillSoil('test_map', position);
+      farmManager.plantSeed('test_map', position, 'radish', 'seed_radish');
+      const plot = farmManager.getPlot('test_map', position)!;
+      farmManager.loadPlots([{ ...plot, state: FarmPlotState.WILTING }]);
+
+      const result = farmManager.reviveCrop('test_map', position);
+
+      expect(result).toBe(true);
+      expect(farmManager.getPlot('test_map', position)?.state).toBe(FarmPlotState.WATERED);
+    });
+
+    it('should do nothing to a healthy crop', () => {
+      const position = { x: 5, y: 10 };
+      farmManager.tillSoil('test_map', position);
+      farmManager.plantSeed('test_map', position, 'radish', 'seed_radish');
+
+      const result = farmManager.reviveCrop('test_map', position);
+
+      expect(result).toBe(false);
+      expect(farmManager.getPlot('test_map', position)?.state).toBe(FarmPlotState.PLANTED);
+    });
   });
 
   describe('harvestCrop', () => {
@@ -266,6 +328,36 @@ describe('FarmManager', () => {
 
       expect(result).toBeNull();
       expect(inventoryManager.addItem).not.toHaveBeenCalled();
+    });
+
+    it('should reset quality/fertiliser/abundantHarvest on a herb harvest instead of carrying them into the next cycle', () => {
+      const position = { x: 5, y: 10 };
+
+      // Herbs cycle READY <-> HERB_COOLDOWN and never pass back through
+      // till()/plantSeed(), so harvestCrop() is the only place these can reset.
+      farmManager.tillSoil('test_map', position);
+      farmManager.plantSeed('test_map', position, 'thyme', 'seed_thyme');
+      const plot = farmManager.getPlot('test_map', position)!;
+      farmManager.loadPlots([
+        {
+          ...plot,
+          state: FarmPlotState.READY,
+          quality: 'excellent',
+          fertiliserApplied: true,
+          abundantHarvest: true,
+        },
+      ]);
+
+      const result = farmManager.harvestCrop('test_map', position);
+
+      expect(result?.cropId).toBe('thyme');
+      expect(result?.quality).toBe('excellent'); // reported quality reflects the harvest just taken
+
+      const updatedPlot = farmManager.getPlot('test_map', position);
+      expect(updatedPlot?.state).toBe(FarmPlotState.HERB_COOLDOWN);
+      expect(updatedPlot?.quality).toBe('normal');
+      expect(updatedPlot?.fertiliserApplied).toBe(false);
+      expect(updatedPlot?.abundantHarvest).toBe(false);
     });
   });
 
@@ -520,6 +612,53 @@ describe('FarmManager', () => {
         const plot = farmManager.getPlot('village', { x: 99, y: 99 });
         expect(plot).toBeUndefined();
       });
+    });
+  });
+
+  describe('debugAdvanceTime', () => {
+    const plantedPlot = (mapId: string, x: number, y: number): FarmPlot => ({
+      mapId,
+      position: { x, y },
+      state: FarmPlotState.PLANTED,
+      cropType: 'radish',
+      plantedAtDay: 1,
+      plantedAtHour: 12,
+      lastWateredDay: 1,
+      lastWateredHour: 12,
+      stateChangedAtDay: 1,
+      stateChangedAtHour: 12,
+      plantedAtTimestamp: Date.now(),
+      lastWateredTimestamp: Date.now(),
+      stateChangedAtTimestamp: Date.now(),
+      quality: 'normal',
+      fertiliserApplied: false,
+    });
+
+    it('only rewinds timestamps for the given map when mapId is provided', () => {
+      farmManager.loadPlots([plantedPlot('village', 1, 1), plantedPlot('personal_garden', 2, 2)]);
+      const beforeOther = farmManager.getPlot('personal_garden', {
+        x: 2,
+        y: 2,
+      })!.plantedAtTimestamp;
+
+      farmManager.debugAdvanceTime(604800000, 'village');
+
+      const village = farmManager.getPlot('village', { x: 1, y: 1 })!;
+      const other = farmManager.getPlot('personal_garden', { x: 2, y: 2 })!;
+      expect(village.state).toBe(FarmPlotState.READY); // matured 7 days ahead
+      expect(other.plantedAtTimestamp).toBe(beforeOther); // untouched
+      expect(other.state).toBe(FarmPlotState.PLANTED); // untouched
+    });
+
+    it('rewinds every map when mapId is omitted', () => {
+      farmManager.loadPlots([plantedPlot('village', 1, 1), plantedPlot('personal_garden', 2, 2)]);
+
+      farmManager.debugAdvanceTime(604800000);
+
+      expect(farmManager.getPlot('village', { x: 1, y: 1 })?.state).toBe(FarmPlotState.READY);
+      expect(farmManager.getPlot('personal_garden', { x: 2, y: 2 })?.state).toBe(
+        FarmPlotState.READY
+      );
     });
   });
 });

--- a/tests/magicEffects.test.ts
+++ b/tests/magicEffects.test.ts
@@ -1,8 +1,10 @@
 /** @vitest-environment node */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { applyPotionEffect, MagicEffectCallbacks } from '../utils/MagicEffects';
 import { getGiftPreferenceReveal } from '../utils/actionHandlers';
 import { createStaticNPC } from '../utils/npcs/createNPC';
+import { farmManager } from '../utils/farmManager';
+import { FarmPlotState, FarmPlot } from '../types';
 
 /**
  * potion_revealing (the Revealing Tonic) used to always report success:false and
@@ -44,6 +46,102 @@ describe('potion_revealing (Revealing Tonic)', () => {
       'reveal_gift_preference',
       expect.any(Number)
     );
+  });
+});
+
+describe('potion_root_revival', () => {
+  beforeEach(() => {
+    farmManager.loadPlots([]);
+  });
+
+  /**
+   * Used to call farmManager.waterPlot() for both WILTING and DEAD plots and count
+   * every one as revived regardless of outcome. waterPlot() explicitly refuses DEAD
+   * plots and no-ops, so the toast lied — DEAD plots stayed dead. Now it uses
+   * reviveCrop() (which does handle DEAD) and only counts actual successes.
+   */
+  it('actually revives dead crops, not just wilting ones', () => {
+    farmManager.loadPlots([
+      {
+        mapId: 'village',
+        position: { x: 1, y: 1 },
+        state: FarmPlotState.DEAD,
+        cropType: 'radish',
+        plantedAtDay: 1,
+        plantedAtHour: 8,
+        lastWateredDay: 1,
+        lastWateredHour: 8,
+        stateChangedAtDay: 2,
+        stateChangedAtHour: 8,
+        plantedAtTimestamp: Date.now() - 100_000,
+        lastWateredTimestamp: Date.now() - 100_000,
+        stateChangedAtTimestamp: Date.now() - 50_000,
+        quality: 'normal',
+        fertiliserApplied: false,
+      },
+    ]);
+
+    const callbacks = makeCallbacks({ getCurrentMapId: () => 'village' });
+    const result = applyPotionEffect('potion_root_revival', callbacks);
+
+    expect(result.message).toBe('Revived 1 crops');
+    const revived = farmManager.getPlot('village', { x: 1, y: 1 });
+    expect(revived?.state).toBe(FarmPlotState.WATERED);
+    expect(revived?.cropType).toBe('radish');
+  });
+
+  it('reports 0 revived when there is nothing to revive', () => {
+    const callbacks = makeCallbacks({ getCurrentMapId: () => 'village' });
+    const result = applyPotionEffect('potion_root_revival', callbacks);
+
+    expect(result.message).toBe('Revived 0 crops');
+  });
+});
+
+describe('potion_harvest_moon', () => {
+  beforeEach(() => {
+    farmManager.loadPlots([]);
+  });
+
+  const growingPlot = (mapId: string, x: number, y: number): FarmPlot => ({
+    mapId,
+    position: { x, y },
+    state: FarmPlotState.PLANTED,
+    cropType: 'radish',
+    plantedAtDay: 1,
+    plantedAtHour: 8,
+    lastWateredDay: 1,
+    lastWateredHour: 8,
+    stateChangedAtDay: 1,
+    stateChangedAtHour: 8,
+    plantedAtTimestamp: Date.now(),
+    lastWateredTimestamp: Date.now(),
+    stateChangedAtTimestamp: Date.now(),
+    quality: 'normal',
+    fertiliserApplied: false,
+  });
+
+  /**
+   * Used to call farmManager.debugAdvanceTime() with no map scope, which rewinds
+   * every plot on every map — not just the current one. Drinking this in one field
+   * silently fast-forwarded crops on other maps (e.g. the shared village farm) past
+   * their watering window too.
+   */
+  it('only matures crops on the current map, leaving other maps untouched', () => {
+    farmManager.loadPlots([growingPlot('personal_garden', 1, 1), growingPlot('village', 2, 2)]);
+
+    const callbacks = makeCallbacks({ getCurrentMapId: () => 'personal_garden' });
+    const result = applyPotionEffect('potion_harvest_moon', callbacks);
+
+    expect(result.message).toBe('Grew 1 crops');
+    // A single calculatePlotState pass lands on WILTING before READY (the water-check
+    // runs first) — the live 2s game-loop tick carries it the rest of the way to READY
+    // in real play. What matters here is that time moved for this plot at all...
+    expect(farmManager.getPlot('personal_garden', { x: 1, y: 1 })?.state).not.toBe(
+      FarmPlotState.PLANTED
+    );
+    // ...and did not move at all for the other map's plot.
+    expect(farmManager.getPlot('village', { x: 2, y: 2 })?.state).toBe(FarmPlotState.PLANTED);
   });
 });
 

--- a/tests/queenAvariciaGhostQuest.test.ts
+++ b/tests/queenAvariciaGhostQuest.test.ts
@@ -1,0 +1,58 @@
+/** @vitest-environment node */
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { handleDialogueAction } from '../utils/dialogueHandlers';
+import { inventoryManager } from '../utils/inventoryManager';
+import { eventChainManager } from '../utils/EventChainManager';
+import { getDialogue } from '../services/dialogueService';
+import { createGhostNPC } from '../utils/npcs/village/queenAvaricia';
+import {
+  GHOST_QUEEN_QUEST_ID,
+  advanceGhostQuestToHasBook,
+} from '../data/questHandlers/ghostQueenHandler';
+
+/**
+ * Regression: the stage-2 "greeting" node's book-delivery response routed
+ * directly to 'ghost_deliver', skipping the 'ghost_deliver_book' pass-through
+ * node that dialogueHandlers.ts intercepts to actually remove history_book
+ * from inventory. That made the item linger forever after completing the
+ * quest through the normal in-game dialogue path (get book from Mushra →
+ * return to the ghost → deliver it).
+ */
+
+function clearHistoryBook(): void {
+  while (inventoryManager.hasItem('history_book', 1)) {
+    inventoryManager.removeItem('history_book', 1);
+  }
+}
+
+describe('Queen Avaricia ghost_queen book delivery', () => {
+  beforeEach(async () => {
+    eventChainManager.initialise();
+    eventChainManager.resetChain(GHOST_QUEEN_QUEST_ID);
+    clearHistoryBook();
+    await eventChainManager.startChain(GHOST_QUEEN_QUEST_ID, {});
+    advanceGhostQuestToHasBook();
+    inventoryManager.addItem('history_book', 1);
+  });
+
+  afterAll(() => {
+    clearHistoryBook();
+  });
+
+  it('routes the stage-2 greeting response through the item-removing pass-through node', async () => {
+    const npc = createGhostNPC();
+    const node = await getDialogue(npc, 'greeting');
+    const deliverOption = node?.responses?.find((r) => r.text.startsWith('The history book'));
+
+    expect(deliverOption?.nextId).toBe('ghost_deliver_book');
+  });
+
+  it('removes history_book from inventory when delivered via the dialogue path', () => {
+    expect(inventoryManager.getQuantity('history_book')).toBe(1);
+
+    const redirect = handleDialogueAction('ghost_queen', 'ghost_deliver_book');
+
+    expect(redirect).toBe('ghost_deliver');
+    expect(inventoryManager.getQuantity('history_book')).toBe(0);
+  });
+});

--- a/utils/EventBus.ts
+++ b/utils/EventBus.ts
@@ -117,7 +117,7 @@ export enum GameEvent {
 export interface EventPayloads {
   [GameEvent.FARM_PLOT_CHANGED]: {
     position?: Position;
-    action?: 'till' | 'plant' | 'water' | 'harvest' | 'clear' | 'wilt' | 'die';
+    action?: 'till' | 'plant' | 'water' | 'harvest' | 'clear' | 'wilt' | 'die' | 'revive';
   };
   [GameEvent.FARM_CROP_GREW]: {
     position: Position;

--- a/utils/MagicEffects.ts
+++ b/utils/MagicEffects.ts
@@ -565,8 +565,10 @@ const POTION_EFFECTS: Record<string, PotionEffectDefinition> = {
       const grownCount = growingPlots.length;
 
       if (grownCount > 0) {
-        // Advance time by 7 days (604800000 ms) to mature all crops
-        farmManager.debugAdvanceTime(604800000);
+        // Advance time by 7 days (604800000 ms) to mature crops on the current map only —
+        // unscoped, this would also fast-forward every other map's plots (including the
+        // shared village farm) past their watering window, silently wilting them offscreen.
+        farmManager.debugAdvanceTime(604800000, mapId);
       }
 
       callbacks.refreshFarmPlots();
@@ -654,9 +656,9 @@ const POTION_EFFECTS: Record<string, PotionEffectDefinition> = {
 
       plots.forEach((plot) => {
         if (plot.state === FarmPlotState.WILTING || plot.state === FarmPlotState.DEAD) {
-          // Water the wilting crop to revive it
-          farmManager.waterPlot(mapId, plot.position);
-          revivedCount++;
+          if (farmManager.reviveCrop(mapId, plot.position)) {
+            revivedCount++;
+          }
         }
       });
 

--- a/utils/farmManager.ts
+++ b/utils/farmManager.ts
@@ -180,7 +180,8 @@ class FarmManager {
         if (plot.state === FarmPlotState.HERB_COOLDOWN) {
           const cooldownMs = (herbCrop.harvestCooldownDays ?? 1) * TimeManager.MS_PER_GAME_DAY;
           // Treat missing timestamp as already expired (handles old save data)
-          const elapsed = plot.harvestedAtTimestamp != null ? now - plot.harvestedAtTimestamp : cooldownMs;
+          const elapsed =
+            plot.harvestedAtTimestamp != null ? now - plot.harvestedAtTimestamp : cooldownMs;
           if (elapsed >= cooldownMs) {
             return {
               ...plot,
@@ -470,6 +471,39 @@ class FarmManager {
   }
 
   /**
+   * Revive a wilting or dead crop back to a healthy, watered state.
+   * Unlike waterPlot(), this also handles DEAD plots — a dead crop's cropType and
+   * plantedAtTimestamp are still intact (only its state changed), so reviving it
+   * just needs to clear the death and treat it as freshly watered.
+   */
+  reviveCrop(mapId: string, position: Position): boolean {
+    const plot = this.getPlot(mapId, position);
+    if (!plot || (plot.state !== FarmPlotState.WILTING && plot.state !== FarmPlotState.DEAD)) {
+      return false;
+    }
+
+    const gameTime = TimeManager.getCurrentTime();
+    const now = Date.now();
+
+    const updatedPlot: FarmPlot = {
+      ...plot,
+      state: FarmPlotState.WATERED,
+      lastWateredDay: gameTime.totalDays,
+      lastWateredHour: gameTime.hour,
+      stateChangedAtDay: gameTime.totalDays,
+      stateChangedAtHour: gameTime.hour,
+      lastWateredTimestamp: now,
+      stateChangedAtTimestamp: now,
+    };
+
+    this.registerPlot(updatedPlot);
+    if (DEBUG.FARM) console.log(`[FarmManager] Revived crop at ${position.x},${position.y}`);
+    eventBus.emit(GameEvent.FARM_PLOT_CHANGED, { position: plot.position, action: 'revive' });
+    this.syncSharedPlot(mapId, position);
+    return true;
+  }
+
+  /**
    * Apply fertiliser to a growing crop
    * Requires player to have fertiliser in inventory (consumes 1)
    * Improves final crop quality when harvested
@@ -577,7 +611,11 @@ class FarmManager {
 
     let updatedPlot: FarmPlot;
     if (crop.isHerb) {
-      // Herbs persist after harvest — enter cooldown, plot stays occupied
+      // Herbs persist after harvest — enter cooldown, plot stays occupied.
+      // Unlike annual crops, herbs never pass back through till()/plantSeed() (the only
+      // other places these boosts get cleared), so they must be reset here or a single
+      // fertiliser/blessing application would compound into a permanent bonus on every
+      // future harvest of the same plant.
       updatedPlot = {
         ...plot,
         state: FarmPlotState.HERB_COOLDOWN,
@@ -585,6 +623,9 @@ class FarmManager {
         stateChangedAtHour: gameTime.hour,
         stateChangedAtTimestamp: now,
         harvestedAtTimestamp: now,
+        quality: 'normal',
+        fertiliserApplied: false,
+        abundantHarvest: false,
       };
     } else {
       // Normal crops reset to fallow
@@ -1184,7 +1225,9 @@ class FarmManager {
         }
 
         if (purged > 0) {
-          console.log(`[SharedFarm] Rejected ${purged} orphaned remote plots — queued for Firestore deletion`);
+          console.log(
+            `[SharedFarm] Rejected ${purged} orphaned remote plots — queued for Firestore deletion`
+          );
         }
 
         // Check for locally-known shared plots that were removed remotely
@@ -1336,13 +1379,19 @@ class FarmManager {
   }
 
   /**
-   * DEBUG: Advance time for all farm plots by specified milliseconds
-   * This rewinds timestamps to simulate time passing
+   * DEBUG: Advance time for farm plots by specified milliseconds
+   * This rewinds timestamps to simulate time passing.
+   * Pass mapId to scope the advance to a single map (e.g. a magic effect that should
+   * only affect the player's current field) — omit it to affect every plot on every
+   * map, as debug tooling intends.
    */
-  debugAdvanceTime(milliseconds: number): void {
-    console.log(`[FarmManager DEBUG] Advancing time by ${milliseconds}ms`);
+  debugAdvanceTime(milliseconds: number, mapId?: string): void {
+    console.log(
+      `[FarmManager DEBUG] Advancing time by ${milliseconds}ms${mapId ? ` (map: ${mapId})` : ''}`
+    );
 
     for (const plot of this.plots.values()) {
+      if (mapId !== undefined && plot.mapId !== mapId) continue;
       const updatedPlot = { ...plot };
 
       // Rewind timestamps (subtract time to make them "older")

--- a/utils/npcs/village/queenAvaricia.ts
+++ b/utils/npcs/village/queenAvaricia.ts
@@ -212,7 +212,10 @@ export function createGhostNPC(): NPC {
         requiredQuestStage: 2,
         maxQuestStage: 2,
         responses: [
-          { text: 'The history book — I wanted to hear your thoughts.', nextId: 'ghost_deliver' },
+          {
+            text: 'The history book — I wanted to hear your thoughts.',
+            nextId: 'ghost_deliver_book',
+          },
         ],
       },
       { id: 'ghost_deliver_book', text: '' }, // intercepted by dialogueHandlers — removes book, then redirects here:
@@ -287,10 +290,7 @@ export function createQueenAvericiaaNPC(): NPC {
         id: 'queen_lore_wizard',
         text: '"A fraudulent wizard who had been pestering me for money. I came to his tower seeking counsel, and he repaid me with treachery. I am still absolutely *furious* about it. Five hundred years, and it still stings."',
         expression: 'default',
-        responses: [
-          { text: 'That sounds dreadful.' },
-          { text: 'Goodbye.' },
-        ],
+        responses: [{ text: 'That sounds dreadful.' }, { text: 'Goodbye.' }],
       },
     ],
   });


### PR DESCRIPTION
## Summary

Follow-up to #11 and #12 (both merged) — a third batch of independent bug fixes. Each commit is self-contained.

- **Skiing mini-game crash-timeout leak** — `handleCrash()` scheduled an untracked `setTimeout(finishRun, 700)` after `triggerExhaustion()`. That call synchronously starts the exhaustion cutscene, which closes all UI and unmounts `SkiingGame` almost immediately — well before the 700ms delay elapses on essentially every crash. The orphaned timeout still fired against stale closures, popping a stray, contradictory "You took a tumble..." toast and re-invoking `onComplete` a second time. Now stores the timeout id and clears it on unmount.
- **Queen Avaricia quest: `history_book` never consumed on delivery** — the stage-2 greeting node's "The history book..." response routed directly to `'ghost_deliver'`, skipping the `'ghost_deliver_book'` pass-through node that `dialogueHandlers.ts` intercepts to actually remove the book from inventory. Since the only way to obtain the book (via Mushra) immediately advances the quest past stage 1, the stage-1 node's item-consuming branch was unreachable dead code — the normal in-game delivery path never consumed the book, leaving it in the player's inventory forever after completing the quest. (Found while verifying the previous PR's Mushra fix, which had used this node as the "correctly gated" reference example — it turned out to have its own, different bug.)
- **Three farm/potion bugs:**
  - `harvestCrop()`'s herb branch never reset `quality`/`fertiliserApplied`/`abundantHarvest`, unlike every other plot-reset path. Herbs cycle READY ↔ HERB_COOLDOWN without ever passing back through `till()`/`plantSeed()` (the only other places these reset), so a single fertiliser or blessing application became a permanent bonus on every future harvest of that plant.
  - `potion_root_revival` called `waterPlot()` for WILTING and DEAD plots alike and always reported success, but `waterPlot()` explicitly refuses DEAD plots and no-ops. The "N crops brought back to life!" toast lied — dead crops stayed dead. Added `farmManager.reviveCrop()`, which does handle DEAD plots, and only counts actual successes.
  - `potion_harvest_moon` counted growing plots on the current map only, but called the unscoped `farmManager.debugAdvanceTime()`, which rewinds every plot on every map. Drinking it in one field silently fast-forwarded crops elsewhere (e.g. the shared village farm) past their watering window. `debugAdvanceTime()` now takes an optional `mapId` to scope the advance; existing debug-tooling callers keep their unscoped behaviour by omitting it.
- **`DarknessLayer` leak on WebGL context restore** — `initPixi()` creates a fresh `DarknessLayer` on every WebGL context restore, but unlike every other layer (tile, sprite, background image, weather, etc.) the previous instance's `destroy()` was never called and its ref never cleared. `DarknessLayer`'s flicker/transition `setInterval` timers only stop via `destroy()`, so a player who lingers in a torch-lit area through a context-loss cycle (common on iPad Safari under memory pressure — the exact scenario the sibling `BackgroundImageLayer` fix in #12 targeted) permanently leaks a 20fps timer on an orphaned instance, stacking another on each subsequent cycle.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 469/469 tests pass (added `tests/queenAvariciaGhostQuest.test.ts`, extended `tests/farmManager.test.ts` and `tests/magicEffects.test.ts`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SoetNoXWrdsQfGEWM2xCk1)_