### PR TITLE
Fix foraging click hitboxes and out-of-season berry/nut picking

### DIFF
--- a/tests/berryForaging.test.ts
+++ b/tests/berryForaging.test.ts
@@ -1,0 +1,129 @@
+/** @vitest-environment node */
+/**
+ * Regressions for #20 (hawthorn/hazelnut pickable outside their season) and
+ * #21 (foraging click hitbox offset from the visible bush image).
+ *
+ * #21's root cause: berryProvider hand-rolled an "8 surrounding tiles" search
+ * that excluded the clicked tile itself, so clicking directly on a bush's own
+ * anchor tile never matched — only clicking one tile away from it did. Fixed
+ * by switching to findTileTypeNearby, whose radius search includes the centre
+ * tile (the same helper fruitTreeProvider/leafPileProvider already use).
+ *
+ * #20's root cause: each harvest handler (handleHazelnutHarvest etc.) already
+ * rejected an out-of-season pick, but berryProvider offered the radial-menu
+ * option regardless of season.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getAvailableInteractions } from '../utils/interactions/index';
+import { mapManager, transitionToMap } from '../maps';
+import { TimeManager, Season } from '../utils/TimeManager';
+import type { MapDefinition } from '../types';
+import { TileType } from '../types';
+
+function bushMap(id: string, bushType: TileType): MapDefinition {
+  const width = 5;
+  const height = 5;
+  const grid = Array.from({ length: height }, () => Array(width).fill(TileType.GRASS));
+  grid[2][2] = bushType; // anchor at (2,2)
+  return {
+    id,
+    name: id,
+    width,
+    height,
+    grid,
+    spawnPoint: { x: 0, y: 0 },
+    transitions: [],
+    colorScheme: 'forest',
+    npcs: [],
+  } as unknown as MapDefinition;
+}
+
+function mockSeason(season: Season) {
+  vi.spyOn(TimeManager, 'getCurrentTime').mockReturnValue({
+    year: 1,
+    season,
+    day: 10,
+    totalDays: 10,
+    hour: 12,
+    minute: 0,
+    timeOfDay: 'day' as never,
+    totalHours: 250,
+    daylight: { dawn: 7, sunrise: 8, sunset: 16, dusk: 17 },
+  });
+}
+
+const CASES: Array<{
+  label: string;
+  tileType: TileType;
+  interactionType: string;
+  inSeason: Season;
+  outOfSeason: Season;
+}> = [
+  {
+    label: 'hazelnut (hazel bush)',
+    tileType: TileType.HAZEL_BUSH,
+    interactionType: 'harvest_hazelnut',
+    inSeason: Season.AUTUMN,
+    outOfSeason: Season.SPRING,
+  },
+  {
+    label: 'red berries (hawthorn bush)',
+    tileType: TileType.BUSH,
+    interactionType: 'harvest_red_berries',
+    inSeason: Season.AUTUMN,
+    outOfSeason: Season.WINTER,
+  },
+  {
+    label: 'blackberries (brambles)',
+    tileType: TileType.BRAMBLES,
+    interactionType: 'harvest_blackberry',
+    inSeason: Season.SUMMER,
+    outOfSeason: Season.WINTER,
+  },
+  {
+    label: 'blueberries',
+    tileType: TileType.BLUEBERRY_BUSH,
+    interactionType: 'harvest_blueberry',
+    inSeason: Season.SUMMER,
+    outOfSeason: Season.WINTER,
+  },
+];
+
+describe.each(CASES)('$label', ({ tileType, interactionType, inSeason, outOfSeason }) => {
+  const mapId = `berry_test_${tileType}`;
+  const anchor = { x: 2, y: 2 };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is offered when clicking directly on the bush anchor tile (#21)', () => {
+    mapManager.registerMap(bushMap(mapId, tileType));
+    transitionToMap(mapId, { x: 0, y: 0 });
+    mockSeason(inSeason);
+
+    const interactions = getAvailableInteractions({
+      position: anchor,
+      currentMapId: mapId,
+      currentTool: 'hand',
+      selectedSeed: null,
+    });
+
+    expect(interactions.map((i) => i.type)).toContain(interactionType);
+  });
+
+  it('is not offered outside its season (#20)', () => {
+    mapManager.registerMap(bushMap(mapId, tileType));
+    transitionToMap(mapId, { x: 0, y: 0 });
+    mockSeason(outOfSeason);
+
+    const interactions = getAvailableInteractions({
+      position: anchor,
+      currentMapId: mapId,
+      currentTool: 'hand',
+      selectedSeed: null,
+    });
+
+    expect(interactions.map((i) => i.type)).not.toContain(interactionType);
+  });
+});

--- a/utils/interactions/providers/berries.ts
+++ b/utils/interactions/providers/berries.ts
@@ -7,14 +7,27 @@
 
 import type { AvailableInteraction, InteractionContext } from '../types';
 import { TileType } from '../../../types';
-import { getTileData } from '../../mapUtils';
+import { findTileTypeNearby } from '../../mapUtils';
 import { groceryAssets, itemAssets, magicalAssets } from '../../../assets';
-import { handleBlackberryHarvest, handleBlueberryHarvest, handleForageAction, handleHazelnutHarvest, handleRedBerryHarvest } from '../../forageHandlers';
+import {
+  handleBlackberryHarvest,
+  handleBlueberryHarvest,
+  handleForageAction,
+  handleHazelnutHarvest,
+  handleRedBerryHarvest,
+} from '../../forageHandlers';
 import { staminaManager } from '../../StaminaManager';
+import { Season, TimeManager } from '../../TimeManager';
 
 export function berryProvider(ctx: InteractionContext): AvailableInteraction[] {
   const { position, currentMapId, onForage, tileX, tileY, tileData } = ctx;
   const interactions: AvailableInteraction[] = [];
+
+  // Each harvest handler below (handleBlackberryHarvest etc.) already rejects an
+  // out-of-season pick with a "not ripe yet" message, but this provider offered
+  // the radial-menu option year-round regardless — the option itself was the bug
+  // (issue #20), not the harvest. Gate each one to match its handler's season.
+  const currentSeason = TimeManager.getCurrentTime().season;
 
   // Check for wild strawberry harvesting
   // Allow picking with any tool or no tool (mouse click works regardless of equipped tool)
@@ -31,25 +44,15 @@ export function berryProvider(ctx: InteractionContext): AvailableInteraction[] {
     });
   }
 
-  // Check for blackberry harvesting from adjacent brambles
-  // Allow picking with any tool or no tool (mouse click works regardless of equipped tool)
-  const adjacentTiles = [
-    { x: tileX - 1, y: tileY },
-    { x: tileX + 1, y: tileY },
-    { x: tileX, y: tileY - 1 },
-    { x: tileX, y: tileY + 1 },
-    { x: tileX - 1, y: tileY - 1 },
-    { x: tileX + 1, y: tileY - 1 },
-    { x: tileX - 1, y: tileY + 1 },
-    { x: tileX + 1, y: tileY + 1 },
-  ];
+  // Check for blackberry/hazelnut/blueberry/hawthorn harvesting from a bush at or
+  // adjacent to the click. findTileTypeNearby's radius=1 search includes the
+  // clicked tile itself as well as its 8 neighbours — a hand-rolled version of
+  // this used to check only the 8 neighbours, so clicking directly on the bush's
+  // own anchor tile never matched (only clicking one tile away from it did),
+  // making the click hitbox appear offset from the visible sprite (issue #21).
+  const hasBrambles = findTileTypeNearby(tileX, tileY, [TileType.BRAMBLES], 1).found;
 
-  const hasBrambles = adjacentTiles.some((tile) => {
-    const adjacentTileData = getTileData(tile.x, tile.y);
-    return adjacentTileData && adjacentTileData.type === TileType.BRAMBLES;
-  });
-
-  if (hasBrambles) {
+  if (hasBrambles && currentSeason === Season.SUMMER) {
     interactions.push({
       type: 'harvest_blackberry',
       label: 'Pick Blackberries',
@@ -65,12 +68,9 @@ export function berryProvider(ctx: InteractionContext): AvailableInteraction[] {
 
   // Check for hazelnut harvesting from adjacent hazel bushes
   // Allow picking with any tool or no tool (mouse click works regardless of equipped tool)
-  const hasHazelBush = adjacentTiles.some((tile) => {
-    const adjacentTileData = getTileData(tile.x, tile.y);
-    return adjacentTileData && adjacentTileData.type === TileType.HAZEL_BUSH;
-  });
+  const hasHazelBush = findTileTypeNearby(tileX, tileY, [TileType.HAZEL_BUSH], 1).found;
 
-  if (hasHazelBush) {
+  if (hasHazelBush && currentSeason === Season.AUTUMN) {
     interactions.push({
       type: 'harvest_hazelnut',
       label: 'Pick Hazelnuts',
@@ -86,12 +86,9 @@ export function berryProvider(ctx: InteractionContext): AvailableInteraction[] {
 
   // Check for blueberry harvesting from adjacent blueberry bushes
   // Allow picking with any tool or no tool (mouse click works regardless of equipped tool)
-  const hasBlueberryBush = adjacentTiles.some((tile) => {
-    const adjacentTileData = getTileData(tile.x, tile.y);
-    return adjacentTileData && adjacentTileData.type === TileType.BLUEBERRY_BUSH;
-  });
+  const hasBlueberryBush = findTileTypeNearby(tileX, tileY, [TileType.BLUEBERRY_BUSH], 1).found;
 
-  if (hasBlueberryBush) {
+  if (hasBlueberryBush && (currentSeason === Season.SUMMER || currentSeason === Season.AUTUMN)) {
     interactions.push({
       type: 'harvest_blueberry',
       label: 'Pick Blueberries',
@@ -106,12 +103,9 @@ export function berryProvider(ctx: InteractionContext): AvailableInteraction[] {
   }
 
   // Check for red berry harvesting from adjacent hawthorn bushes (autumn only)
-  const hasHawthornBush = adjacentTiles.some((tile) => {
-    const adjacentTileData = getTileData(tile.x, tile.y);
-    return adjacentTileData && adjacentTileData.type === TileType.BUSH;
-  });
+  const hasHawthornBush = findTileTypeNearby(tileX, tileY, [TileType.BUSH], 1).found;
 
-  if (hasHawthornBush) {
+  if (hasHawthornBush && currentSeason === Season.AUTUMN) {
     interactions.push({
       type: 'harvest_red_berries',
       label: 'Pick Red Berries',


### PR DESCRIPTION
Fixes #20, #21.

## #21 — Foraging click hitboxes offset from the visible bush

`berryProvider` hand-rolled an "8 surrounding tiles" search for blackberries, hazelnuts, blueberries and hawthorn that excluded the clicked tile itself — so clicking directly on a bush's own anchor tile never matched; only clicking one tile away from it did, making the hitbox look offset from the image.

Switched to `findTileTypeNearby` (already used by `fruitTreeProvider`, `leafPileProvider`, etc.), whose radius search includes the centre tile.

## #20 — Hawthorn/hazelnut pickable outside their season

Each harvest handler (`handleHazelnutHarvest`, `handleRedBerryHarvest`, etc.) in `forageHandlers.ts` already correctly rejected an out-of-season pick with a "not ripe yet" message and no item granted — but `berryProvider` offered the radial-menu option regardless of season, so the option itself was visibly available year-round even though the actual harvest was already blocked. Same gap existed for blackberries (summer) and blueberries (summer/autumn), not just the two named in the issue.

Gated each interaction to match its own handler's season requirement.

## Tests

`tests/berryForaging.test.ts` covers all four bush types for both fixes. Confirmed the hitbox tests fail on the pre-fix code (reverted the provider change locally, 4/8 tests failed as expected, restored the fix). `make verify` green: typecheck clean, 530 tests across 46 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k