### PR TITLE
Fix Performance Tests workflow failing on every PR

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -11,6 +11,10 @@ concurrency:
   group: perf-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write # "Comment on PR" step posts/updates the performance report
+
 jobs:
   performance:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The workflow had no explicit `permissions:` block, so it inherited the repo/org default `GITHUB_TOKEN` scope. On `pull_request` triggers this wasn't enough for the "Comment on PR" step's `github.rest.issues.createComment()` call, which 403'd with `"Resource not accessible by integration"` and crashed the whole job — showing as a red X on every PR regardless of actual FPS results (the "Performance Grade: F" visible in the logs is a red herring; the job never got past the comment step to reach "Check for regressions").

`push` runs to main were unaffected since that step is skipped there (`if: github.event_name == 'pull_request'`) — which is exactly why the failure only ever showed up on PRs, never on main.

`deploy.yml` already declares explicit `permissions:` (contents/pages/id-token) for the same reason; `performance.yml` was just missing its own.

Added `permissions: { contents: read, pull-requests: write }` — the least scope the PR-comment step needs.

Can't unit-test a workflow permissions fix locally — this PR's own Performance Tests run is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k