### PR TITLE
Fix skipped seedling sprite and premature interaction prompts on load

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -179,7 +179,13 @@ const App: React.FC = () => {
   const [isCutscenePlaying, setIsCutscenePlaying] = useState(false); // Track cutscene state
 
   // Loading-screen cutscene state
-  const [isLoadingCutscene, setIsLoadingCutscene] = useState(false); // Overall loading-cutscene mode
+  // Defaults to true (not false!) so the black loading overlay covers the very
+  // first paint, before the mount effect below has decided whether a season
+  // cutscene is actually due — otherwise interaction prompts near the player's
+  // spawn point can render and be clickable for a frame before that effect
+  // resolves (issue #17). The effect flips this back to false immediately when
+  // no cutscene is due this session.
+  const [isLoadingCutscene, setIsLoadingCutscene] = useState(true); // Overall loading-cutscene mode
   const loadingCutsceneDoneRef = useRef(false); // Cutscene animation has ended
   const [loadingProgress, setLoadingProgress] = useState(0); // 0-1 combined loading progress
 
@@ -998,9 +1004,19 @@ const App: React.FC = () => {
 
     if (started) {
       console.log(`[App] Loading cutscene started: ${seasonCutsceneId}`);
+      // Already true by default (see the useState below) — this is the case that
+      // default exists for, but keep it explicit here for clarity.
       setIsLoadingCutscene(true);
       setIsCutscenePlaying(true);
       loadingCutsceneDoneRef.current = false;
+    } else {
+      // No loading cutscene due this session — skip straight to the game, same
+      // as before. isLoadingCutscene defaults to true (not false) so that on
+      // the very first paint, before this effect has even run, the black
+      // loading overlay is what's on screen — not the game world underneath it.
+      // Without that, NPC/transition interaction prompts could render and be
+      // clickable for a frame or two before this effect resolves (issue #17).
+      setIsLoadingCutscene(false);
     }
 
     // Phase 2: Slow async asset loading (runs in parallel with cutscene)

--- a/hooks/useEnvironmentController.ts
+++ b/hooks/useEnvironmentController.ts
@@ -25,6 +25,7 @@ import { mapManager } from '../maps/MapManager';
 import { npcManager } from '../NPCManager';
 import { yuleCelebrationManager } from '../utils/YuleCelebrationManager';
 import { eventChainManager } from '../utils/EventChainManager';
+import { farmManager } from '../utils/farmManager';
 import { TileType } from '../types';
 import type { WeatherManager } from '../utils/WeatherManager';
 import type { WeatherLayer } from '../utils/pixi/WeatherLayer';
@@ -662,6 +663,11 @@ export function useEnvironmentController(
       // Auto-advance event chain stages that have waited long enough
       // (waitDays stages with no player choices — see EventChainManager.checkAutoAdvance)
       eventChainManager.checkAutoAdvance();
+
+      // Catch crop growth-stage sub-boundary crossings (seedling→young→adult)
+      // that no discrete plot-state-change event covers — see
+      // FarmManager.checkGrowthStageTransitions (issue #16).
+      farmManager.checkGrowthStageTransitions();
     }, 10000); // Check every 10 seconds
 
     return () => clearInterval(interval);

--- a/tests/cropGrowthStageTransitions.test.ts
+++ b/tests/cropGrowthStageTransitions.test.ts
@@ -1,0 +1,112 @@
+/** @vitest-environment node */
+/**
+ * Regression for issue #16: the seedling sprite could be skipped entirely.
+ *
+ * getGrowthStage() computes growth stage live from elapsed time, but crossing
+ * a sub-stage boundary (seedling→young, or young→adult) is not a plot state
+ * transition (PLANTED/WATERED/READY) — the only thing that emits
+ * FARM_PLOT_CHANGED and triggers a tile re-render. For a fast-growing crop the
+ * seedling window can be under a minute; if nothing else happens to trigger a
+ * re-render during that window, the plot visually jumps straight from bare
+ * soil to young/adult, skipping the seedling sprite.
+ *
+ * farmManager.checkGrowthStageTransitions() is called periodically (see
+ * useEnvironmentController.ts) and emits FARM_CROP_GREW whenever a plot's
+ * live-computed stage has changed since the last check.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { farmManager } from '../utils/farmManager';
+import { eventBus, GameEvent } from '../utils/EventBus';
+import { FarmPlotState, CropGrowthStage } from '../types';
+import { getCrop } from '../data/crops';
+
+function plantedPlot(mapId: string, x: number, y: number, plantedAtTimestamp: number) {
+  const now = Date.now();
+  return {
+    mapId,
+    position: { x, y },
+    state: FarmPlotState.WATERED,
+    cropType: 'radish',
+    plantedAtDay: 1,
+    plantedAtHour: 0,
+    lastWateredDay: 1,
+    lastWateredHour: 0,
+    stateChangedAtDay: 1,
+    stateChangedAtHour: 0,
+    plantedAtTimestamp,
+    lastWateredTimestamp: now, // watered "just now" so isWatered stays true
+    stateChangedAtTimestamp: now,
+    quality: 'normal' as const,
+    fertiliserApplied: false,
+  };
+}
+
+describe('farmManager.checkGrowthStageTransitions (#16)', () => {
+  const mapId = 'growth_stage_test';
+  const radish = getCrop('radish')!;
+
+  beforeEach(() => {
+    // Fresh plot map for each test — farmManager is a singleton with no reset API,
+    // so use a unique position per test to avoid cross-test interference.
+  });
+
+  it('does not emit on the first observation of a plot (establishes baseline)', () => {
+    const plot = plantedPlot(mapId, 1, 1, Date.now());
+    farmManager.registerPlot(plot);
+
+    const events: unknown[] = [];
+    const unsub = eventBus.on(GameEvent.FARM_CROP_GREW, (p) => events.push(p));
+    farmManager.checkGrowthStageTransitions();
+    unsub();
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('emits FARM_CROP_GREW when a plot crosses seedling→young between checks', () => {
+    // Plant "now" — first check establishes baseline (SEEDLING).
+    const plantedAt = Date.now();
+    const plot = plantedPlot(mapId, 2, 2, plantedAt);
+    farmManager.registerPlot(plot);
+    farmManager.checkGrowthStageTransitions();
+
+    // Simulate time passing past the seedling→young threshold by rewriting
+    // plantedAtTimestamp further into the past (radish growthTimeWatered is short).
+    const seedlingToYoungMs = radish.growthTimeWatered * 0.4; // just past the 0.33 threshold
+    farmManager.registerPlot({ ...plot, plantedAtTimestamp: Date.now() - seedlingToYoungMs });
+
+    const events: Array<{ position: { x: number; y: number }; stage: number }> = [];
+    const unsub = eventBus.on(GameEvent.FARM_CROP_GREW, (p) => events.push(p));
+    farmManager.checkGrowthStageTransitions();
+    unsub();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].stage).toBe(CropGrowthStage.YOUNG);
+    expect(events[0].position).toEqual({ x: 2, y: 2 });
+  });
+
+  it('emits nothing on a check where the stage has not changed', () => {
+    const plot = plantedPlot(mapId, 3, 3, Date.now());
+    farmManager.registerPlot(plot);
+    farmManager.checkGrowthStageTransitions(); // baseline
+
+    const events: unknown[] = [];
+    const unsub = eventBus.on(GameEvent.FARM_CROP_GREW, (p) => events.push(p));
+    farmManager.checkGrowthStageTransitions(); // no time passed, still SEEDLING
+    unsub();
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('ignores plots that are not actively growing (e.g. READY)', () => {
+    const plot = { ...plantedPlot(mapId, 4, 4, Date.now()), state: FarmPlotState.READY };
+    farmManager.registerPlot(plot);
+
+    const events: unknown[] = [];
+    const unsub = eventBus.on(GameEvent.FARM_CROP_GREW, (p) => events.push(p));
+    farmManager.checkGrowthStageTransitions();
+    farmManager.checkGrowthStageTransitions();
+    unsub();
+
+    expect(events).toHaveLength(0);
+  });
+});

--- a/utils/farmManager.ts
+++ b/utils/farmManager.ts
@@ -31,6 +31,10 @@ class FarmManager {
   private dirtySharedPlots: Set<string> = new Set(); // plot keys that need Firestore write
   private recentlyFlushed: Map<string, number> = new Map(); // plot key → flush timestamp
   private flushInterval: ReturnType<typeof setInterval> | null = null;
+
+  // Last-observed growth stage per growing plot, used by checkGrowthStageTransitions()
+  // to detect sub-stage crossings (see that method for why this exists).
+  private lastKnownGrowthStages: Map<string, CropGrowthStage> = new Map();
   private sharedListenerUnsub: (() => void) | null = null;
 
   /**
@@ -935,6 +939,37 @@ class FarmManager {
       return CropGrowthStage.YOUNG;
     } else {
       return CropGrowthStage.ADULT;
+    }
+  }
+
+  /**
+   * Detect growth-stage sub-boundary crossings (seedling→young→adult) for every
+   * growing plot and emit FARM_CROP_GREW for each one that changed since the
+   * last check.
+   *
+   * getGrowthStage() computes stage live from elapsed time, but crossing a
+   * sub-stage boundary is NOT a plot state transition (PLANTED/WATERED/READY —
+   * the only things that emit FARM_PLOT_CHANGED and trigger a tile re-render).
+   * For a fast-growing crop the seedling window can be as short as ~30 real
+   * seconds; if nothing else happens to trigger a re-render during that window,
+   * the seedling sprite is skipped entirely and the plot appears to jump
+   * straight from bare soil to young/adult (issue #16). Call this periodically
+   * (see useEnvironmentController.ts) to guarantee one eventually fires.
+   */
+  checkGrowthStageTransitions(): void {
+    const growingStates = new Set([FarmPlotState.PLANTED, FarmPlotState.WATERED]);
+
+    for (const plot of this.plots.values()) {
+      if (!growingStates.has(plot.state) || !plot.cropType) continue;
+
+      const key = this.getPlotKey(plot.mapId, plot.position);
+      const stage = this.getGrowthStage(plot);
+      const previous = this.lastKnownGrowthStages.get(key);
+      this.lastKnownGrowthStages.set(key, stage);
+
+      if (previous !== undefined && previous !== stage) {
+        eventBus.emit(GameEvent.FARM_CROP_GREW, { position: plot.position, stage });
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #16, #17.

## #16 — Sprout sprite sometimes never renders

Growth stage is computed live from elapsed time (`farmManager.getGrowthStage`), but crossing the SEEDLING→YOUNG sub-stage boundary at 33% progress is not a plot state transition (PLANTED/WATERED/READY) — the only thing that emits `FARM_PLOT_CHANGED` and triggers a tile re-render. For a fast-growing crop (radish: ~30 real seconds in the seedling window), if nothing else happens to trigger a re-render during that window, the plot visually jumps straight from bare soil to young/adult, skipping the seedling sprite entirely.

`GameEvent.FARM_CROP_GREW` already existed for exactly this purpose but was never emitted anywhere — dead infrastructure. Added `FarmManager.checkGrowthStageTransitions()`, which tracks each growing plot's last-observed stage and emits `FARM_CROP_GREW` when it changes since the last check. Wired into the existing 10-second polling interval in `useEnvironmentController.ts` ("Time of Day Polling") rather than adding a new timer — well within the ~30s seedling window for the fastest crop.

## #17 — Interaction prompts visible before "Enter Game"

`isLoadingCutscene` defaulted to `false` and only became `true` inside a mount `useEffect` (after `startCutscene()` decides a season cutscene is due) — a window during which the black loading overlay (which is what actually hides NPC/transition interaction prompts, well above them in z-index) doesn't exist in the DOM yet. Defaulted it to `true` instead, so the overlay covers the very first paint; the mount effect now explicitly sets it back to `false` in the "no cutscene due this session" branch, preserving that path's existing behaviour (skip the loading screen entirely).

**Note:** I could not verify this fix in a live browser (no Chrome connection available this session) — verified via typecheck/tests and code reading only. Worth a manual check before/after merging if you have a moment.

## Tests

`tests/cropGrowthStageTransitions.test.ts` covers the #16 fix directly. `make verify` green: typecheck clean, 520 tests across 45 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k