### PR TITLE
Add Sentry remote error reporting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,18 @@ VITE_FIREBASE_APP_ID=your-app-id-here
 # VITE_USE_FIREBASE_EMULATORS=true
 
 # ============================================
+# Error Reporting (Sentry)
+# ============================================
+# Remote error/crash reporting — without this, an error only exists in that
+# one player's browser console. Free tier: https://sentry.io
+# 1. Sign up, create a new project, pick "React" as the platform
+# 2. Copy the DSN it gives you (looks like https://xxx@oXXX.ingest.sentry.io/XXX)
+# Leave unset to disable entirely — everything in utils/errorReporting.ts
+# becomes a safe no-op, same as Firebase being unconfigured.
+
+# VITE_SENTRY_DSN=your-dsn-here
+
+# ============================================
 # Game Testing
 # ============================================
 # Testing mode for farming system

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,11 @@ jobs:
           VITE_FIREBASE_STORAGE_BUCKET: twiightgame.appspot.com
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          # Error reporting (public - embedded in browser JS, like the Firebase config above).
+          # Unset until the VITE_SENTRY_DSN secret is added — errorReporting.ts no-ops without it.
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          # Tags Sentry errors with the commit that shipped them.
+          VITE_APP_VERSION: ${{ github.sha }}
         run: npm run build
 
       - name: Setup Pages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,22 @@ import { authService } from '../firebase/index';
 import { sharedDataService } from '../firebase/sharedDataService';
 ```
 
+## Error Reporting (Sentry)
+
+Remote error/crash reporting, so a real player's failed login or sync is visible without someone having to notice something looks broken and paste console output.
+
+**Status:** Silently disabled when `VITE_SENTRY_DSN` is unset — same no-op pattern as Firebase above.
+
+**Key file:** `utils/errorReporting.ts` (uses `@sentry/react`) — `initErrorReporting()` (called once in `index.tsx`), `reportError(error, category, extra?)`, `reportMessage(message, category, extra?)`, plus `onUncaughtError`/`onRecoverableError` (React 19's `createRoot()` error hooks — wired in `index.tsx`). Categories: `'auth' | 'sync' | 'shared_farm' | 'game_crash'`.
+
+**Wired into:** `components/ErrorBoundary.tsx` (`componentDidCatch`), `index.tsx` (`onUncaughtError`/`onRecoverableError` — NOT `onCaughtError`, which would double-report what ErrorBoundary already catches), `components/HelpBrowser.tsx` (auth actions), `firebase/syncManager.ts` (`uploadToCloud`/`downloadFromCloud`/`getCloudSyncMeta` — reported once at the source, not at every caller, since multiple call sites funnel through the same methods), `utils/farmManager.ts` (aggregate shared-farm write failures per flush, not per-plot).
+
+**Deliberately not enabled:** performance tracing (`browserTracingIntegration`, `tracesSampleRate: 0`) and session replay (`replayIntegration`) — both are in Sentry's default React setup guide, but are a separate quota and, for replay, a bigger privacy footprint (recording gameplay sessions) than plain error reporting needs. Add them later if actually wanted.
+
+**Setup:** Sign up at sentry.io (free tier), create a React project, copy the DSN into `.env.local` as `VITE_SENTRY_DSN`. For production, add the same value as a `VITE_SENTRY_DSN` GitHub Actions secret (see `.github/workflows/deploy.yml`, which passes it through the build the same way Firebase secrets are, plus `VITE_APP_VERSION` set to `github.sha` so errors can be traced back to the deploy that shipped them).
+
+**Not set up:** source map upload (`@sentry/vite-plugin` + a Sentry auth token) — without it, stack traces in the dashboard show minified names from the production bundle rather than real source lines. Worth adding if the minified traces turn out to be too hard to debug from.
+
 ## Language and Localisation
 
 **IMPORTANT**: This game uses **British English** exclusively.

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { reportError } from '../utils/errorReporting';
 
 interface ErrorBoundaryState {
   hasError: boolean;
@@ -23,6 +24,7 @@ class ErrorBoundary extends React.Component<{ children: React.ReactNode }, Error
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('[ErrorBoundary] Game crashed:', error, errorInfo.componentStack);
+    reportError(error, 'game_crash', { componentStack: errorInfo.componentStack ?? undefined });
   }
 
   handleReload = () => {

--- a/components/HelpBrowser.tsx
+++ b/components/HelpBrowser.tsx
@@ -11,6 +11,7 @@ import {
 } from '../services/anthropicClient';
 import { audioManager } from '../utils/AudioManager';
 import { getAuthService, getSyncManager, type AuthState, type SyncState } from '../firebase/safe';
+import { reportError } from '../utils/errorReporting';
 
 interface HelpBrowserProps {
   onClose: () => void;
@@ -167,6 +168,7 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Sign in failed';
       setAuthError(message);
+      reportError(error, 'auth', { action: 'signIn' });
     } finally {
       setAuthLoading(false);
     }
@@ -191,6 +193,7 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Sign up failed';
       setAuthError(message);
+      reportError(error, 'auth', { action: 'signUp' });
     } finally {
       setAuthLoading(false);
     }
@@ -204,6 +207,7 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Google sign in failed';
       setAuthError(message);
+      reportError(error, 'auth', { action: 'signInWithGoogle' });
     } finally {
       setAuthLoading(false);
     }
@@ -217,6 +221,7 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Guest sign in failed';
       setAuthError(message);
+      reportError(error, 'auth', { action: 'signInAnonymously' });
     } finally {
       setAuthLoading(false);
     }
@@ -228,6 +233,9 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
     try {
       await getSyncManager().syncNow();
     } catch (error: unknown) {
+      // Not reported here — syncNow() calls uploadToCloud(), which already
+      // reports at the source (see firebase/syncManager.ts) so every caller
+      // doesn't have to.
       const message = error instanceof Error ? error.message : 'Cloud save failed';
       setAuthError(message);
     } finally {
@@ -244,6 +252,7 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Sign out failed';
       setAuthError(message);
+      reportError(error, 'auth', { action: 'signOut' });
     } finally {
       setAuthLoading(false);
     }

--- a/firebase/syncManager.ts
+++ b/firebase/syncManager.ts
@@ -22,6 +22,7 @@ import { syncDiaryFromFirestore } from '../services/diaryService';
 import { gameState } from '../GameState';
 import { FIRESTORE_PATHS, SyncMetadata } from './types';
 import { eventBus, GameEvent } from '../utils/EventBus';
+import { reportError } from '../utils/errorReporting';
 
 // ============================================
 // Constants
@@ -193,6 +194,11 @@ class SyncManager {
         error: error instanceof Error ? error.message : 'Upload failed',
       });
       eventBus.emit(GameEvent.CLOUD_SYNC_COMPLETED, { success: false });
+      // Reported once here (not at each caller) since every caller —
+      // onSignIn, periodic sync, syncBeforeSignOut, exit-save, manual Save
+      // Now — funnels through this one method and either rethrows or
+      // swallows the same error.
+      reportError(error, 'sync', { action: 'uploadToCloud', slotId });
       throw error;
     }
   }
@@ -239,6 +245,7 @@ class SyncManager {
         status: 'error',
         error: error instanceof Error ? error.message : 'Download failed',
       });
+      reportError(error, 'sync', { action: 'downloadFromCloud', slotId });
       throw error;
     }
   }
@@ -366,6 +373,11 @@ class SyncManager {
       }
     } catch (error) {
       console.warn('[SyncManager] Failed to get cloud sync meta:', error);
+      // Otherwise-invisible: a failed read here makes onSignIn() treat cloud
+      // as if it had never synced (cloudTimestamp 0), which can trigger an
+      // upload that overwrites cloud data with a stale local save — worth
+      // knowing about even though gameplay isn't blocked.
+      reportError(error, 'sync', { action: 'getCloudSyncMeta' });
     }
 
     return null;

--- a/index.tsx
+++ b/index.tsx
@@ -3,13 +3,18 @@ import ReactDOM from 'react-dom/client';
 import './src/styles/global.css';
 import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
+import { initErrorReporting, onUncaughtError, onRecoverableError } from './utils/errorReporting';
+
+// No-ops when VITE_SENTRY_DSN isn't set — see utils/errorReporting.ts.
+// Called before render so it can catch errors from mount onward.
+initErrorReporting();
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
   throw new Error('Could not find root element to mount to');
 }
 
-const root = ReactDOM.createRoot(rootElement);
+const root = ReactDOM.createRoot(rootElement, { onUncaughtError, onRecoverableError });
 root.render(
   <React.StrictMode>
     <ErrorBoundary>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@pixi/react": "^8.0.3",
+        "@sentry/react": "^10.73.0",
         "atrament": "^5.1.0",
         "firebase": "^12.8.0",
         "pixi.js": "^8.14.0",
@@ -2768,6 +2769,112 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.73.0.tgz",
+      "integrity": "sha512-HqTe1S5RrWLufhX2LaFP3yNoMxfNDroh120bq1zdGHZfFDBMJQ0CDXxHO+L4UJfQ5dWdCCzWbXIAiZuWGa/DFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.73.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.73.0",
+        "@sentry/feedback": "10.73.0",
+        "@sentry/replay": "10.73.0",
+        "@sentry/replay-canvas": "10.73.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.73.0.tgz",
+      "integrity": "sha512-qQygxJZ+RV779+iL1+lrJ4f4sZLgbgW0/JWPNp0YlcEAE62yCsdKbqoTEjB/EugdS4mSjBMX0chZC6rblu2Ycw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.73.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.73.0.tgz",
+      "integrity": "sha512-FLO1UgH19RyasVpofu612WCOgb2nEH0dZy+R72d7p65XU9i0wxlMKm3+sgfwKmiSJp1Qhilaaxs4Jg6BbiM5HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.73.0.tgz",
+      "integrity": "sha512-D6nSngX+e46Mae2/oh2bxBvxNK1z2NERbuMAhB5sx9x4xMBWIyGnYYTECehvEqV9+AqGAgxxhOZoYIG3AmRwww==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.73.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.73.0.tgz",
+      "integrity": "sha512-wJrzS98ddPvhGS/MKNHZyE8X7ecd4KwKdz7fHino2qkqBBrF4cxWr+q/uLTIk5PYWMkeJ4oKMjHAjOqmzGR4tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.73.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.73.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.73.0.tgz",
+      "integrity": "sha512-nN2wjN/Y0J5BOJV5hqRHUEBfxwUsipp1PKjcDHh6Fpxnrtfldu3Y99E8cQInseo5heFdzEvrOHBBrqWZXOHVKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.73.0",
+        "@sentry/core": "10.73.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.73.0.tgz",
+      "integrity": "sha512-sxa2lKkHPfF/j5xFpW7gocthWXRqyoHz8KCPy6yGc8plT477nl57iGSKhQDYsx1Ny10TLjs7YkIuPP1GY/Ax2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.73.0",
+        "@sentry/replay": "10.73.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",
     "@pixi/react": "^8.0.3",
+    "@sentry/react": "^10.73.0",
     "atrament": "^5.1.0",
     "firebase": "^12.8.0",
     "pixi.js": "^8.14.0",

--- a/tests/errorReporting.test.ts
+++ b/tests/errorReporting.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment node
+ *
+ * Safe-wrapper invariant for error reporting: without VITE_SENTRY_DSN set,
+ * every export must be a true no-op (never touch the Sentry SDK, never
+ * throw) — the same guarantee firebase/safe.ts gives when the `firebase`
+ * package isn't installed. VITE_SENTRY_DSN is force-unset via vi.stubEnv()
+ * regardless of a local .env.local, so this stays deterministic for anyone
+ * who has actually configured Sentry locally.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { init, captureException, captureMessage, withScope, reactErrorHandler } = vi.hoisted(() => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  withScope: vi.fn((cb: (scope: unknown) => void) => cb({ setTag: vi.fn(), setContext: vi.fn() })),
+  reactErrorHandler: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('@sentry/react', () => ({
+  init,
+  captureException,
+  captureMessage,
+  withScope,
+  reactErrorHandler,
+}));
+
+vi.stubEnv('VITE_SENTRY_DSN', '');
+
+import {
+  isErrorReportingConfigured,
+  initErrorReporting,
+  reportError,
+  reportMessage,
+} from '../utils/errorReporting';
+
+describe('errorReporting — safe no-op without a DSN configured', () => {
+  beforeEach(() => {
+    init.mockClear();
+    captureException.mockClear();
+    captureMessage.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_SENTRY_DSN', ''); // Keep it unset for the remaining tests in this file
+  });
+
+  it('reports unconfigured', () => {
+    expect(isErrorReportingConfigured()).toBe(false);
+  });
+
+  it('initErrorReporting() does not throw and does not call Sentry.init', () => {
+    expect(() => initErrorReporting()).not.toThrow();
+    expect(init).not.toHaveBeenCalled();
+  });
+
+  it('reportError() does not throw and never reaches Sentry.captureException', () => {
+    expect(() => reportError(new Error('boom'), 'game_crash')).not.toThrow();
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('reportMessage() does not throw and never reaches Sentry.captureMessage', () => {
+    expect(() => reportMessage('something failed', 'sync')).not.toThrow();
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('reportError() handles a non-Error value without throwing', () => {
+    expect(() => reportError('a plain string rejection', 'auth')).not.toThrow();
+  });
+});

--- a/utils/errorReporting.ts
+++ b/utils/errorReporting.ts
@@ -1,0 +1,97 @@
+/**
+ * Error Reporting (Sentry)
+ *
+ * Remote error/crash reporting so real player issues are visible without
+ * someone having to notice something looks wrong and paste console output
+ * (which is literally how prior bugs were found — see git history around
+ * the shared-farm sync fix and the splash-screen game-init fix).
+ *
+ * Mirrors firebase/config.ts's pattern: reads config from VITE_ env vars,
+ * silently disables itself (every export becomes a safe no-op) when the DSN
+ * isn't configured, so the game works identically with or without it set up.
+ *
+ * Deliberately narrower than Sentry's default React setup guide
+ * (skills.sentry.dev/instrument): no browserTracingIntegration (performance
+ * tracing — separate quota, not what "remote error logging" asked for) and
+ * no replayIntegration (records gameplay sessions — a bigger privacy
+ * footprint and bundle-size cost than this needs, for a kids/family game).
+ * Both can be added later if actually wanted.
+ */
+
+import * as Sentry from '@sentry/react';
+
+let initialised = false;
+
+/** Whether a Sentry DSN has been configured via env vars. */
+export function isErrorReportingConfigured(): boolean {
+  return Boolean(import.meta.env.VITE_SENTRY_DSN);
+}
+
+/**
+ * Initialise Sentry. Safe to call even when not configured — no-ops.
+ * Call once, early in app startup (see index.tsx).
+ */
+export function initErrorReporting(): void {
+  if (initialised || !isErrorReportingConfigured()) return;
+
+  Sentry.init({
+    dsn: import.meta.env.VITE_SENTRY_DSN,
+    environment: import.meta.env.MODE,
+    // Set by the deploy workflow to the git commit SHA — lets errors in the
+    // Sentry dashboard be traced back to the exact deploy that shipped them.
+    // Unset locally (no CI to stamp it), which is fine — Sentry just omits it.
+    release: import.meta.env.VITE_APP_VERSION,
+    tracesSampleRate: 0, // Error tracking only — no performance/tracing overhead.
+  });
+  initialised = true;
+  console.log('[ErrorReporting] Sentry initialised');
+}
+
+/**
+ * React 19's root-level error hooks — passed to createRoot() in index.tsx.
+ * Only the two cases components/ErrorBoundary.tsx's componentDidCatch can't
+ * see: an uncaught error with no boundary above it, and an error React
+ * itself recovers from. Deliberately NOT wiring onCaughtError here — that
+ * fires for the same errors ErrorBoundary.componentDidCatch already reports
+ * (with richer context, including the component stack), and wiring both
+ * would double-report every game crash.
+ */
+export const onUncaughtError = Sentry.reactErrorHandler();
+export const onRecoverableError = Sentry.reactErrorHandler();
+
+/** Broad categories used to filter/group errors in the Sentry dashboard. */
+export type ErrorReportCategory = 'auth' | 'sync' | 'shared_farm' | 'game_crash';
+
+/**
+ * Report a caught error. Safe no-op when Sentry isn't configured or hasn't
+ * initialised — callers don't need to check isErrorReportingConfigured()
+ * themselves.
+ */
+export function reportError(
+  error: unknown,
+  category: ErrorReportCategory,
+  extra?: Record<string, unknown>
+): void {
+  if (!initialised) return;
+  Sentry.withScope((scope) => {
+    scope.setTag('category', category);
+    if (extra) scope.setContext('details', extra);
+    Sentry.captureException(error instanceof Error ? error : new Error(String(error)));
+  });
+}
+
+/**
+ * Report a non-exception event (e.g. "write failed" with no thrown Error).
+ */
+export function reportMessage(
+  message: string,
+  category: ErrorReportCategory,
+  extra?: Record<string, unknown>
+): void {
+  if (!initialised) return;
+  Sentry.withScope((scope) => {
+    scope.setTag('category', category);
+    if (extra) scope.setContext('details', extra);
+    Sentry.captureMessage(message, 'warning');
+  });
+}

--- a/utils/farmManager.ts
+++ b/utils/farmManager.ts
@@ -17,6 +17,7 @@ import { getTileCoords } from './mapUtils';
 import { GROWTH_THRESHOLDS, DEBUG, SHARED_FARM_MAP_IDS } from '../constants';
 import { getWeatherZone } from '../data/weatherConfig';
 import { eventBus, GameEvent } from './EventBus';
+import { reportMessage } from './errorReporting';
 
 /** Interval for batch-flushing dirty shared plots to Firestore */
 const SHARED_SYNC_INTERVAL_MS = 10_000;
@@ -1379,6 +1380,14 @@ class FarmManager {
       }
       if (failed > 0) {
         console.warn(`[SharedFarm] ${failed} plot write(s) failed and will be retried`);
+        // Aggregate, not per-plot — a bad connection can fail many plots in
+        // one flush cycle and this runs every 10s, so per-plot reporting
+        // would spam the error budget for what's really one outage.
+        reportMessage(`Shared farm flush: ${failed} plot write(s) failed`, 'shared_farm', {
+          failed,
+          written,
+          cleared,
+        });
       }
     } catch {
       console.log('[SharedFarm] Flush failed — Firebase not available');


### PR DESCRIPTION
Wires up the remote error logging we discussed — without this, an error only ever existed in one player's browser console, discoverable only if they happened to paste it (exactly how the shared-farm and Firestore-abort issues were found this session).

## What it does

`utils/errorReporting.ts` follows the same safe-wrapper pattern as `firebase/config.ts`: every export is a true no-op when `VITE_SENTRY_DSN` is unset, so the game behaves identically with or without it configured.

Used `@sentry/react` (needed for React 19's `reactErrorHandler`, wired into `createRoot`'s `onUncaughtError`/`onRecoverableError` — catches errors no error boundary sees). I followed [skills.sentry.dev/instrument](https://skills.sentry.dev/instrument)'s setup guide but went narrower than its defaults:
- **No performance tracing** (`browserTracingIntegration`) — separate quota, not what "error logging" asked for.
- **No session replay** (`replayIntegration`) — records gameplay sessions; bigger privacy footprint and bundle cost than warranted for a kids/family game.
- **No source map upload yet** (`@sentry/vite-plugin` + auth token) — stack traces will show minified names for now. Noted as a follow-up in CLAUDE.md.

## Wired into

- `components/ErrorBoundary.tsx` — `componentDidCatch`
- `index.tsx` — `onUncaughtError`/`onRecoverableError` (not `onCaughtError`, which would double-report what ErrorBoundary already catches)
- `components/HelpBrowser.tsx` — auth actions (sign in/up/Google/guest/sign out)
- `firebase/syncManager.ts` — `uploadToCloud`/`downloadFromCloud`/`getCloudSyncMeta`, reported once at the source since multiple callers funnel through the same methods (avoids double-reporting)
- `utils/farmManager.ts` — aggregate shared-farm write failures per flush, not per-plot (avoids spamming the error budget over one bad-connection outage)

## Setup already done

- `VITE_SENTRY_DSN` GitHub Actions secret is set.
- `VITE_APP_VERSION` (git SHA) added to the deploy workflow's build env, so a Sentry error can be traced back to the exact deploy that shipped it.
- Local `.env.local` has the DSN too (gitignored via the existing `*.local` pattern — Sentry DSNs are meant to be public/embedded in client JS, unlike an API key).

## Verification

`tests/errorReporting.test.ts` forces the DSN unset (via `vi.stubEnv`, regardless of a local `.env.local`) and confirms every export stays a safe no-op. Also built the game for real and ran it through headless Chrome (Puppeteer): Sentry initialises, no console errors, full gameplay screen renders correctly after Play → Enter Game.

`make verify`: typecheck clean, 583 tests across 57 files pass.

---

Side note: while working on this, another concurrent session appears to be active in the same repo working directory (uncommitted `constants.ts`, `multiplayer/`, `design_docs/planned/MULTIPLAYER.md`, `firebase/realtimeConfig.ts` — looks like it picked up the multiplayer-viability question from earlier). None of that is in this PR — only the 12 files above, staged by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eenMWU4ndZ29oToG4o58k