### PR TITLE
Gate leaf pile interactions to autumn

### DIFF
--- a/tests/leafPileSeason.test.ts
+++ b/tests/leafPileSeason.test.ts
@@ -1,0 +1,94 @@
+/** @vitest-environment node */
+/**
+ * Regression for issue #22: piles of leaves don't despawn outside of autumn.
+ *
+ * The leaf pile SPRITE is already correctly gated to autumn-only in
+ * data/tiles.ts (seasonalImages: empty array for every other season), but the
+ * underlying map tile is a static TileType.PILE_OF_LEAVES that persists
+ * year-round, and leafPileProvider had no season check of its own — so a
+ * player could still Tidy Up / Pick Up an invisible leaf pile outside autumn.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getAvailableInteractions } from '../utils/interactions/index';
+import { mapManager, transitionToMap } from '../maps';
+import { TimeManager, Season } from '../utils/TimeManager';
+import type { MapDefinition } from '../types';
+import { TileType } from '../types';
+
+function leafPileMap(id: string): MapDefinition {
+  const width = 5;
+  const height = 5;
+  const grid = Array.from({ length: height }, () => Array(width).fill(TileType.GRASS));
+  grid[2][2] = TileType.PILE_OF_LEAVES;
+  return {
+    id,
+    name: id,
+    width,
+    height,
+    grid,
+    spawnPoint: { x: 2, y: 2 },
+    transitions: [],
+    colorScheme: 'village',
+    npcs: [],
+  } as unknown as MapDefinition;
+}
+
+function mockSeason(season: Season) {
+  vi.spyOn(TimeManager, 'getCurrentTime').mockReturnValue({
+    year: 1,
+    season,
+    day: 10,
+    totalDays: 10,
+    hour: 12,
+    minute: 0,
+    timeOfDay: 'day' as never,
+    totalHours: 250,
+    daylight: { dawn: 7, sunrise: 8, sunset: 16, dusk: 17 },
+  });
+}
+
+describe('Leaf pile interactions are season-gated to autumn (#22)', () => {
+  const mapId = 'leaf_pile_test';
+  const pilePos = { x: 2, y: 2 };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('offers Tidy Up / Pick Up in autumn', () => {
+    mapManager.registerMap(leafPileMap(mapId));
+    transitionToMap(mapId, pilePos);
+    mockSeason(Season.AUTUMN);
+
+    const interactions = getAvailableInteractions({
+      position: pilePos,
+      currentMapId: mapId,
+      currentTool: 'hand',
+      selectedSeed: null,
+    });
+
+    expect(interactions.map((i) => i.type)).toEqual(
+      expect.arrayContaining(['tidy_leaves', 'pickup_leaves'])
+    );
+  });
+
+  it.each([Season.SPRING, Season.SUMMER, Season.WINTER])(
+    'offers nothing at the same tile in %s (leaf pile sprite is invisible)',
+    (season) => {
+      mapManager.registerMap(leafPileMap(mapId));
+      transitionToMap(mapId, pilePos);
+      mockSeason(season);
+
+      const interactions = getAvailableInteractions({
+        position: pilePos,
+        currentMapId: mapId,
+        currentTool: 'hand',
+        selectedSeed: null,
+      });
+
+      expect(interactions.map((i) => i.type)).not.toEqual(
+        expect.arrayContaining(['tidy_leaves', 'pickup_leaves'])
+      );
+    }
+  );
+});

--- a/utils/interactions/providers/leaves.ts
+++ b/utils/interactions/providers/leaves.ts
@@ -12,6 +12,7 @@ import { findTileTypeNearby } from '../../mapUtils';
 import { gameState } from '../../../GameState';
 import { inventoryManager } from '../../inventoryManager';
 import { magicalAssets } from '../../../assets';
+import { Season, TimeManager } from '../../TimeManager';
 
 /**
  * Handle interacting with a pile of leaves — either tidying (no reward) or picking up (gives maple_leaf).
@@ -34,6 +35,17 @@ function handleLeavesAction(
 export function leafPileProvider(ctx: InteractionContext): AvailableInteraction[] {
   const { currentMapId, tileX, tileY } = ctx;
   const interactions: AvailableInteraction[] = [];
+
+  // Leaf piles are placed as static map tiles that persist year-round, but their
+  // sprite is only drawn in autumn (data/tiles.ts seasonalImages — every other
+  // season is an explicit empty array, so SpriteLayer renders nothing and the
+  // grass baseType shows through). That made them invisible-but-still-clickable
+  // outside autumn — clicking the empty grass where a pile used to be still
+  // offered Tidy Up / Pick Up (issue #22). Gate the interaction to autumn too,
+  // matching the sprite's own seasonal dormancy.
+  if (!TimeManager.isCurrentSeason(Season.AUTUMN)) {
+    return interactions;
+  }
 
   // Check for leaf pile interactions (tidy up or pick up — autumn decorative tile)
   const nearLeaves = findTileTypeNearby(tileX, tileY, [TileType.PILE_OF_LEAVES]);


### PR DESCRIPTION
Fixes #22.

The leaf pile sprite is already correctly gated to autumn-only in `data/tiles.ts` (`seasonalImages: []` for spring/summer/winter — `SpriteLayer` renders nothing and the grass baseType shows through). But the underlying map tile is a static `TileType.PILE_OF_LEAVES` baked into the grid, which persists year-round, and `leafPileProvider` had no season check of its own — so a player could still Tidy Up / Pick Up an invisible leaf pile outside autumn.

Added the same `TimeManager.isCurrentSeason(Season.AUTUMN)` gate the sprite already implicitly has, matching the pattern `snowAngelProvider` uses for its own seasonal restriction.

## Tests

`tests/leafPileSeason.test.ts` covers all four seasons against a real map. `make verify` green: typecheck clean, 512 tests across 43 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k