### PR TITLE
Add a title screen shown before the game loads

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,6 +12,7 @@ import { usePixiRenderer } from './hooks/usePixiRenderer';
 import HUD from './components/HUD';
 import DebugOverlay from './components/DebugOverlay';
 import CharacterCreator from './components/CharacterCreator';
+import SplashScreen from './components/SplashScreen';
 import TouchControls from './components/TouchControls';
 import UnifiedDialogueBox from './components/dialogue/UnifiedDialogueBox';
 import HelpBrowser from './components/HelpBrowser';
@@ -172,6 +173,12 @@ import { useProximityQuestTriggers } from './hooks/useProximityQuestTriggers';
 const App: React.FC = () => {
   // Consolidated UI overlay state (inventory, cooking, shop, etc.)
   const { ui, openUI, closeUI, closeAllUI, toggleUI, isAnyBookOpen } = useUIState();
+
+  // Title screen shown before anything else. Purely a UI gate — game asset
+  // loading (the effect a few lines below) already starts on mount regardless,
+  // so by the time the player clicks Play a returning session may already be
+  // ready to go straight into gameplay.
+  const [showSplashScreen, setShowSplashScreen] = useState(true);
 
   const [isMapInitialized, setIsMapInitialized] = useState(false);
   const [mapErrors, setMapErrors] = useState<MapValidationError[]>([]); // Map validation errors to display
@@ -1770,6 +1777,13 @@ const App: React.FC = () => {
         </div>
       </div>
     );
+  }
+
+  // Title screen — shown first, ahead of map/asset loading (which is already
+  // running in the background regardless). Map validation errors above still
+  // take priority so a developer sees them immediately without an extra click.
+  if (showSplashScreen) {
+    return <SplashScreen onPlay={() => setShowSplashScreen(false)} />;
   }
 
   // Loading screen: show cutscene if active, otherwise simple text

--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -1,0 +1,100 @@
+/**
+ * SplashScreen - Title screen shown before the game starts loading.
+ *
+ * Purely presentational: a season-appropriate scenic backdrop (reusing the
+ * existing cutscene background art, not new assets), the game's name, and
+ * a Play button. Also offers Help (opens the in-game F1 documentation
+ * browser) as a self-contained overlay, so this component has no dependency
+ * on the rest of App.tsx's UI state machine — it can render at the very top
+ * of the component tree, before map/asset loading has even started.
+ */
+
+import React, { useState } from 'react';
+import HelpBrowser from './HelpBrowser';
+import { TimeManager, Season } from '../utils/TimeManager';
+
+interface SplashScreenProps {
+  onPlay: () => void;
+}
+
+const SEASON_BACKGROUNDS: Record<Season, string> = {
+  [Season.SPRING]: 'cutscene_spring_background.png',
+  [Season.SUMMER]: 'cutscene_summer_background.png',
+  [Season.AUTUMN]: 'cutscene_autumn_background.png',
+  [Season.WINTER]: 'cutscene_winter_background.png',
+};
+
+const TITLE_FONT = 'Georgia, "Times New Roman", serif';
+
+const SplashScreen: React.FC<SplashScreenProps> = ({ onPlay }) => {
+  const [showHelp, setShowHelp] = useState(false);
+
+  // Read the season fresh on each mount rather than memoising — the splash
+  // only mounts once per page load, so there's no benefit to memoising and
+  // it always reflects "right now" if the player reloads later in the day.
+  const season = TimeManager.getCurrentTime().season;
+  const backgroundFile = SEASON_BACKGROUNDS[season] ?? SEASON_BACKGROUNDS[Season.SPRING];
+  const backgroundUrl = `/TwilightGame/assets-optimized/cutscenes/${backgroundFile}`;
+
+  if (showHelp) {
+    return <HelpBrowser onClose={() => setShowHelp(false)} />;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 w-full h-full flex flex-col items-center justify-end select-none"
+      style={{
+        backgroundImage: `url(${backgroundUrl})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+      }}
+    >
+      {/* Bottom gradient so the title/buttons stay legible over any background */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            'linear-gradient(to bottom, rgba(20,15,10,0) 40%, rgba(20,15,10,0.55) 75%, rgba(20,15,10,0.85) 100%)',
+        }}
+      />
+
+      <div className="relative z-10 flex flex-col items-center gap-2 pb-6">
+        <h1
+          className="text-6xl sm:text-7xl font-bold text-amber-50 tracking-wide"
+          style={{
+            fontFamily: TITLE_FONT,
+            textShadow: '0 3px 12px rgba(0,0,0,0.6), 0 1px 3px rgba(0,0,0,0.8)',
+          }}
+        >
+          Twilight Village
+        </h1>
+        <p
+          className="text-base sm:text-lg text-amber-100/90 mb-4"
+          style={{ fontFamily: TITLE_FONT, textShadow: '0 1px 4px rgba(0,0,0,0.7)' }}
+        >
+          A peaceful place where time flows gently with the seasons
+        </p>
+
+        <button
+          onClick={onPlay}
+          className="px-10 py-3 text-lg text-amber-100 bg-amber-800/70 border border-amber-600/60 rounded-lg
+            hover:bg-amber-700/80 hover:border-amber-500/70 transition-all duration-300
+            animate-pulse hover:animate-none cursor-pointer shadow-lg"
+          style={{ fontFamily: TITLE_FONT }}
+        >
+          Play
+        </button>
+
+        <button
+          onClick={() => setShowHelp(true)}
+          className="mt-3 text-sm text-amber-100/70 hover:text-amber-100 transition-colors duration-200 cursor-pointer underline underline-offset-4"
+          style={{ fontFamily: TITLE_FONT }}
+        >
+          Help
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SplashScreen;

--- a/tests/splashScreen.test.tsx
+++ b/tests/splashScreen.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * Smoke test for SplashScreen — the first component test in this repo (the
+ * suite has otherwise been logic-level: utils/hooks/data, no React Testing
+ * Library renders). Written specifically because Chrome tooling wasn't
+ * available this session to visually confirm the new title screen renders —
+ * this at least catches a render-time crash (bad import, missing prop,
+ * undefined access) and confirms the two interactive paths (Play, Help)
+ * actually fire, which typecheck alone wouldn't catch.
+ *
+ * Uses jsdom (the project default environment).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SplashScreen from '../components/SplashScreen';
+
+describe('SplashScreen', () => {
+  it('renders the title and a Play button without throwing', () => {
+    render(<SplashScreen onPlay={() => {}} />);
+    expect(screen.getByText('Twilight Village')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument();
+  });
+
+  it('calls onPlay when the Play button is clicked', () => {
+    const onPlay = vi.fn();
+    render(<SplashScreen onPlay={onPlay} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+
+    expect(onPlay).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the Help browser in place of the splash when Help is clicked, without calling onPlay', () => {
+    const onPlay = vi.fn();
+    render(<SplashScreen onPlay={onPlay} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Help' }));
+
+    // HelpBrowser rendered instead — its own close control appears, the
+    // splash's Play button no longer does, and onPlay was never invoked.
+    expect(screen.queryByRole('button', { name: 'Play' })).not.toBeInTheDocument();
+    expect(onPlay).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The game previously loaded straight into a save (or new-character creation) with no title/welcome screen. Adds one, reusing existing art rather than requiring new assets — no dedicated logo/title graphic exists in the repo, but the seasonal cutscene background paintings (`public/assets-optimized/cutscenes/cutscene_<season>_background.png`, already used by the season-change cutscenes) work well as a full-bleed backdrop and happen to make the splash season-aware for free.

## Design

Since this was an open-ended "what would you suggest" ask:

- Full-screen backdrop (today's real season) + "Twilight Village" title (matches the in-fiction name already used in `docs/GETTING_STARTED.md` and the intro cutscene — the game has no separate branded title) + a **Play** button styled to match the existing "Enter Game" button.
- A secondary **Help** button, self-contained (renders `HelpBrowser` directly, no dependency on `App.tsx`'s UI state machine) so the whole component can sit at the very top of the render tree, before any map/asset loading state exists.
- Deliberately **not** a full main menu (no New Game / Continue / Settings branching) — that would need to branch save-loading logic and is a bigger, separate piece of work. This is purely a UI gate: asset loading already starts on mount regardless, so a returning player may already be most of the way loaded by the time they click Play.
- Map validation errors (dev-only) still take priority and show immediately, ahead of the splash, so a broken map definition doesn't require an extra click to see.

## Verification — please give this one a manual look

No Chrome connection was available this session, so I could not visually confirm this in a browser — a real gap for a brand-new UI surface. What I did verify: typecheck clean, the dev server boots without error, and (via curl against the running dev server) all four season background image paths actually resolve to 200s — the most likely thing to have gotten wrong. `tests/splashScreen.test.tsx` (the first `.tsx` component test in this repo — everything else is logic-level) renders it with React Testing Library and confirms it doesn't crash, Play fires its callback, and Help swaps in the HelpBrowser.

I'd treat this PR as needing an actual browser pass before or shortly after merging, more so than the others this session.

`make verify` green: typecheck clean, 570 tests across 54 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k