### PR TITLE
Make maps cover the viewport at any aspect ratio

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -34,7 +34,7 @@ import { EventChainPopup } from './components/EventChainPopup';
 import { useAmbientVFX } from './hooks/useAmbientVFX';
 import { useCharacterSprites, getPlayerSpriteInfo } from './hooks/useCharacterSprites';
 import { useCamera } from './hooks/useCamera';
-import { usePinchZoom, getZoomLimitsForRoom } from './hooks/usePinchZoom';
+import { usePinchZoom, getZoomLimitsForRoom, getCoverZoom } from './hooks/usePinchZoom';
 import { useBrowserZoomLock } from './hooks/useBrowserZoomLock';
 import { useBrowserZoom } from './hooks/useBrowserZoom';
 import { useViewportCulling } from './hooks/useViewportCulling';
@@ -247,6 +247,27 @@ const App: React.FC = () => {
   // Game container ref for click detection
   const gameContainerRef = useRef<HTMLDivElement | null>(null);
 
+  // Track viewport dimensions for responsive scaling (updates on resize/zoom).
+  // Declared here (rather than down with the other viewport-driven memos) so
+  // the zoom-limits computation below — which needs it for coverZoom — can use it.
+  const [viewportSize, setViewportSize] = useState({
+    width: typeof window !== 'undefined' ? window.innerWidth : 1920,
+    height: typeof window !== 'undefined' ? window.innerHeight : 1080,
+  });
+
+  // Listen for viewport changes (resize, zoom)
+  useEffect(() => {
+    const handleResize = () => {
+      setViewportSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   // Pinch-to-zoom (touch) and mouse wheel zoom (desktop)
   // Background-image rooms (interiors) can only zoom in, not out
   // Disable zoom when UI overlays are open so scroll/pinch works in menus
@@ -276,9 +297,23 @@ const App: React.FC = () => {
     const map = mapManager.getMap(currentMapId);
     return map?.renderMode === 'background-image';
   }, [currentMapId]);
+  // Minimum zoom needed for a TILED room to fully cover the viewport (issue #26)
+  // — see getCoverZoom. Irrelevant for background-image rooms, which use their
+  // own viewportScale system and have zoom disabled entirely.
+  const coverZoom = useMemo(() => {
+    if (isBackgroundImageRoom) return 1;
+    const map = mapManager.getMap(currentMapId);
+    if (!map) return 1;
+    return getCoverZoom(
+      map.width * TILE_SIZE,
+      map.height * TILE_SIZE,
+      viewportSize.width,
+      viewportSize.height
+    );
+  }, [isBackgroundImageRoom, currentMapId, viewportSize]);
   const zoomLimits = useMemo(
-    () => getZoomLimitsForRoom(isBackgroundImageRoom, isAnyOverlayOpen),
-    [isBackgroundImageRoom, isAnyOverlayOpen]
+    () => getZoomLimitsForRoom(isBackgroundImageRoom, isAnyOverlayOpen, coverZoom),
+    [isBackgroundImageRoom, isAnyOverlayOpen, coverZoom]
   );
   // Always prevent browser-level zoom changes (Ctrl+scroll, Ctrl+/-/0)
   // Runs independently of game zoom — never disabled, even when overlays are open
@@ -1096,25 +1131,6 @@ const App: React.FC = () => {
   const mapWidth = currentMap ? currentMap.width : 50;
   const mapHeight = currentMap ? currentMap.height : 30;
 
-  // Track viewport dimensions for responsive scaling (updates on resize/zoom)
-  const [viewportSize, setViewportSize] = useState({
-    width: typeof window !== 'undefined' ? window.innerWidth : 1920,
-    height: typeof window !== 'undefined' ? window.innerHeight : 1080,
-  });
-
-  // Listen for viewport changes (resize, zoom)
-  useEffect(() => {
-    const handleResize = () => {
-      setViewportSize({
-        width: window.innerWidth,
-        height: window.innerHeight,
-      });
-    };
-
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
   // Browser page-zoom factor relative to load (1.0 = normal). Keeps the
   // viewportScale memo below invariant to browser zoom — see useBrowserZoom.
   const browserZoom = useBrowserZoom();
@@ -1136,13 +1152,20 @@ const App: React.FC = () => {
     // large monitors — leaving the room image and character the only things that
     // don't magnify. Normalising here lets interiors zoom WITH the browser, like
     // tiled rooms do. See useBrowserZoom / docs/ARCHITECTURE_GOTCHAS.md.
+    //
+    // 'cover' (not the default 'contain'): at a viewport aspect ratio that
+    // doesn't match the reference, 'contain' fits the room fully on screen but
+    // leaves a letterboxed gap on one axis, showing the game's own background
+    // colour through it (issue #26). 'cover' scales to fill both axes instead,
+    // cropping whichever axis has the excess.
     const rawScale = calculateViewportScale(
       viewportSize.width * browserZoom,
       viewportSize.height * browserZoom,
       refViewport.width,
       refViewport.height,
       0.5, // minScale (absolute floor)
-      2.5 // maxScale - allow larger scaling for big monitors
+      2.5, // maxScale - allow larger scaling for big monitors
+      'cover'
     );
 
     // Only scale UP on larger viewports, never scale down

--- a/docs/ARCHITECTURE_GOTCHAS.md
+++ b/docs/ARCHITECTURE_GOTCHAS.md
@@ -318,13 +318,43 @@ magnify with the browser like everything else. Guarded by [`tests/viewportZoom.t
 Note `useBrowserZoomLock` only blocks Ctrl/⌘ + scroll / +/-/0 — the browser's View→Zoom menu and
 persisted per-site zoom still apply, so this path has to be correct.
 
+### Maps not filling the screen at some aspect ratios
+
+Two independent fits used to be **contain** (fit fully inside, gap on the axis with room to
+spare) instead of **cover** (fill both axes, crop the overflow) — at a viewport aspect ratio
+that didn't match the map/reference, the game's own background colour showed through the gap.
+
+- **Tiled rooms**: `useCamera`'s "map smaller than the effective viewport" branch centred the
+  map with empty space on the sides instead of scaling up to cover. Fix:
+  [`getCoverZoom`](../hooks/usePinchZoom.ts) computes the minimum zoom needed to guarantee
+  coverage for the current map + viewport; `App.tsx` feeds it in as the **pinch-zoom minimum**
+  (`getZoomLimitsForRoom`'s `coverZoom` param), so the same `zoom` value that drives the CSS
+  `scale()` transform is also what `useCamera` uses for its math — they can never disagree.
+  `useCamera`'s existing follow-the-player logic (unchanged) then naturally pans the cropped
+  view with the player instead of it sitting static. The axis that determined `coverZoom` is an
+  exact tie (zero pan room, by definition of "just barely covers") — only the other axis has
+  slack to pan on; see [`tests/cameraCoverage.test.ts`](../tests/cameraCoverage.test.ts).
+- **Background-image rooms**: `calculateViewportScale` (`hooks/useViewportScale.ts`) now takes a
+  `fitMode: 'contain' | 'cover'` param (default stays `'contain'` — only `App.tsx`'s
+  `viewportScale` memo passes `'cover'`). These rooms still don't pan with the player — that's a
+  deliberate, larger follow-up left out of the initial fix (see `docs/ARCHITECTURE_GOTCHAS.md`
+  Common mistake #4 below; introducing panning here would touch the click-coordinate pipeline
+  this whole section is about, and needs live-browser verification).
+
+Guarded by [`tests/mapFillsScreen.test.ts`](../tests/mapFillsScreen.test.ts) and
+[`tests/cameraCoverage.test.ts`](../tests/cameraCoverage.test.ts).
+
 ### Common mistakes
 
 1. **Forgetting zoom in gridOffset** — see Section 1
 2. **Placing NPCs using pixel coordinates** — NPCs use tile coordinates, not pixels
 3. **Testing only at zoom=1** — offset bugs only manifest when zoomed
-4. **Assuming camera works the same** — background-image rooms don't scroll; camera is effectively fixed
+4. **Assuming camera works the same** — background-image rooms don't scroll or pan with the
+   player (unlike tiled rooms — see "Maps not filling the screen" above); camera is effectively fixed
 5. **Deriving interior sizes from raw `innerWidth`** — factor out browser zoom (see above) or interiors won't match tiled rooms
+6. **Using `calculateViewportScale`'s default (contain) when you actually need cover** — contain
+   leaves a gap on the axis with room to spare; pass `fitMode: 'cover'` explicitly when the goal
+   is to fill the viewport with no gaps, cropping overflow instead
 
 ---
 

--- a/hooks/useCamera.ts
+++ b/hooks/useCamera.ts
@@ -21,6 +21,12 @@ interface CameraPosition {
  * Hook for camera positioning logic
  * Centers small maps, follows player on large maps
  * Accounts for zoom — at zoom 2x the effective viewport is half the screen size
+ *
+ * `zoom` is expected to already be at least whatever getCoverZoom
+ * (hooks/usePinchZoom.ts) requires for the current map/viewport — App.tsx
+ * enforces that as the pinch-zoom minimum. Given that, mapPixelWidth/Height
+ * should never actually be smaller than the effective viewport below; the
+ * "centre it" branches are a defensive fallback only (issue #26).
  */
 export function useCamera(config: CameraConfig): CameraPosition {
   const {
@@ -44,7 +50,7 @@ export function useCamera(config: CameraConfig): CameraPosition {
     let cameraY: number;
 
     // If map is smaller than effective viewport, center it
-    if (mapPixelWidth < effectiveWidth) {
+    if (mapPixelWidth <= effectiveWidth) {
       cameraX = -(effectiveWidth - mapPixelWidth) / 2;
     } else {
       // Otherwise follow player
@@ -54,7 +60,7 @@ export function useCamera(config: CameraConfig): CameraPosition {
       );
     }
 
-    if (mapPixelHeight < effectiveHeight) {
+    if (mapPixelHeight <= effectiveHeight) {
       cameraY = -(effectiveHeight - mapPixelHeight) / 2;
     } else {
       cameraY = Math.min(

--- a/hooks/usePinchZoom.ts
+++ b/hooks/usePinchZoom.ts
@@ -34,25 +34,56 @@ export interface ZoomLimits {
 }
 
 /**
+ * Minimum zoom needed so a mapPixelWidth x mapPixelHeight tiled room, once
+ * scaled, covers the full given viewport in both axes (like CSS
+ * `background-size: cover`) — never below 1 (never asks for a zoom-OUT just
+ * because the map happens to be huge; that's what the normal zoom-out range
+ * is for).
+ *
+ * Without this, useCamera's "map smaller than viewport" branch centred the
+ * map at 1:1 and left the game's own background colour visible in a border
+ * around it whenever a map was smaller than the browser window in some axis,
+ * or the window's aspect ratio didn't match the map's — issue #26. Feeding
+ * this in as the pinch-zoom minimum (see getZoomLimitsForRoom) means the
+ * actual rendered scale always covers the viewport, and useCamera's existing
+ * follow-the-player logic — unchanged — naturally makes the cropped overflow
+ * pan with the player instead of sitting static.
+ */
+export function getCoverZoom(
+  mapPixelWidth: number,
+  mapPixelHeight: number,
+  viewportWidth: number,
+  viewportHeight: number
+): number {
+  if (mapPixelWidth <= 0 || mapPixelHeight <= 0) return 1;
+  return Math.max(1, viewportWidth / mapPixelWidth, viewportHeight / mapPixelHeight);
+}
+
+/**
  * Decides the pinch/wheel zoom limits for the current room.
  *
  * Background-image rooms (interiors) already fit the viewport responsively via
  * `viewportScale`. Letting pinch/wheel zoom apply on top of that re-fits the room
  * at a different scale mid-frame, which visibly rearranges furniture, NPCs and the
  * character — so game zoom is pinned to 1.0 (disabled) for these rooms. Tiled
- * rooms keep the normal min/max, and are also disabled while a UI overlay is open
- * so scroll/pinch works in menus instead.
+ * rooms keep the normal min/max (raised by `coverZoom` when the map wouldn't
+ * otherwise cover the viewport — see getCoverZoom), and are also disabled while a
+ * UI overlay is open so scroll/pinch works in menus instead.
  */
 export function getZoomLimitsForRoom(
   isBackgroundImageRoom: boolean,
-  isAnyOverlayOpen: boolean
+  isAnyOverlayOpen: boolean,
+  coverZoom: number = DEFAULT_MIN_ZOOM
 ): ZoomLimits {
   if (isBackgroundImageRoom) {
     return { minZoom: 1.0, maxZoom: 1.0, enabled: false };
   }
+  const minZoom = Math.max(DEFAULT_MIN_ZOOM, coverZoom);
   return {
-    minZoom: DEFAULT_MIN_ZOOM,
-    maxZoom: DEFAULT_MAX_ZOOM,
+    minZoom,
+    // A very small map could need more zoom to cover than the default max
+    // allows — extend the ceiling to match rather than leaving a gap.
+    maxZoom: Math.max(DEFAULT_MAX_ZOOM, minZoom),
     enabled: !isAnyOverlayOpen,
   };
 }

--- a/hooks/useViewportScale.ts
+++ b/hooks/useViewportScale.ts
@@ -56,6 +56,11 @@ export interface ViewportScaleResult {
  * @param referenceHeight - Reference viewport height content was designed for
  * @param minScale - Minimum allowed scale (default: 0.5)
  * @param maxScale - Maximum allowed scale (default: 2.0)
+ * @param fitMode - 'contain' (default, fits inside without cropping — leaves a
+ *   letterboxed gap at mismatched aspect ratios) or 'cover' (fills the whole
+ *   viewport, cropping whichever axis has the excess — see the "cover" callers
+ *   in App.tsx for issue #26, where a letterboxed gap left the game's own
+ *   background colour visible around a background-image room).
  * @returns Scale factor to apply
  */
 export function calculateViewportScale(
@@ -64,14 +69,16 @@ export function calculateViewportScale(
   referenceWidth: number,
   referenceHeight: number,
   minScale: number = 0.5,
-  maxScale: number = 2.0
+  maxScale: number = 2.0,
+  fitMode: 'contain' | 'cover' = 'contain'
 ): number {
   // Calculate scale needed to fit both dimensions
   const scaleX = viewportWidth / referenceWidth;
   const scaleY = viewportHeight / referenceHeight;
 
-  // Use the smaller scale to ensure content fits (contain behavior)
-  const scale = Math.min(scaleX, scaleY);
+  // contain: use the smaller scale so content fits fully inside, with letterboxing.
+  // cover: use the larger scale so content fills the viewport, cropping overflow.
+  const scale = fitMode === 'cover' ? Math.max(scaleX, scaleY) : Math.min(scaleX, scaleY);
 
   // Clamp to min/max bounds
   return Math.max(minScale, Math.min(maxScale, scale));

--- a/tests/cameraCoverage.test.ts
+++ b/tests/cameraCoverage.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression for issue #26 (tiled rooms): once App.tsx feeds getCoverZoom's
+ * result in as the pinch-zoom minimum, useCamera should receive a `zoom` that
+ * already guarantees the map covers the viewport — so its "centre a too-small
+ * map" branch should no longer trigger, and the camera should instead follow
+ * the player, panning the (now fully covering, cropped) view with them.
+ *
+ * Uses jsdom (the project default environment) for renderHook.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useCamera } from '../hooks/useCamera';
+import { getCoverZoom } from '../hooks/usePinchZoom';
+import { TILE_SIZE } from '../constants';
+
+describe('useCamera with a coverZoom-raised zoom (#26)', () => {
+  it('follows the player instead of centring, once zoom covers the viewport', () => {
+    // A small 10x8 tile map on a 1920x1080 viewport — smaller than the
+    // viewport at zoom 1, so without the fix the camera would centre it.
+    const mapWidth = 10;
+    const mapHeight = 8;
+    const viewportWidth = 1920;
+    const viewportHeight = 1080;
+    const mapPixelWidth = mapWidth * TILE_SIZE;
+    const mapPixelHeight = mapHeight * TILE_SIZE;
+
+    const coverZoom = getCoverZoom(mapPixelWidth, mapPixelHeight, viewportWidth, viewportHeight);
+    expect(coverZoom).toBeGreaterThan(1); // this map genuinely needs zooming to cover
+
+    // Player near the top-left corner of the map
+    const { result } = renderHook(() =>
+      useCamera({
+        playerPos: { x: 1, y: 1 },
+        mapWidth,
+        mapHeight,
+        viewportWidth,
+        viewportHeight,
+        zoom: coverZoom,
+      })
+    );
+
+    // Camera should be clamped to the map's top-left edge (following the
+    // player, who is near it) — not centred with a negative offset.
+    // (toBeCloseTo rather than toBe: the width axis is an exact tie by
+    // construction — it's the one that determined coverZoom — so it can land
+    // on -0 depending on float rounding; that's still "no gap", just signed zero.)
+    expect(result.current.cameraX).toBeCloseTo(0, 6);
+    expect(result.current.cameraY).toBeCloseTo(0, 6);
+
+    // And it should actually cover: the visible viewport (in map pixels) must
+    // fit within the map's own pixel bounds — no leftover gap to show
+    // background through.
+    const effectiveWidth = viewportWidth / coverZoom;
+    const effectiveHeight = viewportHeight / coverZoom;
+    expect(result.current.cameraX + effectiveWidth).toBeLessThanOrEqual(mapPixelWidth + 1e-6);
+    expect(result.current.cameraY + effectiveHeight).toBeLessThanOrEqual(mapPixelHeight + 1e-6);
+  });
+
+  it('pans on the axis that has crop room as the player moves, instead of staying static', () => {
+    // With these dimensions the WIDTH ratio (1920/640 = 3.0) exceeds the height
+    // ratio (1080/512 ≈ 2.11), so width is the exact-tie axis that determines
+    // coverZoom (zero pan room there, by definition of "just barely covers") —
+    // height is the axis with actual crop/pan room. Move the player along Y.
+    const mapWidth = 10;
+    const mapHeight = 8;
+    const viewportWidth = 1920;
+    const viewportHeight = 1080;
+    const coverZoom = getCoverZoom(
+      mapWidth * TILE_SIZE,
+      mapHeight * TILE_SIZE,
+      viewportWidth,
+      viewportHeight
+    );
+
+    const nearTop = renderHook(() =>
+      useCamera({
+        playerPos: { x: 5, y: 1 },
+        mapWidth,
+        mapHeight,
+        viewportWidth,
+        viewportHeight,
+        zoom: coverZoom,
+      })
+    ).result.current;
+
+    const nearBottom = renderHook(() =>
+      useCamera({
+        playerPos: { x: 5, y: mapHeight - 1 },
+        mapWidth,
+        mapHeight,
+        viewportWidth,
+        viewportHeight,
+        zoom: coverZoom,
+      })
+    ).result.current;
+
+    // The camera must have actually moved on the axis with pan room — a
+    // static, centred camera would report the same position for both.
+    expect(nearBottom.cameraY).toBeGreaterThan(nearTop.cameraY);
+  });
+
+  it('without coverZoom (zoom stuck at 1), a small map still gets centred — the pre-fix behaviour', () => {
+    // Sanity check that the OLD bug is real and this isn't a vacuous test:
+    // at zoom 1 (no cover compensation), the small map is still smaller than
+    // the viewport, so the "centre it" branch (still present as a fallback)
+    // reports a negative camera offset — i.e. letterboxing.
+    const { result } = renderHook(() =>
+      useCamera({
+        playerPos: { x: 1, y: 1 },
+        mapWidth: 10,
+        mapHeight: 8,
+        viewportWidth: 1920,
+        viewportHeight: 1080,
+        zoom: 1,
+      })
+    );
+    expect(result.current.cameraX).toBeLessThan(0);
+  });
+});

--- a/tests/mapFillsScreen.test.ts
+++ b/tests/mapFillsScreen.test.ts
@@ -1,0 +1,102 @@
+/** @vitest-environment node */
+/**
+ * Regression for issue #26: maps didn't always fill the screen at certain
+ * aspect ratios, leaving the game's own background colour visible where the
+ * map didn't cover.
+ *
+ * Two separate root causes, one per room type:
+ *
+ * - Tiled rooms: useCamera's "map smaller than effective viewport" branch
+ *   centred the map with empty space on the sides instead of scaling up to
+ *   cover. getCoverZoom (this file) computes the minimum zoom needed to
+ *   guarantee coverage; App.tsx feeds it in as the pinch-zoom minimum, so the
+ *   same `zoom` value used for the camera's math is also what's actually
+ *   rendered — and useCamera's existing follow-the-player logic (unchanged)
+ *   makes the cropped overflow pan with the player instead of sitting static.
+ *
+ * - Background-image rooms: calculateViewportScale used 'contain' fitting
+ *   (picks the SMALLER of scaleX/scaleY), which fits the room fully on
+ *   screen but leaves a letterboxed gap on whichever axis has room to spare
+ *   at a mismatched aspect ratio. 'cover' mode (new) picks the LARGER scale
+ *   instead, filling both axes and cropping the overflow.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  getCoverZoom,
+  DEFAULT_MIN_ZOOM,
+  DEFAULT_MAX_ZOOM,
+  getZoomLimitsForRoom,
+} from '../hooks/usePinchZoom';
+import { calculateViewportScale } from '../hooks/useViewportScale';
+
+describe('getCoverZoom (#26 — tiled rooms)', () => {
+  it('returns 1 when the map already covers the viewport at 1:1', () => {
+    // Map bigger than viewport in both axes — no zoom needed to cover.
+    expect(getCoverZoom(4000, 3000, 1920, 1080)).toBe(1);
+  });
+
+  it('returns >1 when the map is smaller than the viewport in one axis', () => {
+    // Map is 1600 wide, viewport is 1920 — needs 1920/1600 = 1.2x to cover width.
+    const zoom = getCoverZoom(1600, 3000, 1920, 1080);
+    expect(zoom).toBeCloseTo(1.2, 5);
+  });
+
+  it('picks whichever axis needs MORE zoom (guarantees both axes covered)', () => {
+    // Width needs 1920/1000=1.92x, height needs 1080/900=1.2x — must use the larger.
+    const zoom = getCoverZoom(1000, 900, 1920, 1080);
+    expect(zoom).toBeCloseTo(1.92, 5);
+    // Confirm this genuinely covers both axes
+    expect(1000 * zoom).toBeGreaterThanOrEqual(1920 - 1e-6);
+    expect(900 * zoom).toBeGreaterThanOrEqual(1080 - 1e-6);
+  });
+
+  it('never returns below 1 (never forces a zoom-out just because the map is huge)', () => {
+    expect(getCoverZoom(100, 100, 1920, 1080)).toBeGreaterThanOrEqual(1);
+    expect(getCoverZoom(10000, 10000, 1920, 1080)).toBe(1);
+  });
+});
+
+describe('getZoomLimitsForRoom respects coverZoom for tiled rooms (#26)', () => {
+  it('raises minZoom above the default floor when the map needs it to cover', () => {
+    const limits = getZoomLimitsForRoom(false, false, 1.5);
+    expect(limits.minZoom).toBe(1.5);
+    expect(limits.maxZoom).toBeGreaterThanOrEqual(1.5);
+  });
+
+  it('keeps the normal default floor when coverZoom is below it', () => {
+    const limits = getZoomLimitsForRoom(false, false, 0.2);
+    expect(limits.minZoom).toBe(DEFAULT_MIN_ZOOM);
+    expect(limits.maxZoom).toBe(DEFAULT_MAX_ZOOM);
+  });
+
+  it('still disables zoom entirely for background-image rooms regardless of coverZoom', () => {
+    const limits = getZoomLimitsForRoom(true, false, 3.0);
+    expect(limits.enabled).toBe(false);
+    expect(limits.minZoom).toBe(1.0);
+    expect(limits.maxZoom).toBe(1.0);
+  });
+});
+
+describe('calculateViewportScale cover mode (#26 — background-image rooms)', () => {
+  it('contain (default) picks the smaller ratio, potentially leaving a gap', () => {
+    // Reference 1920x1080. Viewport 2000x1080 (wider than reference) —
+    // contain uses the height ratio (1.0), so width scales to 1920 < 2000: a gap.
+    const scale = calculateViewportScale(2000, 1080, 1920, 1080, 0.5, 2.5, 'contain');
+    expect(scale).toBeCloseTo(1.0, 5);
+  });
+
+  it('cover picks the larger ratio, filling both axes', () => {
+    const scale = calculateViewportScale(2000, 1080, 1920, 1080, 0.5, 2.5, 'cover');
+    const expected = 2000 / 1920; // width is the binding constraint under cover
+    expect(scale).toBeCloseTo(expected, 5);
+    // Confirm this genuinely covers both axes of the viewport
+    expect(1920 * scale).toBeGreaterThanOrEqual(2000 - 1e-6);
+    expect(1080 * scale).toBeGreaterThanOrEqual(1080 - 1e-6);
+  });
+
+  it('defaults to contain when fitMode is omitted (no behaviour change for other callers)', () => {
+    const withDefault = calculateViewportScale(2000, 1080, 1920, 1080, 0.5, 2.5);
+    const withExplicitContain = calculateViewportScale(2000, 1080, 1920, 1080, 0.5, 2.5, 'contain');
+    expect(withDefault).toBe(withExplicitContain);
+  });
+});


### PR DESCRIPTION
Fixes #26.

Two independent "contain" fits used to leave a gap at a mismatched viewport aspect ratio, showing the game's own background colour through it.

## Tiled rooms

`useCamera`'s "map smaller than the effective viewport" branch centred the map with empty space on the sides instead of scaling up to cover. Added `getCoverZoom` (`hooks/usePinchZoom.ts`) — the minimum zoom needed to guarantee a map covers a given viewport, like CSS `background-size: cover`, never below 1. `App.tsx` feeds this in as the **pinch-zoom minimum** (`getZoomLimitsForRoom`'s new `coverZoom` param), so the same `zoom` value that drives the CSS `scale()` transform is also what `useCamera` uses for its own math — they can never disagree. `useCamera`'s existing follow-the-player logic (unchanged) then naturally pans the cropped view with the player instead of it sitting static — exactly the "shift the crop as the player walks around" behaviour the issue asks for.

(Needed `viewportSize` earlier in `App.tsx` than it previously was, since the new `coverZoom` memo needs it — moved its declaration up, no behaviour change to the value itself.)

## Background-image rooms

`calculateViewportScale` always used "contain" (picks the smaller of scaleX/scaleY, so content fits fully on screen but leaves a gap on the other axis). Added a `fitMode: 'contain' | 'cover'` param, defaulting to `'contain'` so every other caller (and the pre-existing `tests/viewportZoom.test.ts`, which asserts contain-shaped values) is unaffected — only `App.tsx`'s `viewportScale` memo now passes `'cover'`.

These rooms still don't pan with the player — **deliberately out of scope** for this PR. `docs/ARCHITECTURE_GOTCHAS.md` already documents "background-image rooms don't scroll" as an invariant several other systems (click-to-tile mapping, gridOffset, sprite positioning) depend on; introducing panning there is a bigger, riskier change that needs live-browser verification I didn't have this session.

## Tests

`tests/mapFillsScreen.test.ts` covers `getCoverZoom`, `getZoomLimitsForRoom`'s new param, and `calculateViewportScale`'s cover mode. `tests/cameraCoverage.test.ts` renders `useCamera` directly (jsdom) to confirm a coverZoom-raised zoom makes the camera follow the player instead of centring, and pans on whichever axis has crop room as the player moves.

**Note:** I could not verify this visually in a live browser this session (no Chrome connection available) — verified via typecheck and the new tests only. Worth a manual check across a few window sizes/aspect ratios before or after merging.

`make verify` green: typecheck clean, 553 tests across 51 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k