### PR TITLE
Wrap up Elias' gardening quest after year 1, fix "traveller" address

### DIFF
--- a/data/cutscenes/elderMemory.ts
+++ b/data/cutscenes/elderMemory.ts
@@ -92,7 +92,7 @@ export const elderMemoryCutscene: CutsceneDefinition = {
       ],
       dialogue: {
         speaker: 'Village Elder',
-        text: 'I was but a young lad then, lying beneath the cherry tree, dreaming of adventures beyond the village. Time moves swiftly, traveller.',
+        text: 'I was but a young lad then, lying beneath the cherry tree, dreaming of adventures beyond the village. Time moves swiftly, young one.',
       },
       transitionOut: {
         type: 'fade',

--- a/tests/gardeningQuestWrapUp.test.ts
+++ b/tests/gardeningQuestWrapUp.test.ts
@@ -1,0 +1,59 @@
+/** @vitest-environment node */
+/**
+ * Regression for issue #23: Elias' gardening quest never ends — after the final
+ * (autumn) delivery, the quest was correctly marked complete internally, but the
+ * dialogue always routed to garden_wait_next_season ("come spring I shall have
+ * something new for thee"), leaving the unreachable garden_quest_complete wrap-up
+ * node dead code and implying the tutorial continues indefinitely.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { handleDialogueAction } from '../utils/dialogueHandlers';
+import { inventoryManager } from '../utils/inventoryManager';
+import { eventChainManager } from '../utils/EventChainManager';
+import {
+  GARDENING_QUEST_ID,
+  hasCompletedSeason,
+} from '../data/questHandlers/gardeningQuestHandler';
+
+describe('Elias gardening quest — final delivery wraps up (#23)', () => {
+  beforeEach(async () => {
+    eventChainManager.initialise();
+    eventChainManager.resetChain(GARDENING_QUEST_ID);
+    while (inventoryManager.hasItem('honey', 1)) {
+      inventoryManager.removeItem('honey', 1);
+    }
+    while (inventoryManager.hasItem('crop_tomato', 1)) {
+      inventoryManager.removeItem('crop_tomato', 1);
+    }
+    await eventChainManager.startChain(GARDENING_QUEST_ID, {
+      springCompleted: false,
+      summerCompleted: false,
+      autumnCompleted: false,
+      currentSeasonTask: 'autumn',
+      seedsReceived: ['spring', 'summer', 'autumn'],
+    });
+    await eventChainManager.advanceToStage(GARDENING_QUEST_ID, 'active');
+  });
+
+  it('routes to garden_task_complete (not the wrap-up) when spring/summer are still outstanding', () => {
+    inventoryManager.addItem('honey', 1);
+    eventChainManager.setMetadata(GARDENING_QUEST_ID, 'springCompleted', false);
+    eventChainManager.setMetadata(GARDENING_QUEST_ID, 'summerCompleted', false);
+
+    const result = handleDialogueAction('village_elder', 'garden_deliver_crop');
+
+    expect(result).toBe('garden_task_complete');
+    expect(hasCompletedSeason('autumn')).toBe(true);
+  });
+
+  it('routes to garden_quest_complete when the autumn delivery is the final season', () => {
+    inventoryManager.addItem('honey', 1);
+    eventChainManager.setMetadata(GARDENING_QUEST_ID, 'springCompleted', true);
+    eventChainManager.setMetadata(GARDENING_QUEST_ID, 'summerCompleted', true);
+
+    const result = handleDialogueAction('village_elder', 'garden_deliver_crop');
+
+    expect(result).toBe('garden_quest_complete');
+    expect(hasCompletedSeason('autumn')).toBe(true);
+  });
+});

--- a/utils/dialogueHandlers.ts
+++ b/utils/dialogueHandlers.ts
@@ -15,6 +15,7 @@ import {
   isGardeningQuestActive,
   getCurrentSeasonTask,
   markSeasonCompleted,
+  hasCompletedSeason,
 } from '../data/questHandlers/gardeningQuestHandler';
 import { startFairyBluebellsQuest } from '../data/questHandlers/fairyBluebellsHandler';
 import {
@@ -649,6 +650,11 @@ function handleEliasQuestActions(nodeId: string): string | void {
           inventoryManager.removeItem('honey', 1);
           const invData = inventoryManager.getInventoryData();
           characterData.saveInventory(invData.items, invData.tools);
+          // Autumn is always the final seasonal task — check spring/summer BEFORE
+          // marking autumn complete (markSeasonCompleted already triggers the
+          // quest-completion check/chain-advance internally; checking here avoids
+          // calling that a second time and racing its async stage transition).
+          const isFinalSeason = hasCompletedSeason('spring') && hasCompletedSeason('summer');
           markSeasonCompleted('autumn');
           friendshipManager.addPoints(
             'village_elder',
@@ -657,7 +663,10 @@ function handleEliasQuestActions(nodeId: string): string | void {
           );
           if (DEBUG.QUEST)
             console.log('[dialogueHandlers] 🍯 Elias accepts your honey for autumn task!');
-          return 'garden_task_complete';
+          // Route to the one-time wrap-up node instead of the "come back next
+          // season" loop, which would otherwise imply the tutorial continues
+          // indefinitely (see garden_quest_complete).
+          return isFinalSeason ? 'garden_quest_complete' : 'garden_task_complete';
         }
       }
 


### PR DESCRIPTION
Fixes #23, #29.

## #23 — Gardening quest never ends

`handleDialogueAction()`'s `garden_deliver_crop` handler always returned `'garden_task_complete'` after an autumn (final season) delivery, routing to `garden_wait_next_season` ("come spring I shall have something new for thee") regardless of whether all three seasons were done — leaving the existing `garden_quest_complete` wrap-up node unreachable. Now checks whether spring and summer were already completed *before* marking autumn complete, and routes to `garden_quest_complete` on the final delivery.

## #29 — Village Elder still calls the PC "traveller"

The Elder's summer-memory cutscene (`data/cutscenes/elderMemory.ts`, can trigger repeatedly via his dialogue tree regardless of relationship with the player) addressed the player as "traveller" — inconsistent with his established voice elsewhere (e.g. "young one" throughout the gardening quest dialogue in `utils/npcs/village/villageElder.ts`). Changed to "young one" to match.

## Tests

`tests/gardeningQuestWrapUp.test.ts` covers both the outstanding-season and final-season delivery paths. `make verify` green: typecheck clean, 503 tests across 41 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k