### PR TITLE
Retry shared-farm plot writes that fail instead of dropping them

### DIFF
--- a/tests/sharedFarmSyncRetry.test.ts
+++ b/tests/sharedFarmSyncRetry.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @vitest-environment node
+ *
+ * Regression test for a shared-farm data-loss bug: flushDirtyPlots() used to
+ * clear a plot out of dirtySharedPlots regardless of whether the Firestore
+ * write actually succeeded, so a failed write (bad connection, etc.) was
+ * silently dropped forever instead of retried on the next flush.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../constants', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    DEBUG: { FARM: false, NPC: false, MAP: false, COLLISION: false },
+  };
+});
+
+vi.mock('../utils/TimeManager', () => ({
+  Season: { SPRING: 'Spring', SUMMER: 'Summer', AUTUMN: 'Autumn', WINTER: 'Winter' },
+  TimeManager: {
+    getCurrentTime: () => ({
+      year: 0,
+      season: 'Spring',
+      day: 1,
+      totalDays: 1,
+      hour: 12,
+      timeOfDay: 'Day',
+      totalHours: 36,
+    }),
+  },
+}));
+
+vi.mock('../utils/inventoryManager', () => ({
+  inventoryManager: {
+    removeItem: vi.fn(() => true),
+    hasItem: vi.fn(() => true),
+    addItem: vi.fn(() => {}),
+    getInventoryData: vi.fn(() => ({ items: {}, tools: {} })),
+  },
+}));
+
+const writePlot = vi.fn();
+const clearPlot = vi.fn();
+
+vi.mock('../firebase/safe', () => ({
+  getCommunityGardenService: () => ({
+    writePlot,
+    clearPlot,
+    startListening: vi.fn(),
+    stopListening: vi.fn(),
+    onPlotsChanged: vi.fn(() => () => {}),
+    docToFarmPlot: vi.fn(),
+  }),
+}));
+
+import { farmManager } from '../utils/farmManager';
+import { FarmPlotState, type FarmPlot } from '../types';
+
+function makePlot(): FarmPlot {
+  return {
+    mapId: 'village',
+    position: { x: 1, y: 1 },
+    state: FarmPlotState.PLANTED,
+    cropType: 'crop_tomato',
+    plantedAtDay: 1,
+    plantedAtHour: 8,
+    lastWateredDay: null,
+    lastWateredHour: null,
+    stateChangedAtDay: 1,
+    stateChangedAtHour: 8,
+    plantedAtTimestamp: Date.now(),
+    lastWateredTimestamp: null,
+    stateChangedAtTimestamp: Date.now(),
+    quality: 'normal',
+    fertiliserApplied: false,
+  };
+}
+
+// Exercises the private flushDirtyPlots() directly — startSharedSync()/
+// stopSharedSync() pull in map registration and listener setup unrelated to
+// this invariant.
+const flush = () =>
+  (farmManager as unknown as { flushDirtyPlots(): Promise<void> }).flushDirtyPlots();
+
+describe('shared farm sync — retry on failed write', () => {
+  const plotKey = 'village:1:1';
+
+  beforeEach(() => {
+    writePlot.mockReset();
+    clearPlot.mockReset();
+    (farmManager as unknown as { plots: Map<string, FarmPlot> }).plots = new Map([
+      [plotKey, makePlot()],
+    ]);
+    (farmManager as unknown as { dirtySharedPlots: Set<string> }).dirtySharedPlots = new Set([
+      plotKey,
+    ]);
+    (farmManager as unknown as { recentlyFlushed: Map<string, number> }).recentlyFlushed =
+      new Map();
+  });
+
+  it('keeps a plot dirty (for retry) when the Firestore write fails', async () => {
+    writePlot.mockResolvedValue(false);
+
+    await flush();
+
+    expect(writePlot).toHaveBeenCalledTimes(1);
+    expect(
+      (farmManager as unknown as { dirtySharedPlots: Set<string> }).dirtySharedPlots.has(plotKey)
+    ).toBe(true);
+  });
+
+  it('retries a previously-failed write on the next flush and clears it once it succeeds', async () => {
+    writePlot.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await flush(); // fails, stays dirty
+    await flush(); // succeeds, should now be cleared
+
+    expect(writePlot).toHaveBeenCalledTimes(2);
+    expect(
+      (farmManager as unknown as { dirtySharedPlots: Set<string> }).dirtySharedPlots.has(plotKey)
+    ).toBe(false);
+  });
+
+  it('clears a plot immediately when the write succeeds on the first attempt', async () => {
+    writePlot.mockResolvedValue(true);
+
+    await flush();
+
+    expect(writePlot).toHaveBeenCalledTimes(1);
+    expect(
+      (farmManager as unknown as { dirtySharedPlots: Set<string> }).dirtySharedPlots.has(plotKey)
+    ).toBe(false);
+  });
+
+  it('keeps a fallow plot dirty when clearPlot fails, and clears it once clearPlot succeeds', async () => {
+    (farmManager as unknown as { plots: Map<string, FarmPlot> }).plots = new Map([
+      [plotKey, { ...makePlot(), state: FarmPlotState.FALLOW }],
+    ]);
+    clearPlot.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await flush();
+    expect(
+      (farmManager as unknown as { dirtySharedPlots: Set<string> }).dirtySharedPlots.has(plotKey)
+    ).toBe(true);
+
+    await flush();
+    expect(clearPlot).toHaveBeenCalledTimes(2);
+    expect(
+      (farmManager as unknown as { dirtySharedPlots: Set<string> }).dirtySharedPlots.has(plotKey)
+    ).toBe(false);
+  });
+});

--- a/utils/farmManager.ts
+++ b/utils/farmManager.ts
@@ -1333,31 +1333,52 @@ class FarmManager {
 
       // Snapshot the dirty set but DON'T clear yet — keeps protection active during async writes
       const toFlush = new Set(this.dirtySharedPlots);
+      const succeeded = new Set<string>();
 
       let written = 0;
       let cleared = 0;
+      let failed = 0;
       const now = Date.now();
       for (const plotKey of toFlush) {
         const plot = this.plots.get(plotKey);
         if (!plot || plot.state === FarmPlotState.FALLOW) {
-          await service.clearPlot(plotKey);
-          cleared++;
+          const ok = await service.clearPlot(plotKey);
+          if (ok) {
+            cleared++;
+            succeeded.add(plotKey);
+          } else {
+            failed++;
+            console.warn(`[SharedFarm] Failed to clear plot ${plotKey} — will retry next flush`);
+          }
         } else {
           const ok = await service.writePlot(plotKey, plot);
-          if (ok) written++;
-          else console.warn(`[SharedFarm] Failed to write plot ${plotKey}`);
+          if (ok) {
+            written++;
+            succeeded.add(plotKey);
+          } else {
+            failed++;
+            console.warn(`[SharedFarm] Failed to write plot ${plotKey} — will retry next flush`);
+          }
         }
-        // Track as recently flushed so we ignore Firestore echoes
-        this.recentlyFlushed.set(plotKey, now);
+        // Only suppress Firestore echoes for changes that actually reached the server —
+        // a failed write stays dirty and must still be applied when it eventually lands.
+        if (succeeded.has(plotKey)) {
+          this.recentlyFlushed.set(plotKey, now);
+        }
       }
 
-      // NOW clear only the keys we actually flushed (new dirty entries added during writes are preserved)
-      for (const plotKey of toFlush) {
+      // Only clear the keys that actually succeeded — a failed write/clear stays in
+      // dirtySharedPlots so the next flush retries it, instead of being silently dropped
+      // (new dirty entries added during writes are unaffected either way).
+      for (const plotKey of succeeded) {
         this.dirtySharedPlots.delete(plotKey);
       }
 
       if (written > 0 || cleared > 0) {
         console.log(`[SharedFarm] Flushed ${written} writes, ${cleared} clears to Firestore`);
+      }
+      if (failed > 0) {
+        console.warn(`[SharedFarm] ${failed} plot write(s) failed and will be retried`);
       }
     } catch {
       console.log('[SharedFarm] Flush failed — Firebase not available');


### PR DESCRIPTION
Found during the Firebase reliability review you asked about earlier — this is the one active bug from that audit.

## The bug

`flushDirtyPlots()` (`utils/farmManager.ts`) cleared every plot out of `dirtySharedPlots` at the end of each 10s flush cycle regardless of whether the Firestore write actually succeeded. A failed `writePlot()`/`clearPlot()` call only logged a `console.warn` and was then treated as done — the change was silently lost forever instead of being retried.

## Fix

Only plot keys whose write/clear actually succeeded get cleared from `dirtySharedPlots`; a failure leaves the key dirty so the next flush retries it. `recentlyFlushed` (which suppresses reprocessing our own Firestore echoes) is now only set for successful writes too — a still-dirty plot needs to accept the eventual remote update once its retry lands, not ignore it.

## Testing

`tests/sharedFarmSyncRetry.test.ts` exercises `flushDirtyPlots()` directly against a mocked `communityGardenService`. Confirmed it actually catches the bug: stashed the fix and reran — 3 of 4 cases failed against the old code, restored the fix and all 4 pass.

`make verify`: typecheck clean, 578 tests across 56 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k