### PR TITLE
Skip logging identical repeated conversations to the Diary

### DIFF
--- a/services/diaryService.ts
+++ b/services/diaryService.ts
@@ -323,6 +323,12 @@ export async function recordConversation(
 /**
  * Record a scripted (non-AI) dialogue exchange.
  * Always stores as raw transcript since there's no AI to summarise.
+ *
+ * Skips logging entirely when this exchange is word-for-word identical to the
+ * most recent prior day's entry for this NPC — many NPCs fall back to the same
+ * repeated line once they have no new dialogue for the day, and logging that
+ * verbatim repeat every single day would clutter the diary with duplicates
+ * (issue #18). A genuinely new exchange (even to the same NPC) still logs.
  */
 export async function recordScriptedConversation(
   npcId: string,
@@ -340,6 +346,15 @@ export async function recordScriptedConversation(
   const existingIndex = entries.findIndex(
     (e) => e.npcId === npcId && e.totalDays === gameTime.totalDays
   );
+
+  if (existingIndex < 0) {
+    const mostRecentPrior = entries
+      .filter((e) => e.npcId === npcId && e.totalDays < gameTime.totalDays)
+      .sort((a, b) => b.totalDays - a.totalDays)[0];
+    if (mostRecentPrior && mostRecentPrior.rawExchanges.endsWith(newExchange)) {
+      return;
+    }
+  }
 
   let entry: DiaryEntry;
 

--- a/tests/diaryRepeatedConversation.test.ts
+++ b/tests/diaryRepeatedConversation.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Regression for issue #18: repeated NPC conversations get logged in the Diary
+ * every time (every day), not just the first — when an NPC has no new dialogue
+ * and falls back to the same repeated line, that exact exchange shouldn't
+ * clutter the diary with a fresh identical entry each day.
+ *
+ * tests/setup.ts stubs `localStorage` globally as a no-op (getItem always
+ * null, setItem a no-op) for the whole suite, so this file installs its own
+ * in-memory Storage implementation to actually exercise persistence.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { recordScriptedConversation, getDiaryEntriesForNPC } from '../services/diaryService';
+import { TimeManager, Season, TimeOfDay, SEASONAL_DAYLIGHT } from '../utils/TimeManager';
+
+function createInMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => store.clear(),
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  } as Storage;
+}
+
+function mockGameTime(totalDays: number) {
+  return {
+    year: 1,
+    season: Season.SPRING,
+    day: totalDays,
+    totalDays,
+    hour: 12,
+    minute: 0,
+    timeOfDay: TimeOfDay.DAY,
+    totalHours: totalDays * 24 + 12,
+    daylight: SEASONAL_DAYLIGHT[Season.SPRING],
+  };
+}
+
+describe('recordScriptedConversation — repeated exchanges (#18)', () => {
+  const originalLocalStorage = global.localStorage;
+
+  beforeEach(() => {
+    global.localStorage = createInMemoryStorage();
+  });
+
+  afterEach(() => {
+    global.localStorage = originalLocalStorage;
+    vi.restoreAllMocks();
+  });
+
+  it('logs the first occurrence of a repeated line normally', async () => {
+    vi.spyOn(TimeManager, 'getCurrentTime').mockReturnValue(mockGameTime(1));
+    await recordScriptedConversation(
+      'village_elder',
+      'Village Elder',
+      'Player',
+      'Hello!',
+      'Good day to thee.'
+    );
+
+    const entries = getDiaryEntriesForNPC('village_elder');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].totalDays).toBe(1);
+  });
+
+  it('skips logging when the exact same exchange repeats on a later day', async () => {
+    vi.spyOn(TimeManager, 'getCurrentTime').mockReturnValue(mockGameTime(1));
+    await recordScriptedConversation(
+      'village_elder',
+      'Village Elder',
+      'Player',
+      'Hello!',
+      'Good day to thee.'
+    );
+
+    vi.spyOn(TimeManager, 'getCurrentTime').mockReturnValue(mockGameTime(2));
+    await recordScriptedConversation(
+      'village_elder',
+      'Village Elder',
+      'Player',
+      'Hello!',
+      'Good day to thee.'
+    );
+
+    const entries = getDiaryEntriesForNPC('village_elder');
+    expect(entries).toHaveLength(1); // No new entry for day 2
+    expect(entries[0].totalDays).toBe(1);
+  });
+
+  it('still logs a genuinely different exchange on a later day', async () => {
+    vi.spyOn(TimeManager, 'getCurrentTime').mockReturnValue(mockGameTime(1));
+    await recordScriptedConversation(
+      'village_elder',
+      'Village Elder',
+      'Player',
+      'Hello!',
+      'Good day to thee.'
+    );
+
+    vi.spyOn(TimeManager, 'getCurrentTime').mockReturnValue(mockGameTime(2));
+    await recordScriptedConversation(
+      'village_elder',
+      'Village Elder',
+      'Player',
+      'How is the garden?',
+      "It's blooming nicely, thank you for asking!"
+    );
+
+    const entries = getDiaryEntriesForNPC('village_elder');
+    expect(entries).toHaveLength(2);
+  });
+
+  it('still logs multiple exchanges within the same day (not skipped by the repeat check)', async () => {
+    vi.spyOn(TimeManager, 'getCurrentTime').mockReturnValue(mockGameTime(1));
+    await recordScriptedConversation(
+      'village_elder',
+      'Village Elder',
+      'Player',
+      'Hello!',
+      'Good day to thee.'
+    );
+    await recordScriptedConversation(
+      'village_elder',
+      'Village Elder',
+      'Player',
+      'Hello!',
+      'Good day to thee.'
+    );
+
+    const entries = getDiaryEntriesForNPC('village_elder');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].exchanges).toBe(2);
+  });
+
+  it('resumes logging once the repeated streak breaks and then repeats again', async () => {
+    vi.spyOn(TimeManager, 'getCurrentTime').mockReturnValue(mockGameTime(1));
+    await recordScriptedConversation('x', 'X', 'Player', 'Hi', 'Same old line.');
+
+    vi.spyOn(TimeManager, 'getCurrentTime').mockReturnValue(mockGameTime(2));
+    await recordScriptedConversation('x', 'X', 'Player', 'Hi', 'Same old line.'); // skipped
+
+    vi.spyOn(TimeManager, 'getCurrentTime').mockReturnValue(mockGameTime(3));
+    await recordScriptedConversation('x', 'X', 'Player', 'Hi', 'Same old line.'); // still skipped (compares to most recent prior, day 1)
+
+    const entries = getDiaryEntriesForNPC('x');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].totalDays).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes #18.

`recordScriptedConversation()` already grouped exchanges by NPC+day (one entry per day), but a **new** entry was still created every day an NPC's dialogue falls back to the same repeated line with no new content — cluttering the diary with identical duplicates day after day.

Before creating a new day's entry, it now checks whether it's word-for-word identical to the most recent **prior** day's entry for that NPC and skips logging if so. A genuinely different exchange (even to the same NPC, even the next day) still logs normally, and multiple exchanges within the same day still merge into that day's entry as before.

Note: `tests/setup.ts` stubs `localStorage` globally as a no-op for the whole test suite, so `tests/diaryRepeatedConversation.test.ts` installs its own in-memory `Storage` implementation to actually exercise persistence — took a bit of debugging to track down why the fix wasn't showing up in a first pass at the test.

`make verify` green: typecheck clean, 506 tests across 41 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k