### PR TITLE
Show fruit tree care actions in the radial menu even as the sole option

### DIFF
--- a/tests/pruneRadialMenu.test.ts
+++ b/tests/pruneRadialMenu.test.ts
@@ -1,0 +1,122 @@
+/** @vitest-environment node */
+/**
+ * Regression for issue #24: in winter, pruning a fruit tree works via the E key
+ * but doesn't show up as an option in the click-based radial menu.
+ *
+ * getAvailableInteractions() (the same entry point the click handler in
+ * useInteractionController.ts calls) already returns 'prune_tree' correctly near
+ * a winter apple tree — confirmed directly here. The actual bug is one level up:
+ * fruitTreeProvider's care actions (prune/mulch/harvest) are usually the ONLY
+ * interaction available near a tree, and useInteractionController.ts silently
+ * auto-executes a click when there's exactly one interaction, showing no radial
+ * menu at all — which looks, to the player, exactly like the option is "missing".
+ * Fixed by setting requireConfirmation: true (the same flag snowAngelProvider
+ * already uses for this), which forces the menu to render even as the sole option.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getAvailableInteractions } from '../utils/interactions/index';
+import { mapManager, transitionToMap } from '../maps';
+import { TimeManager, Season } from '../utils/TimeManager';
+import { fruitTreeManager } from '../utils/fruitTreeManager';
+import type { MapDefinition } from '../types';
+import { TileType } from '../types';
+
+function orchardMap(id: string): MapDefinition {
+  const width = 5;
+  const height = 5;
+  const grid = Array.from({ length: height }, () => Array(width).fill(TileType.GRASS));
+  // Apple tree anchor at (2, 2), player will stand adjacent at (2, 3)
+  grid[2][2] = TileType.APPLE_TREE;
+  return {
+    id,
+    name: id,
+    width,
+    height,
+    grid,
+    spawnPoint: { x: 2, y: 3 },
+    transitions: [],
+    colorScheme: 'village',
+    npcs: [],
+  } as unknown as MapDefinition;
+}
+
+describe('Fruit tree care actions require radial-menu confirmation (#24)', () => {
+  const mapId = 'orchard_test';
+  const treePos = { x: 2, y: 2 };
+  const playerPos = { x: 2, y: 3 };
+
+  beforeEach(() => {
+    mapManager.registerMap(orchardMap(mapId));
+    transitionToMap(mapId, playerPos);
+    vi.spyOn(TimeManager, 'getCurrentTime').mockReturnValue({
+      year: 1,
+      season: Season.WINTER,
+      day: 50,
+      totalDays: 50,
+      hour: 12,
+      minute: 0,
+      timeOfDay: 'day' as never,
+      totalHours: 1212,
+      daylight: { dawn: 7, sunrise: 8, sunset: 16, dusk: 17 },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('includes prune_tree when clicking directly on the tree tile', () => {
+    const interactions = getAvailableInteractions({
+      position: treePos, // clicking the tree itself
+      playerPosition: playerPos,
+      currentMapId: mapId,
+      currentTool: 'hand',
+      selectedSeed: null,
+    });
+
+    expect(interactions.map((i) => i.type)).toContain('prune_tree');
+  });
+
+  it('sets requireConfirmation so the radial menu shows even as the sole interaction', () => {
+    const interactions = getAvailableInteractions({
+      position: treePos,
+      playerPosition: playerPos,
+      currentMapId: mapId,
+      currentTool: 'hand',
+      selectedSeed: null,
+    });
+
+    expect(interactions).toHaveLength(1);
+    expect(interactions[0].type).toBe('prune_tree');
+    expect(interactions[0].requireConfirmation).toBe(true);
+  });
+
+  it('includes prune_tree when clicking elsewhere near the player (canopy click emulation)', () => {
+    // Simulates clicking on the tree's canopy, which visually extends above the
+    // anchor tile — a position the anchor-only tile search wouldn't match, but
+    // fruitTreeProvider intentionally searches from playerPosition instead.
+    const interactions = getAvailableInteractions({
+      position: { x: treePos.x, y: treePos.y - 2 },
+      playerPosition: playerPos,
+      currentMapId: mapId,
+      currentTool: 'hand',
+      selectedSeed: null,
+    });
+
+    expect(interactions.map((i) => i.type)).toContain('prune_tree');
+  });
+
+  it('does not include prune_tree once the tree has already been pruned this winter', () => {
+    fruitTreeManager.pruneTree(mapId, treePos.x, treePos.y);
+
+    const interactions = getAvailableInteractions({
+      position: treePos,
+      playerPosition: playerPos,
+      currentMapId: mapId,
+      currentTool: 'hand',
+      selectedSeed: null,
+    });
+
+    expect(interactions.map((i) => i.type)).not.toContain('prune_tree');
+  });
+});

--- a/utils/interactions/providers/fruitTrees.ts
+++ b/utils/interactions/providers/fruitTrees.ts
@@ -35,6 +35,11 @@ export function fruitTreeProvider(ctx: InteractionContext): AvailableInteraction
         label: 'Prune Tree',
         icon: '✂️',
         color: '#6B7280',
+        // Fruit tree care is usually the ONLY interaction available near the
+        // tree, which would otherwise auto-execute the click with no radial
+        // menu shown at all — looking, to the player, exactly like the option
+        // is "missing" (issue #24). Force the menu so it's always visible.
+        requireConfirmation: true,
         execute: () => {
           fruitTreeManager.pruneTree(currentMapId, tx, ty);
           onFarmAction?.({ handled: true, message: 'You pruned the apple tree.' });
@@ -48,6 +53,7 @@ export function fruitTreeProvider(ctx: InteractionContext): AvailableInteraction
         label: 'Mulch Tree',
         icon: '🌱',
         color: '#78350F',
+        requireConfirmation: true,
         execute: () => {
           fruitTreeManager.mulchTree(currentMapId, tx, ty);
           onFarmAction?.({ handled: true, message: 'You mulched around the apple tree.' });
@@ -61,6 +67,7 @@ export function fruitTreeProvider(ctx: InteractionContext): AvailableInteraction
         label: 'Harvest Apples',
         icon: '🍎',
         color: '#DC2626',
+        requireConfirmation: true,
         execute: () => {
           const wasAbundant = fruitTreeManager.isAbundant(currentMapId, tx, ty);
           const result = fruitTreeManager.harvestTree(currentMapId, tx, ty);


### PR DESCRIPTION
Fixes #24.

## Investigation

I reproduced `getAvailableInteractions()` directly against a real map with a winter apple tree (`tests/pruneRadialMenu.test.ts`) — it already returned `'prune_tree'` correctly, both for a click directly on the tree and a click on the canopy (the search uses the player's position, not the click position, since the multi-tile sprite's anchor sits at the trunk base — see the comment in `fruitTrees.ts`). So `fruitTreeProvider` itself was fine.

## Root cause

Fruit tree care actions (prune/mulch/harvest) are usually the **only** interaction available near a tree. `useInteractionController.ts` silently auto-executes a click when there's exactly one interaction, showing no radial menu at all — which looks, to the player, exactly like the option is "missing". This matches the issue's own hint: *"I've had issues with the radial menu before when there's only one option available — worth checking if that's connected."*

## Fix

Set `requireConfirmation: true` on all three fruit tree care interactions — the same flag `snowAngelProvider` already uses to force the radial menu to render even as the sole option. Applied to mulch/harvest too, not just prune, since they're structurally identical and would hit the same bug in their respective seasons.

## Tests

`tests/pruneRadialMenu.test.ts` exercises the real interaction pipeline (real map, real `fruitTreeManager` state) and asserts `requireConfirmation` is set. `make verify` green: typecheck clean, 507 tests across 42 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k