### PR TITLE
Fix three Yule celebration bugs: stuck NPCs, trapped player, dead-end dialogue

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -441,8 +441,10 @@ const App: React.FC = () => {
     teleportPlayer(spawn);
     lastTransitionTime.current = Date.now();
 
-    // End Yule celebration BEFORE updating the NPC manager's map, so that
-    // removeDynamicNPC() still targets 'village' (its currentMapId at this point).
+    // End Yule celebration when leaving the village mid-timer. Note transitionToMap()
+    // above already moved npcManager's currentMapId to the destination (MapManager.loadMap
+    // updates it as soon as the map loads) — forceEnd() cleans up village NPCs by explicit
+    // map id (YULE_MAP_ID), not currentMapId, so this doesn't need to run before that call.
     if (map.id !== 'village' && yuleCelebrationManager.isActive()) {
       yuleCelebrationManager.forceEnd();
     }
@@ -503,7 +505,12 @@ const App: React.FC = () => {
 
     // Handle Yule celebration opening cutscene completion
     if (action.cutsceneId === YULE_CUTSCENE_ID) {
-      yuleCelebrationManager.onCutsceneComplete();
+      // Nudge the player out of the way if they're standing where an event NPC
+      // is about to be placed, so they can't end up trapped inside one (#27).
+      const safePlayerPosition = yuleCelebrationManager.onCutsceneComplete(playerPos);
+      if (safePlayerPosition) {
+        teleportPlayer(safePlayerPosition);
+      }
     }
 
     // Handle fairy queen cutscene completions

--- a/NPCManager.ts
+++ b/NPCManager.ts
@@ -171,14 +171,20 @@ class NPCManagerClass {
     // Check season condition (supports single value or array)
     if (conditions.season) {
       const allowed = Array.isArray(conditions.season) ? conditions.season : [conditions.season];
-      if (!allowed.includes(currentTime.season.toLowerCase() as 'spring' | 'summer' | 'autumn' | 'winter')) {
+      if (
+        !allowed.includes(
+          currentTime.season.toLowerCase() as 'spring' | 'summer' | 'autumn' | 'winter'
+        )
+      ) {
         return false;
       }
     }
 
     // Check time of day condition (supports single value or array)
     if (conditions.timeOfDay) {
-      const allowed = Array.isArray(conditions.timeOfDay) ? conditions.timeOfDay : [conditions.timeOfDay];
+      const allowed = Array.isArray(conditions.timeOfDay)
+        ? conditions.timeOfDay
+        : [conditions.timeOfDay];
       if (!allowed.includes(currentTime.timeOfDay.toLowerCase() as 'day' | 'night')) {
         return false;
       }
@@ -892,27 +898,32 @@ class NPCManagerClass {
   }
 
   /**
-   * Remove a dynamic NPC from the current map (for despawning)
+   * Remove a dynamic NPC from a map (for despawning). Defaults to the current map,
+   * but accepts an explicit `mapId` for callers (e.g. YuleCelebrationManager) that
+   * may run after `currentMapId` has already moved on — MapManager.loadMap() sets
+   * it as soon as a transition starts, before any "player is leaving map X" cleanup
+   * gets a chance to run.
    */
-  removeDynamicNPC(npcId: string): void {
-    if (!this.currentMapId) {
+  removeDynamicNPC(npcId: string, mapId?: string): void {
+    const targetMapId = mapId ?? this.currentMapId;
+    if (!targetMapId) {
       console.warn('[NPCManager] Cannot remove dynamic NPC: No current map');
       return;
     }
 
-    const mapNPCs = this.npcsByMap.get(this.currentMapId) || [];
+    const mapNPCs = this.npcsByMap.get(targetMapId) || [];
     const filteredNPCs = mapNPCs.filter((n) => n.id !== npcId);
 
     if (filteredNPCs.length === mapNPCs.length) {
-      console.warn(`[NPCManager] NPC ${npcId} not found on map ${this.currentMapId}`);
+      console.warn(`[NPCManager] NPC ${npcId} not found on map ${targetMapId}`);
       return;
     }
 
-    this.npcsByMap.set(this.currentMapId, filteredNPCs);
+    this.npcsByMap.set(targetMapId, filteredNPCs);
     this.npcStates.delete(npcId);
 
-    console.log(`[NPCManager] Removed dynamic NPC ${npcId} from map ${this.currentMapId}`);
-    eventBus.emit(GameEvent.NPC_DESPAWNED, { npcId, mapId: this.currentMapId });
+    console.log(`[NPCManager] Removed dynamic NPC ${npcId} from map ${targetMapId}`);
+    eventBus.emit(GameEvent.NPC_DESPAWNED, { npcId, mapId: targetMapId });
   }
 
   /**
@@ -926,7 +937,10 @@ class NPCManagerClass {
     let npc: NPC | undefined;
     for (const npcs of this.npcsByMap.values()) {
       const found = npcs.find((n) => n.id === npcId);
-      if (found) { npc = found; break; }
+      if (found) {
+        npc = found;
+        break;
+      }
     }
     if (!npc) return null;
 
@@ -947,7 +961,10 @@ class NPCManagerClass {
     let npc: NPC | undefined;
     for (const npcs of this.npcsByMap.values()) {
       const found = npcs.find((n) => n.id === npcId);
-      if (found) { npc = found; break; }
+      if (found) {
+        npc = found;
+        break;
+      }
     }
     if (!npc) return;
 
@@ -963,7 +980,9 @@ class NPCManagerClass {
   setEventOverridePosition(npcId: string, position: Position): void {
     const npc = this.getNPCById(npcId);
     if (!npc) {
-      console.warn(`[NPCManager] setEventOverridePosition: NPC "${npcId}" not found on current map`);
+      console.warn(
+        `[NPCManager] setEventOverridePosition: NPC "${npcId}" not found on current map`
+      );
       return;
     }
     if (!this.eventOverrides.has(npcId)) {
@@ -976,10 +995,22 @@ class NPCManagerClass {
   /**
    * Restore all NPCs to their positions before event overrides were applied,
    * then clear the override registry.
+   *
+   * Looks the NPC up across all maps (like setEventScaleOverride/restoreEventScale
+   * already do) rather than via getNPCById/currentMapId — MapManager.loadMap() sets
+   * currentMapId as soon as a transition starts, so a caller cleaning up after
+   * "player left map X" can no longer rely on currentMapId still being X.
    */
   clearEventOverrides(): void {
     for (const [npcId, originalPosition] of this.eventOverrides) {
-      const npc = this.getNPCById(npcId);
+      let npc: NPC | undefined;
+      for (const npcs of this.npcsByMap.values()) {
+        const found = npcs.find((n) => n.id === npcId);
+        if (found) {
+          npc = found;
+          break;
+        }
+      }
       if (npc) {
         npc.position = { ...originalPosition };
         eventBus.emit(GameEvent.NPC_MOVED, { npcId, position: originalPosition });
@@ -993,9 +1024,13 @@ class NPCManagerClass {
    * Get the current location for an NPC based on the current season
    * Returns null if NPC should not appear this season
    */
-  private getSeasonalLocationForNPC(
-    npc: NPC
-  ): { mapId: string; position: Position; direction: Direction; static?: boolean; scale?: number } | null {
+  private getSeasonalLocationForNPC(npc: NPC): {
+    mapId: string;
+    position: Position;
+    direction: Direction;
+    static?: boolean;
+    scale?: number;
+  } | null {
     if (!npc.seasonalLocations) {
       // No seasonal locations, use base location
       const state = this.npcStates.get(npc.id);

--- a/components/dialogue/ScriptedControls.tsx
+++ b/components/dialogue/ScriptedControls.tsx
@@ -57,7 +57,8 @@ function filterResponses(responses: DialogueResponse[] | undefined): DialogueRes
       if (cookingManager.isCookingCourseComplete()) return false;
     }
     if (response.requiredSeason) {
-      if (TimeManager.getCurrentTime().season.toLowerCase() !== response.requiredSeason) return false;
+      if (TimeManager.getCurrentTime().season.toLowerCase() !== response.requiredSeason)
+        return false;
     }
     if (response.hiddenIfAnyDomainStarted) {
       const masteredCount = cookingManager.getMasteredDomainCount();
@@ -82,18 +83,22 @@ const ScriptedControls: React.FC<ScriptedControlsProps> = ({
 }) => {
   const filtered = filterResponses(dialogue.responses);
 
+  const continueButton = (
+    <button
+      onClick={onClose}
+      className="text-xs transition-colors duration-200"
+      style={{ fontFamily: TEXT_FONT, color: 'rgba(180, 160, 140, 0.8)' }}
+      onMouseEnter={(e) => (e.currentTarget.style.color = '#d4a373')}
+      onMouseLeave={(e) => (e.currentTarget.style.color = 'rgba(180, 160, 140, 0.8)')}
+    >
+      Click to continue ▼
+    </button>
+  );
+
   if (filtered.length === 0 && !canUseAI) {
     return (
       <div className="flex-shrink-0 flex justify-center" style={{ padding: '6px 6% 8px' }}>
-        <button
-          onClick={onClose}
-          className="text-xs transition-colors duration-200"
-          style={{ fontFamily: TEXT_FONT, color: 'rgba(180, 160, 140, 0.8)' }}
-          onMouseEnter={(e) => (e.currentTarget.style.color = '#d4a373')}
-          onMouseLeave={(e) => (e.currentTarget.style.color = 'rgba(180, 160, 140, 0.8)')}
-        >
-          Click to continue ▼
-        </button>
+        {continueButton}
       </div>
     );
   }
@@ -103,7 +108,11 @@ const ScriptedControls: React.FC<ScriptedControlsProps> = ({
       className="flex-shrink-0 overflow-y-auto"
       style={{ padding: '6px 6% 8px', maxHeight: '90px' }}
     >
-      <div className="flex flex-wrap gap-1.5 justify-center">
+      <div className="flex flex-wrap gap-1.5 justify-center items-center">
+        {/* No scripted responses to show (only reachable when canUseAI is true —
+            see the early return above) — still needs a way to dismiss the box
+            without going into AI chat. */}
+        {filtered.length === 0 && continueButton}
         {filtered.map((response, index) => (
           <button
             key={index}

--- a/tests/yuleCelebrationMapLeave.test.ts
+++ b/tests/yuleCelebrationMapLeave.test.ts
@@ -1,0 +1,96 @@
+/** @vitest-environment node */
+/**
+ * Regression for issue #30: Yule celebration NPCs weren't reset when the player
+ * left the village map before the 10-minute timer finished.
+ *
+ * Root cause: MapManager.loadMap() calls npcManager.setCurrentMap(mapId) as soon
+ * as a transition starts. App.tsx's handleMapTransition calls transitionToMap()
+ * BEFORE running the Yule forceEnd() check, so by the time forceEnd() ran,
+ * npcManager's "current map" was already the destination — not 'village'.
+ * removeDynamicNPC()/clearEventOverrides() silently no-opped (wrong map / NPC
+ * not found via currentMapId lookup), leaving festival NPCs in place and
+ * static NPCs (Village Elder, Mr Fox) stuck at their Yule-tree positions.
+ *
+ * Fix: NPCManager.removeDynamicNPC() accepts an explicit mapId, and
+ * clearEventOverrides() looks NPCs up across all maps — both independent of
+ * currentMapId — and YuleCelebrationManager passes YULE_MAP_ID explicitly.
+ */
+import { describe, it, expect } from 'vitest';
+import { npcManager } from '../NPCManager';
+import { mapManager, transitionToMap } from '../maps';
+import { yuleCelebrationManager } from '../utils/YuleCelebrationManager';
+import { createNPC } from '../utils/npcs/createNPC';
+import { YULE_NPC_CONFIGS } from '../data/yuleCelebration';
+import type { MapDefinition } from '../types';
+import { TileType } from '../types';
+
+function tinyMap(id: string, npcs: ReturnType<typeof createNPC>[] = []): MapDefinition {
+  return {
+    id,
+    name: id,
+    width: 5,
+    height: 5,
+    grid: Array.from({ length: 5 }, () => Array(5).fill(TileType.GRASS)),
+    spawnPoint: { x: 2, y: 2 },
+    transitions: [],
+    colorScheme: 'village',
+    npcs,
+  } as unknown as MapDefinition;
+}
+
+describe('Yule celebration — leaving the map early (#30)', () => {
+  it('restores static NPC positions and removes festival NPCs when the player leaves before the timer ends', () => {
+    const elder = createNPC({
+      id: 'village_elder',
+      name: 'Village Elder',
+      position: { x: 5, y: 5 },
+      sprite: '',
+      dialogue: [{ id: 'default', text: 'Hi.' }],
+    });
+    const shopkeeper = createNPC({
+      id: 'shopkeeper',
+      name: 'Mr Fox',
+      position: { x: 10, y: 10 },
+      sprite: '',
+      dialogue: [{ id: 'default', text: 'Hi.' }],
+    });
+    mapManager.registerMap(tinyMap('village', [elder, shopkeeper]));
+    mapManager.registerMap(tinyMap('mums_kitchen', []));
+    transitionToMap('village', { x: 2, y: 2 });
+
+    // Simulate the cutscene having completed (bypasses cutsceneManager/season gate)
+    (yuleCelebrationManager as unknown as { state: unknown }).state = {
+      isActive: false,
+      startTime: 0,
+      year: 5,
+      npcWishes: {},
+      giftsReceived: new Set(),
+    };
+    yuleCelebrationManager.onCutsceneComplete();
+
+    expect(npcManager.getNPCById('village_elder')?.position).toEqual(
+      YULE_NPC_CONFIGS.find((c) => c.celebrationId === 'village_elder')!.position
+    );
+    expect(npcManager.getNPCById('festival_mum')).not.toBeNull();
+
+    // Mirror App.tsx's handleMapTransition exactly: transitionToMap() runs first
+    // (which moves npcManager's currentMapId), then the Yule forceEnd() check.
+    const { map } = transitionToMap('mums_kitchen', { x: 2, y: 2 });
+    if (map.id !== 'village' && yuleCelebrationManager.isActive()) {
+      yuleCelebrationManager.forceEnd();
+    }
+    npcManager.setCurrentMap(map.id);
+
+    // Return to village
+    transitionToMap('village', { x: 2, y: 2 });
+
+    expect(npcManager.getNPCById('village_elder')?.position).toEqual({ x: 5, y: 5 });
+    expect(npcManager.getNPCById('shopkeeper')?.position).toEqual({ x: 10, y: 10 });
+    expect(npcManager.getNPCById('festival_mum')).toBeNull();
+    expect(npcManager.getNPCById('festival_old_woman_knitting')).toBeNull();
+    expect(npcManager.getNPCById('festival_child')).toBeNull();
+    expect(npcManager.getNPCById('festival_mushra')).toBeNull();
+    expect(npcManager.getNPCById('festival_bear')).toBeNull();
+    expect(yuleCelebrationManager.isActive()).toBe(false);
+  });
+});

--- a/tests/yulePlayerClearance.test.ts
+++ b/tests/yulePlayerClearance.test.ts
@@ -1,0 +1,58 @@
+/** @vitest-environment node */
+/**
+ * Regression for issue #27: the player could get trapped inside an NPC placed
+ * for the Yule celebration event. findSafePlayerPosition() checks the player's
+ * position against every tile a Yule NPC is about to occupy and, if too close,
+ * finds the nearest clear tile to nudge them to.
+ */
+import { describe, it, expect } from 'vitest';
+import { findSafePlayerPosition } from '../utils/YuleCelebrationManager';
+import { YULE_NPC_CONFIGS } from '../data/yuleCelebration';
+
+describe('findSafePlayerPosition (#27)', () => {
+  const occupied = YULE_NPC_CONFIGS.map((c) => c.position);
+
+  it('returns null when the player is already clear of every NPC position', () => {
+    // Far away from the Yule tree cluster (positions cluster around x:22-27, y:14-17)
+    expect(findSafePlayerPosition({ x: 0, y: 0 }, occupied)).toBeNull();
+  });
+
+  it('nudges the player when standing exactly on an NPC celebration tile', () => {
+    const npcTile = occupied[0];
+    const result = findSafePlayerPosition(npcTile, occupied);
+    expect(result).not.toBeNull();
+
+    // The nudge must actually be clear of every occupied tile
+    for (const pos of occupied) {
+      const dist = Math.hypot(result!.x - pos.x, result!.y - pos.y);
+      expect(dist).toBeGreaterThanOrEqual(1.2);
+    }
+  });
+
+  it('nudges the player when merely too close (not exactly on) an NPC tile', () => {
+    const npcTile = occupied[0];
+    const nearby = { x: npcTile.x + 0.3, y: npcTile.y };
+    const result = findSafePlayerPosition(nearby, occupied);
+    expect(result).not.toBeNull();
+  });
+
+  it('picks the nearest clear tile, not just any clear tile', () => {
+    const npcTile = occupied[0];
+    const result = findSafePlayerPosition(npcTile, occupied);
+    const dist = Math.hypot(result!.x - npcTile.x, result!.y - npcTile.y);
+    // With a single occupied tile, radius-1 ring search should find something close
+    expect(dist).toBeLessThan(3);
+  });
+
+  it('returns a position clear of ALL seven Yule NPC tiles at once', () => {
+    // Player standing in the middle of the whole cluster
+    const centre = { x: 24.5, y: 15.7 };
+    const result = findSafePlayerPosition(centre, occupied);
+    if (result) {
+      for (const pos of occupied) {
+        const dist = Math.hypot(result.x - pos.x, result.y - pos.y);
+        expect(dist).toBeGreaterThanOrEqual(1.2);
+      }
+    }
+  });
+});

--- a/utils/YuleCelebrationManager.ts
+++ b/utils/YuleCelebrationManager.ts
@@ -11,6 +11,7 @@
  * - Ends with a screen blackout and NPC restoration
  */
 
+import type { Position } from '../types';
 import { eventBus, GameEvent } from './EventBus';
 import { TimeManager, Season } from './TimeManager';
 import { inventoryManager } from './inventoryManager';
@@ -50,11 +51,55 @@ interface CelebrationState {
   startTime: number;
   year: number;
   npcWishes: Record<string, string>; // celebrationId -> itemId
-  giftsReceived: Set<string>;        // celebrationIds who have received a gift
+  giftsReceived: Set<string>; // celebrationIds who have received a gift
 }
 
 interface PersistedData {
   celebratedYears: number[];
+}
+
+// ============================================================================
+// Player clearance (issue #27 — player must not end up trapped inside an
+// NPC placed for the celebration)
+// ============================================================================
+
+/** Minimum distance (tiles) the player must be from a Yule NPC's celebration tile. */
+const YULE_PLAYER_CLEARANCE = 1.2;
+
+function distance(a: Position, b: Position): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+/**
+ * If the player's current position is too close to one of the positions Yule
+ * NPCs are about to occupy, find the nearest clear tile to nudge them to.
+ * Returns null if the player's current position is already clear (the common case).
+ *
+ * Searches outward in square rings from the player's own position so the nudge
+ * is always the smallest one that clears every occupied tile.
+ */
+export function findSafePlayerPosition(
+  playerPosition: Position,
+  occupiedPositions: Position[]
+): Position | null {
+  const isTooClose = (pos: Position) =>
+    occupiedPositions.some((occupied) => distance(pos, occupied) < YULE_PLAYER_CLEARANCE);
+
+  if (!isTooClose(playerPosition)) return null;
+
+  const MAX_SEARCH_RADIUS = 6;
+  for (let radius = 1; radius <= MAX_SEARCH_RADIUS; radius++) {
+    for (let dy = -radius; dy <= radius; dy++) {
+      for (let dx = -radius; dx <= radius; dx++) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) !== radius) continue; // ring only, nearest first
+        const candidate = { x: playerPosition.x + dx, y: playerPosition.y + dy };
+        if (!isTooClose(candidate)) return candidate;
+      }
+    }
+  }
+  // Effectively unreachable (would need 7 NPCs to blanket a 13x13 area), but
+  // never leave the player stuck with no fallback.
+  return null;
 }
 
 // ============================================================================
@@ -127,12 +172,27 @@ class YuleCelebrationManagerClass {
   /**
    * Called by App.tsx when the Yule celebration cutscene finishes.
    * Moves NPCs to celebration positions, gives Mum's Yule log, starts timer.
+   *
+   * Pass the player's current position to have the player nudged out of the way
+   * if it's too close to a tile an NPC is about to be placed on (issue #27 — the
+   * player must not end up trapped inside an NPC's collision box). Returns the
+   * safe position to teleport the player to, or null if no nudge is needed.
    */
-  onCutsceneComplete(): void {
-    if (!this.state) return;
+  onCutsceneComplete(playerPosition?: Position): Position | null {
+    if (!this.state) return null;
 
     this.state.isActive = true;
     this.state.startTime = Date.now();
+
+    // Check the player isn't standing where an NPC is about to be placed BEFORE
+    // placing any of them, so the returned position is always safe by the time
+    // the caller acts on it.
+    const safePlayerPosition = playerPosition
+      ? findSafePlayerPosition(
+          playerPosition,
+          YULE_NPC_CONFIGS.map((config) => config.position)
+        )
+      : null;
 
     // Place dynamic festival NPCs on the village map
     this.placeFestivalNPCs();
@@ -176,6 +236,8 @@ class YuleCelebrationManagerClass {
 
     this.startTimer();
     console.log('[YuleCelebration] Celebration started — 10 minutes on the clock!');
+
+    return safePlayerPosition;
   }
 
   private placeFestivalNPCs(): void {
@@ -328,7 +390,7 @@ class YuleCelebrationManagerClass {
       // Remove dynamic festival NPCs
       for (const config of YULE_NPC_CONFIGS) {
         if (config.isDynamic) {
-          npcManager.removeDynamicNPC(config.celebrationId);
+          npcManager.removeDynamicNPC(config.celebrationId, YULE_MAP_ID);
         }
       }
 
@@ -359,8 +421,13 @@ class YuleCelebrationManagerClass {
 
   /**
    * Force-end the celebration immediately (e.g. player leaves the village).
-   * Skips the blackout animation and cleans up NPCs synchronously so that
-   * npcManager.currentMapId is still 'village' at the time of removal.
+   * Skips the blackout animation and cleans up NPCs synchronously.
+   *
+   * removeDynamicNPC() is passed YULE_MAP_ID explicitly rather than relying on
+   * npcManager's "current" map — MapManager.loadMap() sets that as soon as a map
+   * transition starts (before the caller here gets to run), so by the time this is
+   * invoked from App.tsx's handleMapTransition, currentMapId is already the
+   * destination map, not 'village'. See NPCManager.removeDynamicNPC/clearEventOverrides.
    */
   forceEnd(): void {
     if (!this.state) return;
@@ -373,7 +440,7 @@ class YuleCelebrationManagerClass {
     // Remove dynamic festival NPCs immediately (currentMapId is still 'village')
     for (const config of YULE_NPC_CONFIGS) {
       if (config.isDynamic) {
-        npcManager.removeDynamicNPC(config.celebrationId);
+        npcManager.removeDynamicNPC(config.celebrationId, YULE_MAP_ID);
       }
     }
 


### PR DESCRIPTION
Fixes #27, #28, #30.

## #30 — NPCs not reset when leaving the village mid-celebration

Root cause: `MapManager.loadMap()` calls `npcManager.setCurrentMap(mapId)` as soon as a transition starts. `App.tsx`'s `handleMapTransition` calls `transitionToMap()` **before** running the Yule `forceEnd()` check, so by the time `forceEnd()` ran, `npcManager.currentMapId` was already the destination map — not `'village'`. `removeDynamicNPC()`/`clearEventOverrides()` silently no-opped (NPC "not found" on the wrong map), so festival NPCs stuck around and Village Elder/Mr Fox stayed at their Yule-tree positions.

I confirmed this with a standalone repro exercising the real `transitionToMap()` path before writing the fix (see `tests/yuleCelebrationMapLeave.test.ts`).

Fix: `removeDynamicNPC()` now accepts an explicit `mapId`, and `clearEventOverrides()` looks NPCs up across all maps (matching the pattern `setEventScaleOverride`/`restoreEventScale` already used) — both independent of `currentMapId`. `YuleCelebrationManager` passes `YULE_MAP_ID` explicitly.

## #27 — Player could get trapped inside an event NPC

`YuleCelebrationManager.onCutsceneComplete()` now takes the player's position and checks it against every tile a Yule NPC is about to occupy (`findSafePlayerPosition`, same file). If too close, it returns the nearest clear tile and `App.tsx` teleports the player there **before** any NPC is placed.

## #28 — Yule gift reciprocation dialogue had no continue button

`ScriptedControls.tsx` only rendered the "Click to continue" fallback when `filtered.length === 0 && !canUseAI`. Yule NPCs have `aiEnabled: true`, so `canUseAI` was true and the fallback never rendered for response-less nodes like `yule_gift_reciprocation` — leaving only the "AI chat" button, no way to just dismiss. The continue button now also renders inside the AI-chat-available branch whenever there are no scripted responses.

## Tests

`tests/yuleCelebrationMapLeave.test.ts` and `tests/yulePlayerClearance.test.ts` reproduce #30 and #27 respectively against the real code paths. `make verify` green: typecheck clean, 501 tests across 40 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k