### PR TITLE
Make interior viewportScale invariant to browser page zoom

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -36,6 +36,7 @@ import { useCharacterSprites, getPlayerSpriteInfo } from './hooks/useCharacterSp
 import { useCamera } from './hooks/useCamera';
 import { usePinchZoom } from './hooks/usePinchZoom';
 import { useBrowserZoomLock } from './hooks/useBrowserZoomLock';
+import { useBrowserZoom } from './hooks/useBrowserZoom';
 import { useViewportCulling } from './hooks/useViewportCulling';
 import { useUIState } from './hooks/useUIState';
 import { useGameEvents } from './hooks/useGameEvents';
@@ -1079,6 +1080,10 @@ const App: React.FC = () => {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
+  // Browser page-zoom factor relative to load (1.0 = normal). Keeps the
+  // viewportScale memo below invariant to browser zoom — see useBrowserZoom.
+  const browserZoom = useBrowserZoom();
+
   // Calculate viewport scale for background-image rooms
   // This scales the entire room (image, grid, characters) to fit the viewport
   // IMPORTANT: Only scale UP on large screens, never scale down on small screens
@@ -1090,10 +1095,15 @@ const App: React.FC = () => {
     // Get reference viewport from map definition, or use defaults
     const refViewport = currentMap.referenceViewport ?? DEFAULT_REFERENCE_VIEWPORT;
 
-    // Calculate scale to fit current viewport
+    // Divide the browser-zoom factor back out of the viewport dimensions before
+    // fitting. Browser zoom shrinks innerWidth/innerHeight (CSS px), which would
+    // otherwise drag viewportScale toward its 1.0 floor and cancel the zoom on
+    // large monitors — leaving the room image and character the only things that
+    // don't magnify. Normalising here lets interiors zoom WITH the browser, like
+    // tiled rooms do. See useBrowserZoom / docs/ARCHITECTURE_GOTCHAS.md.
     const rawScale = calculateViewportScale(
-      viewportSize.width,
-      viewportSize.height,
+      viewportSize.width * browserZoom,
+      viewportSize.height * browserZoom,
       refViewport.width,
       refViewport.height,
       0.5, // minScale (absolute floor)
@@ -1103,7 +1113,7 @@ const App: React.FC = () => {
     // Only scale UP on larger viewports, never scale down
     // This ensures small screens still see the original design
     return Math.max(1.0, rawScale);
-  }, [currentMap?.renderMode, currentMap?.referenceViewport, viewportSize]);
+  }, [currentMap?.renderMode, currentMap?.referenceViewport, viewportSize, browserZoom]);
 
   // Memoize compact mode for touch controls to avoid synchronous DOM reads on every render
   const isCompactMode = useMemo(() => {

--- a/docs/ARCHITECTURE_GOTCHAS.md
+++ b/docs/ARCHITECTURE_GOTCHAS.md
@@ -290,12 +290,30 @@ Background-image rooms use pre-drawn artwork instead of tile-by-tile rendering. 
 - **`layers`**: Array of image layers (back, NPC, front) composited in order
 - **`centered`**: Flag on image layers indicating viewport centering
 
+### Browser zoom vs `viewportScale` (the "interior won't zoom" bug)
+
+`viewportScale` (responsive fit for interiors) is derived from `window.innerWidth/innerHeight`,
+which are **CSS pixels** — browser page zoom shrinks them. On any monitor larger than the
+reference viewport (1920×1080), zooming in used to drag `viewportScale` back toward its `1.0`
+floor and **exactly cancel the browser's magnification**: the room artwork and the character
+(both sized by `viewportScale`) stayed the same physical size while tiled rooms magnified
+normally. Tiled rooms have no `viewportScale`, so the browser's own scaling passes straight
+through — hence the mismatch.
+
+Fix: [`hooks/useBrowserZoom.ts`](../hooks/useBrowserZoom.ts) reports the page-zoom factor
+(`devicePixelRatio / baselineDpr`), and the `viewportScale` memo in `App.tsx` multiplies it back
+into the viewport dimensions so `viewportScale` is **browser-zoom-invariant**. Interiors then
+magnify with the browser like everything else. Guarded by [`tests/viewportZoom.test.ts`](../tests/viewportZoom.test.ts).
+Note `useBrowserZoomLock` only blocks Ctrl/⌘ + scroll / +/-/0 — the browser's View→Zoom menu and
+persisted per-site zoom still apply, so this path has to be correct.
+
 ### Common mistakes
 
 1. **Forgetting zoom in gridOffset** — see Section 1
 2. **Placing NPCs using pixel coordinates** — NPCs use tile coordinates, not pixels
 3. **Testing only at zoom=1** — offset bugs only manifest when zoomed
 4. **Assuming camera works the same** — background-image rooms don't scroll; camera is effectively fixed
+5. **Deriving interior sizes from raw `innerWidth`** — factor out browser zoom (see above) or interiors won't match tiled rooms
 
 ---
 

--- a/hooks/useBrowserZoom.ts
+++ b/hooks/useBrowserZoom.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Tracks the browser's page-zoom factor relative to the zoom level the app was
+ * first loaded at (1.0 = same as load, 2.0 = zoomed in to 200%, 0.5 = 50%).
+ *
+ * Browser (page) zoom multiplies `window.devicePixelRatio` by the zoom factor
+ * while dividing `window.innerWidth`/`innerHeight` by the same factor. We capture
+ * DPR once at load as the baseline (assumed to be the user's normal zoom) and
+ * report the live ratio.
+ *
+ * WHY THIS EXISTS — background-image rooms (interiors) scale their artwork with
+ * `viewportScale`, which is derived from `window.innerWidth`/`innerHeight`. Under
+ * browser zoom those CSS dimensions shrink, so on any monitor larger than the
+ * reference viewport `viewportScale` drops back toward its 1.0 floor and silently
+ * *cancels out* the zoom: the room image and character stay the same physical
+ * size while tiled rooms magnify normally. Dividing this factor back out of the
+ * viewport dimensions before computing `viewportScale` makes it
+ * browser-zoom-invariant, so interiors magnify with the browser like everything
+ * else. See docs/ARCHITECTURE_GOTCHAS.md (background-image room rendering).
+ *
+ * Note: browser zoom always changes `innerWidth`, so a `resize` listener (the
+ * same signal the rest of the app already uses) reliably catches zoom changes.
+ */
+export function useBrowserZoom(): number {
+  const baselineDprRef = useRef(
+    typeof window !== 'undefined' && window.devicePixelRatio ? window.devicePixelRatio : 1
+  );
+  const [zoomFactor, setZoomFactor] = useState(1);
+
+  useEffect(() => {
+    const update = () => {
+      const dpr = window.devicePixelRatio || 1;
+      setZoomFactor(dpr / baselineDprRef.current);
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
+  return zoomFactor;
+}

--- a/tests/viewportZoom.test.ts
+++ b/tests/viewportZoom.test.ts
@@ -1,0 +1,80 @@
+/** @vitest-environment node */
+/**
+ * viewportZoom — guards the browser-zoom fix for background-image (interior) rooms.
+ *
+ * Background: interior artwork + the player are sized by `viewportScale`, derived
+ * from `window.innerWidth/innerHeight`. Browser page zoom shrinks those CSS
+ * dimensions, so on monitors larger than the reference viewport `viewportScale`
+ * used to drop toward its 1.0 floor and cancel the zoom — the room and character
+ * were the ONLY things that didn't magnify. The fix divides the browser-zoom
+ * factor back out (see hooks/useBrowserZoom.ts + the viewportScale memo in App.tsx).
+ *
+ * Invariant under test: for a FIXED physical monitor, `viewportScale` must be the
+ * same at every browser-zoom level, so the browser's own magnification passes
+ * through to interiors exactly as it does for tiled rooms.
+ */
+import { describe, it, expect } from 'vitest';
+import { calculateViewportScale, DEFAULT_REFERENCE_VIEWPORT } from '../hooks/useViewportScale';
+
+/**
+ * Mirrors the App.tsx viewportScale computation for a background-image room.
+ * Browser zoom `z` (relative to load) multiplies devicePixelRatio and divides
+ * innerWidth/innerHeight by the same factor, so at zoom z the CSS viewport is
+ * physical/z. `browserZoom` (= dpr/baselineDpr) is z, and we normalise it out.
+ */
+function interiorViewportScale(
+  physicalWidth: number,
+  physicalHeight: number,
+  browserZoom: number,
+  ref = DEFAULT_REFERENCE_VIEWPORT
+): number {
+  const cssWidth = physicalWidth / browserZoom; // window.innerWidth at this zoom
+  const cssHeight = physicalHeight / browserZoom; // window.innerHeight at this zoom
+  const rawScale = calculateViewportScale(
+    cssWidth * browserZoom, // normalise the zoom back out
+    cssHeight * browserZoom,
+    ref.width,
+    ref.height,
+    0.5,
+    2.5
+  );
+  return Math.max(1.0, rawScale);
+}
+
+describe('interior viewportScale vs browser zoom', () => {
+  const monitors = [
+    { name: '1080p', w: 1920, h: 1080 },
+    { name: '1440p', w: 2560, h: 1440 },
+    { name: '4K', w: 3840, h: 2160 },
+    { name: 'ultrawide 3440x1440', w: 3440, h: 1440 },
+  ];
+  const zoomLevels = [0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5];
+
+  for (const m of monitors) {
+    it(`${m.name}: viewportScale is invariant across browser zoom`, () => {
+      const baseline = interiorViewportScale(m.w, m.h, 1.0);
+      for (const z of zoomLevels) {
+        const scale = interiorViewportScale(m.w, m.h, z);
+        expect(scale).toBeCloseTo(baseline, 6);
+      }
+    });
+  }
+
+  it('large monitors still scale up at load (fix preserves default appearance)', () => {
+    // 4K at 100% should scale up (this is the responsive behaviour we keep).
+    expect(interiorViewportScale(3840, 2160, 1.0)).toBeGreaterThan(1.0);
+    // 1080p at 100% stays at the 1.0 floor.
+    expect(interiorViewportScale(1920, 1080, 1.0)).toBe(1.0);
+  });
+
+  it('regression: without normalisation, zoom cancels on large monitors', () => {
+    // The OLD (buggy) behaviour = fitting the raw CSS viewport with no zoom
+    // compensation. On 4K, zooming to 200% dropped the scale from 2.0 to 1.0,
+    // exactly cancelling the browser magnification. This asserts the bug existed
+    // so the invariant test above is meaningful.
+    const buggy = (physW: number, physH: number, z: number) =>
+      Math.max(1.0, calculateViewportScale(physW / z, physH / z, 1920, 1080, 0.5, 2.5));
+    expect(buggy(3840, 2160, 1.0)).toBeCloseTo(2.0, 6);
+    expect(buggy(3840, 2160, 2.0)).toBeCloseTo(1.0, 6); // zoom cancelled → the bug
+  });
+});


### PR DESCRIPTION
## Problem

Background-image rooms (interiors) size their artwork and the player via `viewportScale`, derived from `window.innerWidth/innerHeight` — **CSS pixels**, which browser page zoom shrinks.

On any monitor larger than the reference viewport (1920×1080), zooming in dragged `viewportScale` back toward its `1.0` floor and *exactly cancelled* the browser's magnification. The room artwork and the character were the only things that didn't grow, while tiled rooms (which have no `viewportScale`) magnified normally.

## Fix

`hooks/useBrowserZoom.ts` reports the page-zoom factor (`devicePixelRatio` relative to the baseline captured at load). The `viewportScale` memo in `App.tsx` divides it back out of the viewport dimensions before fitting, making `viewportScale` browser-zoom-invariant.

This is **browser page zoom**, distinct from the in-game pinch/wheel `zoom` from `usePinchZoom`. `useBrowserZoomLock` only blocks Ctrl/⌘ + scroll and +/-/0 — the View→Zoom menu and persisted per-site zoom still apply, so this path has to be correct.

## Tests

`tests/viewportZoom.test.ts` asserts `viewportScale` is identical at every zoom level for a fixed physical monitor (1080p / 1440p / 4K / ultrawide × 8 zoom levels), keeps the responsive scale-up at 100%, and pins the old cancelling behaviour as an explicit regression case.

`make verify` green: typecheck clean, 491 tests across 37 files pass.

Docs updated in `docs/ARCHITECTURE_GOTCHAS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k