### PR TITLE
Remove dev-only freebies from the real new-player starter inventory

### DIFF
--- a/tests/starterInventory.test.ts
+++ b/tests/starterInventory.test.ts
@@ -1,0 +1,76 @@
+/** @vitest-environment node */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { inventoryManager } from '../utils/inventoryManager';
+
+/**
+ * Regression: initializeStarterItems() ran unconditionally for every genuinely
+ * new player (utils/gameInitializer.ts, "No saved inventory found" branch — no
+ * DEBUG/dev gate), but three blocks were self-labelled as dev/testing leftovers:
+ *
+ * - `seed_fairy_bluebell` — commented "quest-locked in production", so handing
+ *   it out for free bypassed the fairy bluebells quest's intended gating.
+ * - Wreath workshop materials (maple_leaf, straw, crop_lavender, red_berries,
+ *   heather_sprig) — commented "TODO: remove after testing", bypassed the
+ *   wreath quest's material-gathering gameplay loop.
+ * - ~28 individual grocery ingredients at quantity 1 — commented "Add all
+ *   grocery ingredients for testing", clutter no real player was meant to start
+ *   with (they're meant to buy/forage/farm these).
+ *
+ * This doesn't assert the exact starter set (that's free to evolve) — just
+ * that these specific dev-only items don't silently creep back in.
+ */
+describe('initializeStarterItems (#audit)', () => {
+  const DEV_ONLY_ITEMS = [
+    'seed_fairy_bluebell',
+    'maple_leaf',
+    'straw',
+    'crop_lavender',
+    'red_berries',
+    'heather_sprig',
+    'milk',
+    'cream',
+    'butter',
+    'flour',
+    'yeast',
+    'meat',
+  ];
+
+  beforeEach(() => {
+    // Only stackable items support removeItem() — tools are permanent once
+    // acquired (removeItem() deliberately no-ops on them), so a
+    // while(hasItem) cleanup loop over a tool spins forever. Tools are
+    // idempotent to re-acquire (Set semantics), so there's nothing to clear.
+    for (const itemId of [
+      ...DEV_ONLY_ITEMS,
+      'seed_radish',
+      'seed_tomato',
+      'seed_salad',
+      'crop_blackberry',
+      'crop_radish',
+      'tea_leaves',
+      'water',
+    ]) {
+      while (inventoryManager.hasItem(itemId, 1)) {
+        inventoryManager.removeItem(itemId, 1);
+      }
+    }
+  });
+
+  it('does not give new players quest-locked or dev-testing-only items', () => {
+    inventoryManager.initializeStarterItems();
+
+    for (const itemId of DEV_ONLY_ITEMS) {
+      expect(inventoryManager.hasItem(itemId, 1)).toBe(false);
+    }
+  });
+
+  it('still gives the intended starter set (tools, seeds, tea ingredients)', () => {
+    inventoryManager.initializeStarterItems();
+
+    expect(inventoryManager.hasItem('tool_hoe', 1)).toBe(true);
+    expect(inventoryManager.hasItem('tool_watering_can', 1)).toBe(true);
+    expect(inventoryManager.hasItem('seed_radish', 1)).toBe(true);
+    expect(inventoryManager.hasItem('tea_leaves', 1)).toBe(true);
+    expect(inventoryManager.hasItem('water', 1)).toBe(true);
+  });
+});

--- a/utils/inventoryManager.ts
+++ b/utils/inventoryManager.ts
@@ -800,16 +800,6 @@ class InventoryManager {
     this.addItem('seed_tomato', 8);
     this.addItem('seed_salad', 20);
 
-    // DEV: Testing magical crops (quest-locked in production)
-    this.addItem('seed_fairy_bluebell', 5);
-
-    // DEV: Wreath workshop test materials (TODO: remove after testing)
-    this.addItem('maple_leaf', 10);
-    this.addItem('straw', 15);
-    this.addItem('crop_lavender', 5);
-    this.addItem('red_berries', 6);
-    this.addItem('heather_sprig', 8);
-
     // Start with some harvested crops/materials
     this.addItem('crop_blackberry', 12); // Wild berries
     this.addItem('crop_radish', 5);
@@ -817,36 +807,6 @@ class InventoryManager {
     // Start with cooking ingredients for tea (starter recipe)
     this.addItem('tea_leaves', 5);
     this.addItem('water', 10);
-
-    // DEV: Add all grocery ingredients for testing
-    this.addItem('milk', 1);
-    this.addItem('cream', 1);
-    this.addItem('butter', 1);
-    this.addItem('cheese', 1);
-    this.addItem('egg', 1);
-    this.addItem('flour', 1);
-    this.addItem('sugar', 1);
-    this.addItem('salt', 1);
-    this.addItem('yeast', 1);
-    this.addItem('olive_oil', 1);
-    this.addItem('vanilla', 1);
-    this.addItem('cinnamon', 1);
-    this.addItem('meat', 1);
-    this.addItem('minced_meat', 1);
-    this.addItem('pasta', 1);
-    this.addItem('bread', 1);
-    this.addItem('chocolate', 1);
-    this.addItem('almonds', 1);
-    this.addItem('strawberry_jam', 1);
-    this.addItem('basil', 1);
-    this.addItem('thyme', 1);
-    this.addItem('allspice', 1);
-    this.addItem('curry_powder', 1);
-    this.addItem('baking_powder', 1);
-    this.addItem('cocoa_powder', 1);
-    this.addItem('rice', 1);
-    this.addItem('tomato_tin', 1);
-    this.addItem('crop_tomato', 1);
   }
 }
 


### PR DESCRIPTION
`initializeStarterItems()` runs unconditionally for every genuinely new player (`gameInitializer.ts`'s "no saved inventory found" branch — no DEBUG/dev flag gate), but three blocks were self-labelled as leftover dev/testing code:

- `seed_fairy_bluebell` x5 — commented "quest-locked in production", so handing it out for free bypassed the fairy bluebells quest's intended gating.
- Wreath workshop materials (maple_leaf, straw, crop_lavender, red_berries, heather_sprig) — commented "TODO: remove after testing", bypassed the wreath quest's material-gathering gameplay loop.
- ~28 individual grocery ingredients at quantity 1 — commented "Add all grocery ingredients for testing"; real players are meant to buy/forage/farm these, not start with one of everything.

Kept everything not explicitly marked DEV: tools, basic farming seeds, the pre-harvested starter crops, and the tea-recipe ingredients.

## Tests

`tests/starterInventory.test.ts` guards against these creeping back in.

Along the way, discovered (in my own test's cleanup helper, not the product code) that `removeItem()` deliberately refuses to remove tools ("permanent once acquired") — a `while (hasItem(tool))` cleanup loop spins forever on one and OOMs. Not a product bug, just a trap worth documenting: tools are idempotent to re-acquire, so a test cleanup helper should just not try to clear them.

`make verify` green: typecheck clean, 555 tests across 52 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k