### PR TITLE
Fix swapped mess-pile hitboxes and stale service-worker caching

### DIFF
--- a/data/questHandlers/mrFoxPicnicHandler.ts
+++ b/data/questHandlers/mrFoxPicnicHandler.ts
@@ -40,10 +40,15 @@ export interface MessPilePosition {
   description: string;
 }
 
+// NOTE: pile 0's artwork (shed_interior_mess1.png) is actually painted on the
+// right of the shed backdrop, and pile 2's artwork (shed_interior_mess3.png)
+// on the left — the opposite of what their ids would suggest. relativeX below
+// is calibrated to where the clutter is actually drawn, not to the id order,
+// so clicking a pile clears the pile that's visibly there.
 export const MESS_PILE_POSITIONS: MessPilePosition[] = [
-  { id: 0, relativeX: 0.20, relativeY: 0.47, radius: 0.12, description: 'Left floor pile' },
+  { id: 0, relativeX: 0.8, relativeY: 0.47, radius: 0.12, description: 'Right floor pile' },
   { id: 1, relativeX: 0.49, relativeY: 0.47, radius: 0.12, description: 'Centre floor pile' },
-  { id: 2, relativeX: 0.80, relativeY: 0.47, radius: 0.12, description: 'Right floor pile' },
+  { id: 2, relativeX: 0.2, relativeY: 0.47, radius: 0.12, description: 'Left floor pile' },
 ];
 
 // ============================================================================
@@ -174,7 +179,8 @@ export function checkShedComplete(): void {
 
     // Advance quest
     eventChainManager.advanceToStage(QUEST_ID, 'blanket_obtained');
-    if (DEBUG.QUEST) console.log('[MrFoxPicnic] Shed clean — blanket awarded, advancing to blanket_obtained');
+    if (DEBUG.QUEST)
+      console.log('[MrFoxPicnic] Shed clean — blanket awarded, advancing to blanket_obtained');
   }
 }
 
@@ -192,7 +198,8 @@ export function handleBlanketGiven(): void {
   eventBus.emit(GameEvent.INVENTORY_CHANGED, { action: 'remove', itemId: 'quest_picnic_blanket' });
 
   eventChainManager.advanceToStage(QUEST_ID, 'cooking_problem');
-  if (DEBUG.QUEST) console.log('[MrFoxPicnic] Blanket given to Mr Fox, advancing to cooking_problem');
+  if (DEBUG.QUEST)
+    console.log('[MrFoxPicnic] Blanket given to Mr Fox, advancing to cooking_problem');
 }
 
 // ============================================================================
@@ -270,9 +277,9 @@ export function handleQuestComplete(): void {
 // as a placed item in Mum's kitchen so the player can pick it up and fill it.
 handlerRegistry.register(QUEST_ID, 'filling_basket', async (_chainId, _stageId, _ctx) => {
   // Only spawn once — check if basket already exists on the map
-  const existing = gameState.getPlacedItems('mums_kitchen').find(
-    (item) => item.itemId === 'quest_picnic_basket'
-  );
+  const existing = gameState
+    .getPlacedItems('mums_kitchen')
+    .find((item) => item.itemId === 'quest_picnic_basket');
   if (existing) return;
 
   gameState.addPlacedItem({

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,21 @@
 // Service Worker for Twilight Game PWA
-const CACHE_NAME = 'twilight-game-v1';
+const CACHE_NAME = 'twilight-game-v2';
 const urlsToCache = [
   '/TwilightGame/',
   '/TwilightGame/index.html',
 ];
+
+// Requests we must always try the network for first: the HTML shell and any
+// navigation. index.html isn't content-hashed, and it's what points the
+// browser at the current build's hashed JS/CSS bundle names — serving a
+// stale cached copy of it (cache-first, as this worker used to do) leaves
+// returning players stuck on whatever version was cached on their first
+// visit, forever, since a byte-identical cached response never expires here.
+// Everything else Vite emits (the hashed asset filenames under /assets/) is
+// safe to cache-first, since a given filename's content never changes.
+function isNavigationOrShell(request) {
+  return request.mode === 'navigate' || request.url.endsWith('/index.html');
+}
 
 // Install event - cache initial resources
 self.addEventListener('install', (event) => {
@@ -29,26 +41,39 @@ self.addEventListener('activate', (event) => {
   );
 });
 
-// Fetch event - serve from cache, fallback to network
 self.addEventListener('fetch', (event) => {
+  if (isNavigationOrShell(event.request)) {
+    // Network-first: always get the latest build when online; only fall
+    // back to whatever's cached if the network request fails (offline).
+    event.respondWith(
+      fetch(event.request)
+        .then((response) => {
+          if (response && response.status === 200 && response.type === 'basic') {
+            const responseToCache = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseToCache));
+          }
+          return response;
+        })
+        .catch(() => caches.match(event.request))
+    );
+    return;
+  }
+
+  // Cache-first for everything else (content-hashed assets, images, etc.)
   event.respondWith(
     caches.match(event.request)
       .then((response) => {
-        // Cache hit - return response
         if (response) {
           return response;
         }
 
-        // Clone the request
         const fetchRequest = event.request.clone();
 
         return fetch(fetchRequest).then((response) => {
-          // Check if valid response
           if (!response || response.status !== 200 || response.type !== 'basic') {
             return response;
           }
 
-          // Clone the response
           const responseToCache = response.clone();
 
           caches.open(CACHE_NAME)

--- a/tests/messPileHitboxes.test.ts
+++ b/tests/messPileHitboxes.test.ts
@@ -1,0 +1,46 @@
+/** @vitest-environment node */
+/**
+ * Regression test for the mess-pile hit-detection bug in the seed shed
+ * (Mr Fox's Picnic quest): clicking the pile that's visually on the right
+ * was clearing the pile drawn on the left, and vice versa.
+ *
+ * Root cause: pile 0's artwork (shed_interior_mess1.png) is actually painted
+ * on the right of the shed backdrop, and pile 2's artwork
+ * (shed_interior_mess3.png) on the left — the opposite of what
+ * MESS_PILE_POSITIONS' relativeX/description said. checkMessPileClick()
+ * itself was always correct; only the position data was wrong.
+ */
+import { describe, it, expect } from 'vitest';
+import { checkMessPileClick } from '../utils/messInteractions';
+import { MESS_PILE_POSITIONS } from '../data/questHandlers/mrFoxPicnicHandler';
+
+// Simple 1x1 image bounds so screen coords equal relative coords.
+const IMAGE_LEFT = 0;
+const IMAGE_TOP = 0;
+const IMAGE_WIDTH = 1;
+const IMAGE_HEIGHT = 1;
+
+describe('mess pile hitboxes', () => {
+  it('pile 0 (shed_interior_mess1.png) is hit on the right of the image', () => {
+    const result = checkMessPileClick(0.8, 0.47, IMAGE_LEFT, IMAGE_TOP, IMAGE_WIDTH, IMAGE_HEIGHT);
+    expect(result.hit).toBe(true);
+    expect(result.pileIndex).toBe(0);
+  });
+
+  it('pile 2 (shed_interior_mess3.png) is hit on the left of the image', () => {
+    const result = checkMessPileClick(0.2, 0.47, IMAGE_LEFT, IMAGE_TOP, IMAGE_WIDTH, IMAGE_HEIGHT);
+    expect(result.hit).toBe(true);
+    expect(result.pileIndex).toBe(2);
+  });
+
+  it('pile 1 (shed_interior_mess2.png) stays centred', () => {
+    const result = checkMessPileClick(0.49, 0.47, IMAGE_LEFT, IMAGE_TOP, IMAGE_WIDTH, IMAGE_HEIGHT);
+    expect(result.hit).toBe(true);
+    expect(result.pileIndex).toBe(1);
+  });
+
+  it('every pile position is unique so hitboxes cannot silently overlap', () => {
+    const xs = MESS_PILE_POSITIONS.map((p) => p.relativeX);
+    expect(new Set(xs).size).toBe(xs.length);
+  });
+});


### PR DESCRIPTION
Two bugs reported after the splash-screen release:

1. **Seed shed "tidy up" mini-game**: clicking the mess pile on the right cleared a pile on the left, and vice versa. `checkMessPileClick()` itself was correct — the bug was in `MESS_PILE_POSITIONS` (`data/questHandlers/mrFoxPicnicHandler.ts`): pile id 0's artwork (`shed_interior_mess1.png`) is actually painted on the **right** of the shed backdrop, and pile id 2's (`shed_interior_mess3.png`) on the **left** — opposite of their coded `relativeX`/description. Swapped the two so the hitboxes match where the art actually is. Added `tests/messPileHitboxes.test.ts`.

2. **Splash screen (#48) invisible to a returning player**: reported as "blank screen, then the season cutscene" — i.e. the old pre-splash flow. Root cause: `public/sw.js` cached `index.html` cache-first under a `CACHE_NAME` that never changes across deploys. Once a browser has visited once, it can be stuck serving that first visit's exact HTML (and the hashed JS bundle it points at) forever — a cache hit never expires or revalidates, so no future deploy reaches it while online. Changed navigation/`index.html` requests to network-first (cache is only a fallback when offline); content-hashed asset files stay cache-first since a given filename's bytes never change. Bumped `CACHE_NAME` so existing installs also drop the stale entry.

`make verify`: typecheck clean, 574 tests across 55 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k