### PR TITLE
Play seasonal village music on the title screen

### DIFF
--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -9,9 +9,10 @@
  * of the component tree, before map/asset loading has even started.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import HelpBrowser from './HelpBrowser';
 import { TimeManager, Season } from '../utils/TimeManager';
+import { audioManager } from '../utils/AudioManager';
 
 interface SplashScreenProps {
   onPlay: () => void;
@@ -22,6 +23,19 @@ const SEASON_BACKGROUNDS: Record<Season, string> = {
   [Season.SUMMER]: 'cutscene_summer_background.png',
   [Season.AUTUMN]: 'cutscene_autumn_background.png',
   [Season.WINTER]: 'cutscene_winter_background.png',
+};
+
+// Reuses the same village theme (and seasonal variants) the village map
+// itself plays — there's no dedicated title track yet, but this is the
+// game's most "peaceful home base" music, which fits a title screen well.
+// Every key here is always loaded by gameInitializer's audioAssets batch, so
+// no readiness check is needed: playMusic() queues and auto-starts once the
+// batch finishes loading, same as the ambient sound calls elsewhere.
+const SEASON_MUSIC: Record<Season, string> = {
+  [Season.SPRING]: 'music_village',
+  [Season.SUMMER]: 'music_village_summer',
+  [Season.AUTUMN]: 'music_village_autumn',
+  [Season.WINTER]: 'music_village_winter',
 };
 
 const TITLE_FONT = 'Georgia, "Times New Roman", serif';
@@ -35,6 +49,19 @@ const SplashScreen: React.FC<SplashScreenProps> = ({ onPlay }) => {
   const season = TimeManager.getCurrentTime().season;
   const backgroundFile = SEASON_BACKGROUNDS[season] ?? SEASON_BACKGROUNDS[Season.SPRING];
   const backgroundUrl = `/TwilightGame/assets-optimized/cutscenes/${backgroundFile}`;
+
+  // Music plays for as long as the splash (title card + Help) is mounted,
+  // and fades out once the player presses Play — the in-game ambient music
+  // system (useEnvironmentController) runs on its own random schedule rather
+  // than looping continuously, so there's no guarantee anything else fades
+  // in to cover an abrupt stop.
+  useEffect(() => {
+    audioManager.playMusic(SEASON_MUSIC[season] ?? 'music_village', { fadeIn: 1500 });
+    return () => {
+      audioManager.stopMusic(800);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- play once per mount, not on season re-reads
+  }, []);
 
   if (showHelp) {
     return <HelpBrowser onClose={() => setShowHelp(false)} />;


### PR DESCRIPTION
Adds music to the splash screen (#48), reusing existing tracks rather than adding a new one.

## What it plays

`music_village` / `music_village_summer` / `_autumn` / `_winter` — the same seasonal village tracks the village map itself already plays via `useEnvironmentController`. There's no dedicated title theme in the asset library yet, and this is already the game's "peaceful home base" music, which fits the splash's tone.

## Why no readiness check before calling playMusic()

All four keys are always present in `gameInitializer`'s `audioAssets` batch load. `AudioManager.playMusic()` already queues a request and auto-starts it once loading finishes if the sound isn't ready yet — the same pattern the ambient sound effects rely on elsewhere — so no `hasSound()` guard is needed here.

## Lifecycle

- Fades in (1.5s) on mount.
- Keeps playing behind the Help browser (a state toggle inside the same mounted `SplashScreen`, not an unmount).
- Fades out (0.8s) when the splash unmounts, i.e. when Play is pressed. The in-game ambient music system plays on its own random 8–20 minute schedule rather than looping continuously, so nothing was guaranteed to crossfade in and cover an abrupt stop otherwise.

## Autoplay

Browsers block audio until a user gesture. `useEnvironmentController` already attaches a document-wide click/touch/keydown listener that resumes the `AudioContext` — it runs on every render, including while the splash is showing — so the first click (Play, Help, anywhere) unlocks audio. No new listener needed.

`make verify`: typecheck clean, 574 tests across 55 files pass. As with #48, I couldn't listen to this in a live browser this session (no Chrome connection) — worth a quick manual listen after merging to confirm the seasonal pick and volume levels feel right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k