### PR TITLE
Replace inline Math.floor() tile-coord math with getTileCoords()

### DIFF
--- a/utils/actionHandlers.ts
+++ b/utils/actionHandlers.ts
@@ -85,8 +85,7 @@ export interface DeskInteractionResult {
  * Returns the closest desk with its position and state
  */
 export function checkDeskInteraction(playerPos: Position, mapId: string): DeskInteractionResult {
-  const playerTileX = Math.floor(playerPos.x);
-  const playerTileY = Math.floor(playerPos.y);
+  const { x: playerTileX, y: playerTileY } = getTileCoords(playerPos);
 
   // Check adjacent tiles (not diagonals - must be directly adjacent for desk use)
   const adjacentTiles = [
@@ -629,8 +628,7 @@ export function handleFarmAction(
  * Wells are 2x2 multi-tile sprites, so check current tile and adjacent tiles
  */
 export function checkWellInteraction(playerPos: Position): boolean {
-  const playerTileX = Math.floor(playerPos.x);
-  const playerTileY = Math.floor(playerPos.y);
+  const { x: playerTileX, y: playerTileY } = getTileCoords(playerPos);
 
   // Check player's current tile and adjacent tiles (including diagonals for 2x2 well)
   const tilesToCheck = [
@@ -661,8 +659,7 @@ export function checkWellInteraction(playerPos: Position): boolean {
  * Used for refilling the watering can
  */
 export function checkWaterSource(playerPos: Position): boolean {
-  const playerTileX = Math.floor(playerPos.x);
-  const playerTileY = Math.floor(playerPos.y);
+  const { x: playerTileX, y: playerTileY } = getTileCoords(playerPos);
 
   // Water source tile types
   const waterSourceTypes = [
@@ -751,8 +748,7 @@ export function handleCollectWater(): { success: boolean; message: string } {
  * Returns the type and position of the cooking location if found
  */
 export function checkCookingLocation(playerPos: Position): CookingLocationResult {
-  const playerTileX = Math.floor(playerPos.x);
-  const playerTileY = Math.floor(playerPos.y);
+  const { x: playerTileX, y: playerTileY } = getTileCoords(playerPos);
 
   // Check player's current tile and adjacent tiles (not diagonal)
   const tilesToCheck = [

--- a/utils/farmManager.ts
+++ b/utils/farmManager.ts
@@ -1157,8 +1157,7 @@ class FarmManager {
       if (plot.mapId !== mapId) continue;
       if (plot.state === FarmPlotState.FALLOW) continue;
 
-      const tileX = Math.floor(plot.position.x);
-      const tileY = Math.floor(plot.position.y);
+      const { x: tileX, y: tileY } = getTileCoords(plot.position);
       const baseTile = mapDef.grid[tileY]?.[tileX];
 
       if (baseTile !== TileType.SOIL_FALLOW) {
@@ -1238,8 +1237,7 @@ class FarmManager {
           // If the map was edited to remove farm tiles here, delete the stale Firestore record.
           const mapDef = mapManager.getMap(farmPlot.mapId);
           if (mapDef) {
-            const tileX = Math.floor(farmPlot.position.x);
-            const tileY = Math.floor(farmPlot.position.y);
+            const { x: tileX, y: tileY } = getTileCoords(farmPlot.position);
             const baseTile = mapDef.grid[tileY]?.[tileX];
             if (baseTile !== TileType.SOIL_FALLOW) {
               this.dirtySharedPlots.add(plotId);

--- a/utils/forageHandlers.ts
+++ b/utils/forageHandlers.ts
@@ -4,7 +4,14 @@
  */
 
 import { Position, TileType } from '../types';
-import { getTileData, findTileTypeNearby, hasTileTypeNearby, getLavaLakeAnchor, getSurroundingTiles } from './mapUtils';
+import {
+  getTileData,
+  getTileCoords,
+  findTileTypeNearby,
+  hasTileTypeNearby,
+  getLavaLakeAnchor,
+  getSurroundingTiles,
+} from './mapUtils';
 import { gameState } from '../GameState';
 import { inventoryManager } from './inventoryManager';
 import { characterData } from './CharacterData';
@@ -49,7 +56,7 @@ function findNearbySparrow(
     const dx = Math.abs(npc.position.x - playerTileX);
     const dy = Math.abs(npc.position.y - playerTileY);
     if (dx <= 3 && dy <= 3) {
-      return { x: Math.floor(npc.position.x), y: Math.floor(npc.position.y) };
+      return getTileCoords(npc.position);
     }
   }
   return null;
@@ -129,8 +136,7 @@ export function handleForageAction(playerPos: Position, currentMapId: string): F
     return { found: false, message: '' };
   }
 
-  const playerTileX = Math.floor(playerPos.x);
-  const playerTileY = Math.floor(playerPos.y);
+  const { x: playerTileX, y: playerTileY } = getTileCoords(playerPos);
   const tileData = getTileData(playerTileX, playerTileY);
 
   if (!tileData) {
@@ -589,7 +595,7 @@ export function handleForageAction(playerPos: Position, currentMapId: string): F
     if (season !== Season.AUTUMN) {
       const msg =
         season === Season.WINTER
-          ? "The heather is buried under the frost. It blooms in autumn."
+          ? 'The heather is buried under the frost. It blooms in autumn.'
           : "The heather isn't in bloom yet. Come back in autumn.";
       return { found: false, message: msg, outOfSeason: true };
     }
@@ -885,7 +891,8 @@ export function handleForageAction(playerPos: Position, currentMapId: string): F
     if (season !== Season.AUTUMN) {
       return {
         found: false,
-        message: 'The meadow grass is too green and lush to gather. Come back in autumn when it has dried.',
+        message:
+          'The meadow grass is too green and lush to gather. Come back in autumn when it has dried.',
         outOfSeason: true,
       };
     }
@@ -991,12 +998,20 @@ export function handleForageAction(playerPos: Position, currentMapId: string): F
     if (season !== Season.WINTER) {
       return {
         found: false,
-        message: 'The spruce tree holds its branches tight. In winter, fallen sprigs can be gathered from beneath.',
+        message:
+          'The spruce tree holds its branches tight. In winter, fallen sprigs can be gathered from beneath.',
         outOfSeason: true,
       };
     }
 
-    if (gameState.isForageTileOnCooldown(currentMapId, spruceAnchor.x, spruceAnchor.y, TIMING.FORAGE_COOLDOWN_MS)) {
+    if (
+      gameState.isForageTileOnCooldown(
+        currentMapId,
+        spruceAnchor.x,
+        spruceAnchor.y,
+        TIMING.FORAGE_COOLDOWN_MS
+      )
+    ) {
       return { found: false, message: "You've already gathered from this tree today." };
     }
 
@@ -1011,7 +1026,10 @@ export function handleForageAction(playerPos: Position, currentMapId: string): F
 
     if (!succeeded) {
       gameState.recordForage(currentMapId, spruceAnchor.x, spruceAnchor.y);
-      return { found: false, message: 'You search beneath the spruce, but find no suitable sprigs.' };
+      return {
+        found: false,
+        message: 'You search beneath the spruce, but find no suitable sprigs.',
+      };
     }
 
     const quantityFound = rollForageQuantity();
@@ -1574,8 +1592,7 @@ export function handleForageAction(playerPos: Position, currentMapId: string): F
  * Does not drain stamina — caller is responsible.
  */
 export function handleBlackberryHarvest(playerPos: Position, currentMapId: string): ForageResult {
-  const playerTileX = Math.floor(playerPos.x);
-  const playerTileY = Math.floor(playerPos.y);
+  const { x: playerTileX, y: playerTileY } = getTileCoords(playerPos);
 
   for (const tile of getSurroundingTiles({ x: playerTileX, y: playerTileY })) {
     const tileData = getTileData(tile.x, tile.y);
@@ -1608,8 +1625,7 @@ export function handleBlackberryHarvest(playerPos: Position, currentMapId: strin
  * Does not drain stamina — caller is responsible.
  */
 export function handleHazelnutHarvest(playerPos: Position, currentMapId: string): ForageResult {
-  const playerTileX = Math.floor(playerPos.x);
-  const playerTileY = Math.floor(playerPos.y);
+  const { x: playerTileX, y: playerTileY } = getTileCoords(playerPos);
 
   for (const tile of getSurroundingTiles({ x: playerTileX, y: playerTileY })) {
     const tileData = getTileData(tile.x, tile.y);
@@ -1618,7 +1634,11 @@ export function handleHazelnutHarvest(playerPos: Position, currentMapId: string)
     const { season } = TimeManager.getCurrentTime();
     if (season !== Season.AUTUMN) {
       if (DEBUG.FORAGE) console.log(`[Forage] Hazel bush out of season (${season})`);
-      return { found: false, message: 'The hazel bushes have no ripe nuts yet.', outOfSeason: true };
+      return {
+        found: false,
+        message: 'The hazel bushes have no ripe nuts yet.',
+        outOfSeason: true,
+      };
     }
 
     if (gameState.isForageTileOnCooldown(currentMapId, tile.x, tile.y, TIMING.FORAGE_COOLDOWN_MS)) {
@@ -1642,8 +1662,7 @@ export function handleHazelnutHarvest(playerPos: Position, currentMapId: string)
  * Does not drain stamina — caller is responsible.
  */
 export function handleBlueberryHarvest(playerPos: Position, currentMapId: string): ForageResult {
-  const playerTileX = Math.floor(playerPos.x);
-  const playerTileY = Math.floor(playerPos.y);
+  const { x: playerTileX, y: playerTileY } = getTileCoords(playerPos);
 
   for (const tile of getSurroundingTiles({ x: playerTileX, y: playerTileY })) {
     const tileData = getTileData(tile.x, tile.y);
@@ -1652,7 +1671,11 @@ export function handleBlueberryHarvest(playerPos: Position, currentMapId: string
     const { season } = TimeManager.getCurrentTime();
     if (season !== Season.SUMMER && season !== Season.AUTUMN) {
       if (DEBUG.FORAGE) console.log(`[Forage] Blueberry bush out of season (${season})`);
-      return { found: false, message: 'The blueberry bushes have no ripe berries yet.', outOfSeason: true };
+      return {
+        found: false,
+        message: 'The blueberry bushes have no ripe berries yet.',
+        outOfSeason: true,
+      };
     }
 
     if (gameState.isForageTileOnCooldown(currentMapId, tile.x, tile.y, TIMING.FORAGE_COOLDOWN_MS)) {
@@ -1676,8 +1699,7 @@ export function handleBlueberryHarvest(playerPos: Position, currentMapId: string
  * Does not drain stamina — caller is responsible.
  */
 export function handleRedBerryHarvest(playerPos: Position, currentMapId: string): ForageResult {
-  const playerTileX = Math.floor(playerPos.x);
-  const playerTileY = Math.floor(playerPos.y);
+  const { x: playerTileX, y: playerTileY } = getTileCoords(playerPos);
 
   for (const tile of getSurroundingTiles({ x: playerTileX, y: playerTileY })) {
     const tileData = getTileData(tile.x, tile.y);
@@ -1686,7 +1708,11 @@ export function handleRedBerryHarvest(playerPos: Position, currentMapId: string)
     const { season } = TimeManager.getCurrentTime();
     if (season !== Season.AUTUMN) {
       if (DEBUG.FORAGE) console.log(`[Forage] Hawthorn bush out of season (${season})`);
-      return { found: false, message: 'The hawthorn bush has no ripe berries yet.', outOfSeason: true };
+      return {
+        found: false,
+        message: 'The hawthorn bush has no ripe berries yet.',
+        outOfSeason: true,
+      };
     }
 
     if (gameState.isForageTileOnCooldown(currentMapId, tile.x, tile.y, TIMING.FORAGE_COOLDOWN_MS)) {

--- a/utils/interactions/index.ts
+++ b/utils/interactions/index.ts
@@ -8,7 +8,7 @@
  * under ./providers/ — see ./README.md before adding one.
  */
 
-import { getTileData } from '../mapUtils';
+import { getTileData, getTileCoords } from '../mapUtils';
 import { gameState } from '../../GameState';
 import { getItem } from '../../data/items';
 import { INTERACTION_PROVIDERS } from './registry';
@@ -60,8 +60,7 @@ function findItemAtPosition(
 
 /** Build the context shared by every provider. */
 function createInteractionContext(config: GetInteractionsConfig): InteractionContext {
-  const tileX = Math.floor(config.position.x);
-  const tileY = Math.floor(config.position.y);
+  const { x: tileX, y: tileY } = getTileCoords(config.position);
   const placedItems = gameState.getPlacedItems(config.currentMapId);
 
   return {


### PR DESCRIPTION
CLAUDE.md documents `mapUtils.ts`'s `getTileCoords(pos)` as the standard way to convert a world position to tile coordinates, specifically calling out inline `Math.floor()` as the pattern to avoid. Ten call sites across `actionHandlers.ts`, `forageHandlers.ts`, `farmManager.ts` and `interactions/index.ts` (`createInteractionContext`, the shared context builder every interaction provider goes through) still hand-rolled it.

Purely mechanical — same values, same downstream variable names (`{ x: tileX, y: tileY } = getTileCoords(pos)` in place of two separate `Math.floor()` calls), no behaviour change.

`make verify` green: typecheck clean, 553 tests across 51 files pass (same count as before — this doesn't add coverage, just removes duplication the existing tests already exercise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k