### PR TITLE
Disable pinch/wheel zoom in interior rooms

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -34,7 +34,7 @@ import { EventChainPopup } from './components/EventChainPopup';
 import { useAmbientVFX } from './hooks/useAmbientVFX';
 import { useCharacterSprites, getPlayerSpriteInfo } from './hooks/useCharacterSprites';
 import { useCamera } from './hooks/useCamera';
-import { usePinchZoom } from './hooks/usePinchZoom';
+import { usePinchZoom, getZoomLimitsForRoom } from './hooks/usePinchZoom';
 import { useBrowserZoomLock } from './hooks/useBrowserZoomLock';
 import { useViewportCulling } from './hooks/useViewportCulling';
 import { useUIState } from './hooks/useUIState';
@@ -261,14 +261,26 @@ const App: React.FC = () => {
     ui.miniGame ||
     ui.devTools ||
     ui.vfxTestPanel;
-  const zoomMinForMap = useMemo(() => {
+  // Background-image rooms (interiors) already fit the viewport responsively via
+  // `viewportScale` (see the memo below); pinch/wheel zoom is disabled there so it
+  // can't re-fit the room at a different scale mid-frame and rearrange the layout.
+  // See getZoomLimitsForRoom (hooks/usePinchZoom.ts) for the full rationale.
+  const isBackgroundImageRoom = useMemo(() => {
     const map = mapManager.getMap(currentMapId);
-    return map?.renderMode === 'background-image' ? 1.0 : 0.5;
+    return map?.renderMode === 'background-image';
   }, [currentMapId]);
+  const zoomLimits = useMemo(
+    () => getZoomLimitsForRoom(isBackgroundImageRoom, isAnyOverlayOpen),
+    [isBackgroundImageRoom, isAnyOverlayOpen]
+  );
   // Always prevent browser-level zoom changes (Ctrl+scroll, Ctrl+/-/0)
   // Runs independently of game zoom — never disabled, even when overlays are open
   useBrowserZoomLock();
-  const { zoom, resetZoom } = usePinchZoom({ minZoom: zoomMinForMap, enabled: !isAnyOverlayOpen });
+  const { zoom, resetZoom } = usePinchZoom({
+    minZoom: zoomLimits.minZoom,
+    maxZoom: zoomLimits.maxZoom,
+    enabled: zoomLimits.enabled,
+  });
 
   // Toast notifications for user feedback
   const { messages: toastMessages, showToast, dismissToast } = useToast();

--- a/hooks/usePinchZoom.ts
+++ b/hooks/usePinchZoom.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 /** Default zoom limits */
-const DEFAULT_MIN_ZOOM = 0.5;
-const DEFAULT_MAX_ZOOM = 2.0;
+export const DEFAULT_MIN_ZOOM = 0.5;
+export const DEFAULT_MAX_ZOOM = 2.0;
 const DEFAULT_ZOOM = 1.0;
 
 /** Mouse wheel zoom sensitivity (smaller = slower) */
@@ -25,6 +25,36 @@ interface UsePinchZoomResult {
   zoom: number;
   /** Reset zoom to 1.0 */
   resetZoom: () => void;
+}
+
+export interface ZoomLimits {
+  minZoom: number;
+  maxZoom: number;
+  enabled: boolean;
+}
+
+/**
+ * Decides the pinch/wheel zoom limits for the current room.
+ *
+ * Background-image rooms (interiors) already fit the viewport responsively via
+ * `viewportScale`. Letting pinch/wheel zoom apply on top of that re-fits the room
+ * at a different scale mid-frame, which visibly rearranges furniture, NPCs and the
+ * character — so game zoom is pinned to 1.0 (disabled) for these rooms. Tiled
+ * rooms keep the normal min/max, and are also disabled while a UI overlay is open
+ * so scroll/pinch works in menus instead.
+ */
+export function getZoomLimitsForRoom(
+  isBackgroundImageRoom: boolean,
+  isAnyOverlayOpen: boolean
+): ZoomLimits {
+  if (isBackgroundImageRoom) {
+    return { minZoom: 1.0, maxZoom: 1.0, enabled: false };
+  }
+  return {
+    minZoom: DEFAULT_MIN_ZOOM,
+    maxZoom: DEFAULT_MAX_ZOOM,
+    enabled: !isAnyOverlayOpen,
+  };
 }
 
 /**

--- a/tests/pinchZoomLimits.test.ts
+++ b/tests/pinchZoomLimits.test.ts
@@ -1,0 +1,39 @@
+/** @vitest-environment node */
+/**
+ * getZoomLimitsForRoom — guards issue #25: pinch/wheel zoom must be disabled in
+ * background-image rooms (interiors), because they already fit the viewport via
+ * `viewportScale` and letting game zoom apply on top rearranges the room layout.
+ */
+import { describe, it, expect } from 'vitest';
+import { getZoomLimitsForRoom, DEFAULT_MIN_ZOOM, DEFAULT_MAX_ZOOM } from '../hooks/usePinchZoom';
+
+describe('getZoomLimitsForRoom', () => {
+  it('disables zoom entirely in background-image rooms, even with no overlay open', () => {
+    const limits = getZoomLimitsForRoom(true, false);
+    expect(limits.enabled).toBe(false);
+    expect(limits.minZoom).toBe(1.0);
+    expect(limits.maxZoom).toBe(1.0);
+  });
+
+  it('stays disabled in background-image rooms with an overlay open too', () => {
+    const limits = getZoomLimitsForRoom(true, true);
+    expect(limits.enabled).toBe(false);
+    expect(limits.minZoom).toBe(1.0);
+    expect(limits.maxZoom).toBe(1.0);
+  });
+
+  it('allows the normal zoom range in tiled rooms when no overlay is open', () => {
+    const limits = getZoomLimitsForRoom(false, false);
+    expect(limits.enabled).toBe(true);
+    expect(limits.minZoom).toBe(DEFAULT_MIN_ZOOM);
+    expect(limits.maxZoom).toBe(DEFAULT_MAX_ZOOM);
+  });
+
+  it('disables zoom in tiled rooms while a UI overlay is open', () => {
+    const limits = getZoomLimitsForRoom(false, true);
+    expect(limits.enabled).toBe(false);
+    // Limits stay at the normal range — only listener attachment is gated by `enabled`.
+    expect(limits.minZoom).toBe(DEFAULT_MIN_ZOOM);
+    expect(limits.maxZoom).toBe(DEFAULT_MAX_ZOOM);
+  });
+});


### PR DESCRIPTION
Fixes #25.

## Problem

Background-image rooms (interiors) already fit the viewport responsively via `viewportScale`. Pinch/wheel zoom (`usePinchZoom`) was still active on top of that, so zooming re-fit the room at a different scale mid-frame — visibly rearranging furniture, NPCs and the character.

## Fix

Extracted the min/max/enabled decision into `getZoomLimitsForRoom` (pure function, `hooks/usePinchZoom.ts`):
- Background-image rooms: zoom pinned to `1.0` and listeners disabled outright.
- Tiled rooms: unchanged — `0.5`–`2.0` range, disabled while a UI overlay is open.

`App.tsx` now derives `zoomLimits` from this helper instead of inlining the min-only ternary it had before (which left `maxZoom` at its default `2.0`, allowing zoom-in in interiors — the actual bug).

## Tests

New `tests/pinchZoomLimits.test.ts` covers all four (room type × overlay) combinations. `make verify` green: typecheck clean, 489 tests across 37 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k