### PR TITLE
Fix splash screen blocking game init; rename village to Clover Village

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1712,10 +1712,30 @@ const App: React.FC = () => {
     onShowToast: showToast,
   });
 
+  // Title screen overlay. Deliberately NOT an early return: map/asset loading
+  // (including mounting the PixiJS canvas below, once isMapInitialized flips
+  // true) must keep proceeding on its normal schedule underneath while the
+  // splash is up, exactly as it would with no splash at all. An early return
+  // here previously blocked the canvas from ever mounting until Play was
+  // pressed, which could leave the game stuck on a black screen with a frozen
+  // loading bar once the splash *was* dismissed — the canvas-mounting effects
+  // had already run once against a canvas that didn't exist yet, and never
+  // got a reason to retry. SplashScreen renders itself as a fixed,
+  // high-z-index overlay, so it just needs to be painted alongside whichever
+  // branch below is currently rendering, not returned instead of it.
+  const splashOverlay = showSplashScreen ? (
+    <SplashScreen onPlay={() => setShowSplashScreen(false)} />
+  ) : null;
+
   // Show character creator as full-screen replacement only on first launch (before map loads)
   // When opened mid-game (via settings), it renders as an overlay further below
   if (ui.characterCreator && !isMapInitialized) {
-    return <CharacterCreator onComplete={handleCharacterCreated} />;
+    return (
+      <>
+        <CharacterCreator onComplete={handleCharacterCreated} />
+        {splashOverlay}
+      </>
+    );
   }
 
   // Show validation errors screen if there are map errors
@@ -1775,15 +1795,9 @@ const App: React.FC = () => {
             <li>Save the file - HMR will reload automatically</li>
           </ol>
         </div>
+        {splashOverlay}
       </div>
     );
-  }
-
-  // Title screen — shown first, ahead of map/asset loading (which is already
-  // running in the background regardless). Map validation errors above still
-  // take priority so a developer sees them immediately without an extra click.
-  if (showSplashScreen) {
-    return <SplashScreen onPlay={() => setShowSplashScreen(false)} />;
   }
 
   // Loading screen: show cutscene if active, otherwise simple text
@@ -1799,6 +1813,7 @@ const App: React.FC = () => {
               style={{ width: `${loadingProgress * 100}%` }}
             />
           </div>
+          {splashOverlay}
         </div>
       );
     }
@@ -1812,12 +1827,14 @@ const App: React.FC = () => {
               style={{ width: `${loadingProgress * 100}%` }}
             />
           </div>
+          {splashOverlay}
         </div>
       );
     }
     return (
       <div className="bg-gray-900 text-white w-full h-full flex items-center justify-center">
         Loading map...
+        {splashOverlay}
       </div>
     );
   }
@@ -2848,6 +2865,8 @@ const App: React.FC = () => {
 
       {/* Character creator overlay (mid-game, via settings button) */}
       {ui.characterCreator && <CharacterCreator onComplete={handleCharacterCreated} />}
+
+      {splashOverlay}
     </div>
   );
 };

--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -13,6 +13,7 @@ import React, { useEffect, useState } from 'react';
 import HelpBrowser from './HelpBrowser';
 import { TimeManager, Season } from '../utils/TimeManager';
 import { audioManager } from '../utils/AudioManager';
+import { Z_SPLASH_SCREEN, zClass } from '../zIndex';
 
 interface SplashScreenProps {
   onPlay: () => void;
@@ -63,63 +64,72 @@ const SplashScreen: React.FC<SplashScreenProps> = ({ onPlay }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- play once per mount, not on season re-reads
   }, []);
 
-  if (showHelp) {
-    return <HelpBrowser onClose={() => setShowHelp(false)} />;
-  }
-
+  // Wrapped in its own fixed, high-z-index root: this renders alongside the
+  // game underneath (which keeps loading/initialising the whole time — see
+  // App.tsx), not in place of it, so it must out-rank every other overlay
+  // (including the loading screen and its own "Enter Game" gate) to stay on
+  // top. The wrapper also gives HelpBrowser (rendered inside it, below, at
+  // its own normal z-index) a fresh local stacking context, so it isn't
+  // compared against the game's z-indexed overlays directly.
   return (
-    <div
-      className="fixed inset-0 w-full h-full flex flex-col items-center justify-end select-none"
-      style={{
-        backgroundImage: `url(${backgroundUrl})`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-      }}
-    >
-      {/* Bottom gradient so the title/buttons stay legible over any background */}
-      <div
-        className="absolute inset-0"
-        style={{
-          background:
-            'linear-gradient(to bottom, rgba(20,15,10,0) 40%, rgba(20,15,10,0.55) 75%, rgba(20,15,10,0.85) 100%)',
-        }}
-      />
-
-      <div className="relative z-10 flex flex-col items-center gap-2 pb-6">
-        <h1
-          className="text-6xl sm:text-7xl font-bold text-amber-50 tracking-wide"
+    <div className={`fixed inset-0 ${zClass(Z_SPLASH_SCREEN)}`}>
+      {showHelp ? (
+        <HelpBrowser onClose={() => setShowHelp(false)} />
+      ) : (
+        <div
+          className="fixed inset-0 w-full h-full flex flex-col items-center justify-end select-none"
           style={{
-            fontFamily: TITLE_FONT,
-            textShadow: '0 3px 12px rgba(0,0,0,0.6), 0 1px 3px rgba(0,0,0,0.8)',
+            backgroundImage: `url(${backgroundUrl})`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
           }}
         >
-          Twilight Village
-        </h1>
-        <p
-          className="text-base sm:text-lg text-amber-100/90 mb-4"
-          style={{ fontFamily: TITLE_FONT, textShadow: '0 1px 4px rgba(0,0,0,0.7)' }}
-        >
-          A peaceful place where time flows gently with the seasons
-        </p>
+          {/* Bottom gradient so the title/buttons stay legible over any background */}
+          <div
+            className="absolute inset-0"
+            style={{
+              background:
+                'linear-gradient(to bottom, rgba(20,15,10,0) 40%, rgba(20,15,10,0.55) 75%, rgba(20,15,10,0.85) 100%)',
+            }}
+          />
 
-        <button
-          onClick={onPlay}
-          className="px-10 py-3 text-lg text-amber-100 bg-amber-800/70 border border-amber-600/60 rounded-lg
+          <div className="relative z-10 flex flex-col items-center gap-2 pb-6">
+            <h1
+              className="text-6xl sm:text-7xl font-bold text-amber-50 tracking-wide"
+              style={{
+                fontFamily: TITLE_FONT,
+                textShadow: '0 3px 12px rgba(0,0,0,0.6), 0 1px 3px rgba(0,0,0,0.8)',
+              }}
+            >
+              Clover Village
+            </h1>
+            <p
+              className="text-base sm:text-lg text-amber-100/90 mb-4"
+              style={{ fontFamily: TITLE_FONT, textShadow: '0 1px 4px rgba(0,0,0,0.7)' }}
+            >
+              A peaceful place where time flows gently with the seasons
+            </p>
+
+            <button
+              onClick={onPlay}
+              className="px-10 py-3 text-lg text-amber-100 bg-amber-800/70 border border-amber-600/60 rounded-lg
             hover:bg-amber-700/80 hover:border-amber-500/70 transition-all duration-300
             animate-pulse hover:animate-none cursor-pointer shadow-lg"
-          style={{ fontFamily: TITLE_FONT }}
-        >
-          Play
-        </button>
+              style={{ fontFamily: TITLE_FONT }}
+            >
+              Play
+            </button>
 
-        <button
-          onClick={() => setShowHelp(true)}
-          className="mt-3 text-sm text-amber-100/70 hover:text-amber-100 transition-colors duration-200 cursor-pointer underline underline-offset-4"
-          style={{ fontFamily: TITLE_FONT }}
-        >
-          Help
-        </button>
-      </div>
+            <button
+              onClick={() => setShowHelp(true)}
+              className="mt-3 text-sm text-amber-100/70 hover:text-amber-100 transition-colors duration-200 cursor-pointer underline underline-offset-4"
+              style={{ fontFamily: TITLE_FONT }}
+            >
+              Help
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/data/cutscenes/intro.ts
+++ b/data/cutscenes/intro.ts
@@ -47,12 +47,12 @@ export const introCutscene: CutsceneDefinition = {
         },
       ],
       dialogue: {
-        text: 'Welcome to Twilight Village, a peaceful place where time flows gently with the seasons.',
+        text: 'Welcome to Clover Village, a peaceful place where time flows gently with the seasons.',
         seasonalText: {
-          spring: 'Welcome to Twilight Village in the springtime, when cherry blossoms paint the sky pink.',
-          summer: 'Welcome to Twilight Village in summer, when the sun shines bright and the crops grow tall.',
-          autumn: 'Welcome to Twilight Village in autumn, when leaves turn gold and harvests are abundant.',
-          winter: 'Welcome to Twilight Village in winter, when snow blankets the land in peaceful silence.',
+          spring: 'Welcome to Clover Village in the springtime, when cherry blossoms paint the sky pink.',
+          summer: 'Welcome to Clover Village in summer, when the sun shines bright and the crops grow tall.',
+          autumn: 'Welcome to Clover Village in autumn, when leaves turn gold and harvests are abundant.',
+          winter: 'Welcome to Clover Village in winter, when snow blankets the land in peaceful silence.',
         },
       },
       transitionOut: {
@@ -179,7 +179,7 @@ export const introCutscene: CutsceneDefinition = {
         },
       ],
       dialogue: {
-        text: 'Your journey begins now. Explore the village, meet your neighbours, and build your new life in Twilight Village.',
+        text: 'Your journey begins now. Explore the village, meet your neighbours, and build your new life in Clover Village.',
         autoAdvance: {
           delay: 4000,
         },

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Twilight Village is a living, breathing world where things happen — not just to you, but to everyone playing. **World events** are shared happenings that all players can see and react to. **Event chains** are branching stories that unfold over time based on your choices.
+Clover Village is a living, breathing world where things happen — not just to you, but to everyone playing. **World events** are shared happenings that all players can see and react to. **Event chains** are branching stories that unfold over time based on your choices.
 
 ## World Events
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Welcome to Twilight Village! This peaceful farming and exploration game lets you explore a charming village, meet quirky characters, grow crops, and discover secrets.
+Welcome to Clover Village! This peaceful farming and exploration game lets you explore a charming village, meet quirky characters, grow crops, and discover secrets.
 
 ## Your First Steps
 
@@ -189,4 +189,4 @@ Press **F1** anytime to open the Help Browser:
 - **AI Chat** - Setting up AI conversations
 - **Cloud Saves** - Save your progress across devices
 
-Enjoy your time in Twilight Village!
+Enjoy your time in Clover Village!

--- a/tests/splashScreen.test.tsx
+++ b/tests/splashScreen.test.tsx
@@ -16,7 +16,7 @@ import SplashScreen from '../components/SplashScreen';
 describe('SplashScreen', () => {
   it('renders the title and a Play button without throwing', () => {
     render(<SplashScreen onPlay={() => {}} />);
-    expect(screen.getByText('Twilight Village')).toBeInTheDocument();
+    expect(screen.getByText('Clover Village')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument();
   });
 

--- a/zIndex.ts
+++ b/zIndex.ts
@@ -251,6 +251,11 @@ export const Z_LOADING = 3500;
 /** Error overlays */
 export const Z_ERROR = 4000;
 
+/** Title/splash screen — sits above absolutely everything, including errors,
+ *  since it's rendered as an overlay (not a replacement) so the game can
+ *  keep initialising underneath while it's shown. */
+export const Z_SPLASH_SCREEN = 4500;
+
 // =============================================================================
 // HELPER - Tailwind class generator
 // =============================================================================


### PR DESCRIPTION
**Critical fix, confirmed live** — the splash screen (#48) could leave the game stuck on a black screen forever after clicking Play. Reported by a real player after this deployed: "stuck after splash screen, it didn't load any sprites or background, just dark — loading bar stuck half way".

## Root cause

`SplashScreen` was rendered as an early `return`, replacing the entire component tree — including the PixiJS canvas — until Play was clicked. I reproduced this with a headless Puppeteer run mirroring the real scenario (linger ~4s on the splash so background init has time to finish, click Play, wait 12s): on the current production code the "Enter Game" gate never appears and the canvas samples as solid black (`0,0,0`) forever. I wasn't able to fully pin down the exact internal mechanism (something about the canvas not existing yet during initial mount doesn't recover once it later appears), but the fix removes the condition that causes it rather than chasing the precise cause further.

## Fix

`SplashScreen` now renders as an overlay (fixed position, new `Z_SPLASH_SCREEN = 4500`, above even `Z_ERROR`) alongside whatever's underneath, instead of replacing it — the same pattern already used successfully elsewhere in this file for the loading-cutscene overlay ("game content renders underneath for PixiJS to init"). Game initialisation now proceeds on exactly the same schedule it would with no splash at all; the splash is purely a visual layer on top, dismissed by flipping `showSplashScreen` false. `HelpBrowser` (opened from the splash) is nested inside the same overlay wrapper so it gets its own local stacking context.

## Verification

Ran the same headless Puppeteer script against both the fix and the current production code:
- **Before (current prod):** "Enter Game" never appears after 12s; canvas is 100% solid black.
- **After (this PR):** full rendered village scene — cottage, garden, NPCs, rain, HUD — after the identical click sequence.

`make verify`: typecheck clean, 574 tests across 55 files pass.

## Also in this PR: village rename

Renamed "Twilight Village" → "Clover Village" per your request. It turned out to already be the established in-fiction name throughout the intro cutscene dialogue and docs, not just my splash screen text, so this updates it everywhere consistently: `data/cutscenes/intro.ts`, `docs/GETTING_STARTED.md`, `docs/EVENTS.md`, `components/SplashScreen.tsx`.

(Not touched: the DOMException in the console dump traced to `firebase/communityGardenService.ts`, pre-existing code unrelated to this session — it's Firestore's expected-but-noisy behaviour when a real-time listener is torn down mid-request, not an actual crash. vConsole being live in production was also flagged but you asked to leave it as-is.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k