### PR TITLE
Add shared-world multiplayer: presence, emotes, determinism

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,20 @@ VITE_FIREBASE_MESSAGING_SENDER_ID=your-messaging-sender-id
 VITE_FIREBASE_APP_ID=your-app-id-here
 
 # ============================================
+# Multiplayer (shared world presence)
+# ============================================
+# Realtime Database URL — required for seeing other players. Firestore keeps the
+# durable shared state (community garden, world events); presence is ephemeral
+# and lives in RTDB because it needs onDisconnect() and per-write billing would
+# be absurd for data with a 200ms shelf life.
+# Find it at Firebase Console > Realtime Database > the URL above the data tree.
+# Without it the game runs exactly as single-player.
+VITE_FIREBASE_DATABASE_URL=https://twiightgame-default-rtdb.europe-west1.firebasedatabase.app
+
+# Set to "false" to disable multiplayer even when the database URL is present.
+# VITE_MULTIPLAYER_ENABLED=false
+
+# ============================================
 # Firebase Enable/Disable
 # ============================================
 # Set to "false" to completely disable Firebase (cloud saves, shared data)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,10 @@ jobs:
           VITE_FIREBASE_STORAGE_BUCKET: twiightgame.appspot.com
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          # Realtime Database URL for multiplayer presence. Unset until the
+          # VITE_FIREBASE_DATABASE_URL secret is added - firebase/realtimeConfig.ts
+          # no-ops without it and the game runs exactly as single-player.
+          VITE_FIREBASE_DATABASE_URL: ${{ secrets.VITE_FIREBASE_DATABASE_URL }}
           # Error reporting (public - embedded in browser JS, like the Firebase config above).
           # Unset until the VITE_SENTRY_DSN secret is added — errorReporting.ts no-ops without it.
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}

--- a/.github/workflows/firebase.yml
+++ b/.github/workflows/firebase.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'firestore.rules'
       - 'firestore.indexes.json'
+      - 'database.rules.json'
       - 'firebase.json'
       - '.github/workflows/firebase.yml'
 
@@ -14,7 +15,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy-firestore-rules:
+  deploy-rules:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,9 +43,41 @@ jobs:
           # Clean up
           rm /tmp/sa.json
 
+      # Realtime Database holds ephemeral multiplayer presence (see
+      # design_docs/planned/MULTIPLAYER.md). These rules are what make the emote
+      # vocabulary closed server-side, so they must ship before presence is
+      # switched on for anyone.
+      #
+      # Skipped — not failed — when the project has no Realtime Database instance:
+      # creating one is a Firebase Console action (it needs a region choice), and a
+      # red workflow on main for an optional feature that is switched off would be
+      # worse than a clear log line.
+      - name: Deploy Realtime Database Rules
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          echo "$GOOGLE_APPLICATION_CREDENTIALS_JSON" > /tmp/sa.json
+          export GOOGLE_APPLICATION_CREDENTIALS=/tmp/sa.json
+
+          if firebase database:instances:list --project twiightgame 2>/dev/null | grep -qE '[a-z0-9]'; then
+            firebase deploy --only database --project twiightgame
+            echo "RTDB_DEPLOYED=true" >> $GITHUB_ENV
+          else
+            echo "No Realtime Database instance in project twiightgame - skipping."
+            echo "Create one in the Firebase Console to enable multiplayer presence."
+            echo "RTDB_DEPLOYED=false" >> $GITHUB_ENV
+          fi
+
+          rm /tmp/sa.json
+
       - name: Deployment Summary
         run: |
           echo "## Firebase Deployment Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Firestore Rules**: Deployed" >> $GITHUB_STEP_SUMMARY
+          if [ "$RTDB_DEPLOYED" = "true" ]; then
+            echo "- **Realtime Database Rules**: Deployed (multiplayer presence)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- **Realtime Database Rules**: Skipped - no RTDB instance in this project" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "- **Project**: twiightgame" >> $GITHUB_STEP_SUMMARY

--- a/App.tsx
+++ b/App.tsx
@@ -30,6 +30,7 @@ import { useCollisionDetection } from './hooks/useCollisionDetection';
 import { useMovementController } from './hooks/useMovementController';
 import { useInteractionController } from './hooks/useInteractionController';
 import { useEnvironmentController } from './hooks/useEnvironmentController';
+import { useMultiplayerController } from './hooks/useMultiplayerController';
 import { useEventChainUI } from './hooks/useEventChainUI';
 import { EventChainPopup } from './components/EventChainPopup';
 import { useAmbientVFX } from './hooks/useAmbientVFX';
@@ -68,6 +69,9 @@ import TileRenderer from './components/TileRenderer';
 // BackgroundSprites and ForegroundSprites removed - now rendered by PixiJS SpriteLayer
 import PlacedItems from './components/PlacedItems';
 import NPCRenderer from './components/NPCRenderer';
+import RemotePlayerOverlay from './components/RemotePlayerOverlay';
+import EmoteWheel from './components/EmoteWheel';
+import PresenceIndicator from './components/PresenceIndicator';
 import Inventory, { InventoryItem } from './components/Inventory';
 import QuickSlotBar from './components/QuickSlotBar';
 import AnimationOverlay from './components/AnimationOverlay';
@@ -384,6 +388,39 @@ const App: React.FC = () => {
     activeNPC,
   });
 
+  // ── Multiplayer presence ──────────────────────────────────────────────────
+  // Refs so the game-loop publisher below reads live values without being
+  // rebuilt (and re-subscribed) on every step the player takes.
+  const presenceStateRef = useRef({ direction, playerSizeTier, isFairyForm });
+  presenceStateRef.current = { direction, playerSizeTier, isFairyForm };
+
+  const getLocalPresence = useCallback(() => {
+    const character = gameState.getSelectedCharacter();
+    if (!character) return null;
+    const live = presenceStateRef.current;
+    return {
+      name: character.name,
+      characterId: character.characterId || 'character1',
+      position: playerPosRef.current,
+      direction: live.direction,
+      sizeTier: live.playerSizeTier,
+      fairyForm: live.isFairyForm,
+      emote: null,
+    };
+  }, [playerPosRef]);
+
+  const {
+    remotePlayerCount,
+    remotePlayerNames,
+    tickMultiplayer,
+    sendEmote,
+  } = useMultiplayerController({ currentMapId, getLocalPresence });
+
+  const [showEmoteWheel, setShowEmoteWheel] = useState(false);
+  // Stable identity: useKeyboardControls captures its handler once at mount.
+  const toggleEmoteWheel = useCallback(() => setShowEmoteWheel((open) => !open), []);
+  const closeEmoteWheel = useCallback(() => setShowEmoteWheel(false), []);
+
   // Fairy form fading state — true in the last 30s to trigger sprite flicker
   const [isFairyFormFading, setIsFairyFormFading] = useState(false);
 
@@ -636,6 +673,28 @@ const App: React.FC = () => {
     });
   }, [showToast]);
 
+  // Shared farm: another player got to a ripe crop first, so the optimistic
+  // grant was rolled back. Say so, or the item silently vanishing looks like a bug.
+  useEffect(() => {
+    return eventBus.on(GameEvent.FARM_HARVEST_CONTESTED, (payload) => {
+      showToast(`Someone else picked those ${payload.cropDisplayName} first!`, 'info');
+    });
+  }, [showToast]);
+
+  // Another player joined or left this map
+  useEffect(() => {
+    const unsubJoined = eventBus.on(GameEvent.REMOTE_PLAYER_JOINED, (payload) => {
+      showToast(`${payload.name} is here`, 'info');
+    });
+    const unsubLeft = eventBus.on(GameEvent.REMOTE_PLAYER_LEFT, (payload) => {
+      showToast(`${payload.name} wandered off`, 'info');
+    });
+    return () => {
+      unsubJoined();
+      unsubLeft();
+    };
+  }, [showToast]);
+
   // Yule celebration EventBus subscriptions
   useEffect(() => {
     const unsubStart = eventBus.on(GameEvent.YULE_CELEBRATION_STARTED, (payload) => {
@@ -829,6 +888,7 @@ const App: React.FC = () => {
     onFarmActionAnimation: handleFarmActionAnimation,
     onShowToast: showToast,
     onSetSelectedItemSlot: setSelectedItemSlot,
+    onToggleEmoteWheel: toggleEmoteWheel,
   });
 
   /**
@@ -902,6 +962,11 @@ const App: React.FC = () => {
     const now = Date.now();
     const deltaTime = Math.min((now - lastFrameTime.current) / 1000, 0.1); // Cap at 100ms to avoid huge jumps
     lastFrameTime.current = now;
+
+    // Advance remote players (interpolation) and publish our own position.
+    // Runs before the dialogue/cutscene early-return below: other players should
+    // keep walking around while you are mid-conversation.
+    tickMultiplayer(now);
 
     // Update NPCs (they continue moving even when dialogue is open)
     // NPC movement triggers NPC_MOVED event via EventBus
@@ -1014,6 +1079,7 @@ const App: React.FC = () => {
     checkChainProximity,
     currentMapId,
     ui.miniGame,
+    tickMultiplayer,
   ]);
 
   // Disabled automatic transitions - now using action key (E or Enter)
@@ -1723,6 +1789,14 @@ const App: React.FC = () => {
   // got a reason to retry. SplashScreen renders itself as a fixed,
   // high-z-index overlay, so it just needs to be painted alongside whichever
   // branch below is currently rendering, not returned instead of it.
+  /**
+   * True only once the player is actually looking at the world: past the title
+   * screen, past the loading cutscene, map ready, no cutscene running. Gates the
+   * multiplayer UI, which has nothing sensible to say before then.
+   */
+  const isInWorld =
+    !showSplashScreen && !isLoadingCutscene && !isCutscenePlaying && isMapInitialized;
+
   const splashOverlay = showSplashScreen ? (
     <SplashScreen onPlay={() => setShowSplashScreen(false)} />
   ) : null;
@@ -1962,6 +2036,15 @@ const App: React.FC = () => {
           />
         )}
 
+        {/* Render other players as DOM elements when PixiJS is disabled */}
+        {!USE_PIXI_RENDERER && (
+          <RemotePlayerOverlay
+            characterScale={currentMap?.characterScale}
+            gridOffset={effectiveGridOffset}
+            tileSize={effectiveTileSize}
+          />
+        )}
+
         {/* Render Placed Items (food, decorations) - Between player and foreground */}
         {!USE_PIXI_RENDERER && (
           <PlacedItems
@@ -2140,6 +2223,20 @@ const App: React.FC = () => {
         />
       )}
 
+      {/* Multiplayer: who else is here, and the emote picker.
+          Both are gated on the world actually being on screen — an emote picker
+          floating over the black loading screen looks broken. */}
+      {isInWorld && !isAnyOverlayOpen && (
+        <PresenceIndicator
+          count={remotePlayerCount}
+          names={remotePlayerNames}
+          compact={isCompactMode}
+        />
+      )}
+      {isInWorld && showEmoteWheel && (
+        <EmoteWheel onSelect={sendEmote} onClose={closeEmoteWheel} compact={isCompactMode} />
+      )}
+
       {/* Touch controls - hidden when any modal is open or cutscene playing */}
       {isTouchDevice &&
         !activeNPC &&
@@ -2156,6 +2253,7 @@ const App: React.FC = () => {
             onDirectionPress={touchControls.handleDirectionPress}
             onDirectionRelease={touchControls.handleDirectionRelease}
             onResetPress={touchControls.handleResetPress}
+            onEmotePress={toggleEmoteWheel}
             compact={isCompactMode}
             onPhotoPress={
               selectedItemSlot !== null &&

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,9 @@ Firebase provides cloud saves via Firestore and cross-player features (NPC gossi
 - `firebase/cloudSaveService.ts` — Save/load game state to Firestore
 - `firebase/sharedDataService.ts` — Cross-player NPC gossip sharing
 - `firebase/syncManager.ts` — Local↔Cloud save synchronisation
+- `firebase/communityGardenService.ts` — Shared farm plots (+ `claimPlot` harvest transactions)
+- `firebase/presenceService.ts` — **Multiplayer presence** (Realtime Database, not Firestore)
+- `firebase/realtimeConfig.ts` — Realtime Database init (`VITE_FIREBASE_DATABASE_URL`)
 - `components/HelpBrowser.tsx` — Account & Cloud Saves UI (F1 → Settings)
 - `components/AIDialogueBox.tsx` — Gossip injection into NPC conversations
 
@@ -54,6 +57,35 @@ Remote error/crash reporting, so a real player's failed login or sync is visible
 **Setup:** Sign up at sentry.io (free tier), create a React project, copy the DSN into `.env.local` as `VITE_SENTRY_DSN`. For production, add the same value as a `VITE_SENTRY_DSN` GitHub Actions secret (see `.github/workflows/deploy.yml`, which passes it through the build the same way Firebase secrets are, plus `VITE_APP_VERSION` set to `github.sha` so errors can be traced back to the deploy that shipped them).
 
 **Not set up:** source map upload (`@sentry/vite-plugin` + a Sentry auth token) — without it, stack traces in the dashboard show minified names from the production bundle rather than real source lines. Worth adding if the minified traces turn out to be too hard to debug from.
+
+## Multiplayer (Shared World)
+
+Players can inhabit the same maps at once — see each other walk around, and emote. Design and
+implementation notes: [`design_docs/planned/MULTIPLAYER.md`](design_docs/planned/MULTIPLAYER.md).
+
+**Status:** Implemented, inert until `VITE_FIREBASE_DATABASE_URL` is set. Toggle with
+`MULTIPLAYER_ENABLED` in `constants.ts`. Without it the game is exactly single-player.
+
+**Key files:**
+- `multiplayer/` — pure logic: `wire.ts` (encode/validate), `interpolation.ts`, `publishPolicy.ts`,
+  `emotes.ts`, `RemotePlayerManager.ts` (SSoT for other players — mirrors `NPCManager`)
+- `hooks/useMultiplayerController.ts` — the domain controller; App.tsx only wires it
+- `utils/pixi/RemotePlayerLayer.ts` — rendering (mirrors `NPCLayer`)
+- `database.rules.json` — RTDB security rules
+
+**Three rules that are easy to break:**
+
+1. **Never put remote player positions through React state.** They change every frame.
+   `usePixiRenderer`'s per-frame `updateAnimations()` polls `remotePlayerManager` directly; the
+   EventBus trigger fires only on join/leave.
+2. **The emote list is duplicated in `multiplayer/emotes.ts` and `database.rules.json` on purpose** —
+   the rules enforce the closed vocabulary server-side, which is the whole reason player-to-player
+   communication is safe for a young audience. There is no free-text chat and there should not be.
+   `tests/emoteVocabulary.test.ts` fails if the two lists drift.
+3. **Anything in the shared simulation must be deterministic.** Time and weather already are.
+   NPC wander and fairy spawns now use `utils/seededRandom.ts` keyed on `(id, time slot)`.
+   Reintroducing `Math.random()` there silently desyncs what two players see —
+   `tests/determinism.test.ts` guards it.
 
 ## Language and Localisation
 
@@ -336,6 +368,7 @@ Custom React hooks for game systems:
 - `hooks/useMovementController.ts` - Player position, direction, animation, pathfinding, size effects
 - `hooks/useInteractionController.ts` - NPC dialogue, radial menu, farm actions, canvas clicks
 - `hooks/useEnvironmentController.ts` - Weather, time of day, ambient audio, item decay, movement effects
+- `hooks/useMultiplayerController.ts` - Presence rooms, publishing the local player, remote player lifecycle, emotes
 
 ### Utilities (`utils/`)
 
@@ -346,6 +379,7 @@ Pure functions and game systems:
 - `utils/interactions/` - **Click interaction system** — see its [README](utils/interactions/README.md). One provider module per interaction kind
 - `utils/CharacterData.ts` - **Unified persistence API** for all character data (inventory, farming, cooking, friendships)
 - `utils/EventBus.ts` - **Type-safe pub/sub event system** for decoupling managers from React components
+- `utils/seededRandom.ts` - Deterministic PRNG keyed on (id, time slot) — use instead of `Math.random()` in anything two players must agree on
 - `utils/mapUtils.ts` - Tile data access via MapManager
 - `utils/testUtils.ts` - Startup sanity checks
 - `utils/tileRenderUtils.ts` - Tile transform calculations

--- a/NPCManager.ts
+++ b/NPCManager.ts
@@ -5,6 +5,7 @@ import { metadataCache } from './utils/MetadataCache';
 import { TimeManager, Season } from './utils/TimeManager';
 import { eventBus, GameEvent } from './utils/EventBus';
 import { audioManager } from './utils/AudioManager';
+import { createDecisionRandom, slotPhaseOffset } from './utils/seededRandom';
 
 /**
  * NPCManager - Single Source of Truth for all NPC data
@@ -27,6 +28,8 @@ interface NPCState {
   moveDuration: number; // How long to move in current direction (ms)
   waitDuration: number; // How long to wait before next move (ms)
   isWaiting: boolean;
+  /** Absolute wander slot this NPC last made a decision in (see WANDER_SLOT_MS) */
+  lastWanderSlot?: number;
   isInDialogue: boolean; // Freeze movement when talking to player
   baseMapId: string; // Original map where NPC was registered
   basePosition: Position; // Original position when NPC was created
@@ -57,6 +60,23 @@ class NPCManagerClass {
   private frozenNPCIds: Set<string> = new Set();
 
   private readonly NPC_SPEED = 1.0; // tiles per second
+
+  /**
+   * Length of one wander decision slot, in milliseconds.
+   *
+   * Wander decisions are keyed to absolute wall-clock slots rather than to
+   * accumulated local state, so every client picks the same direction for the
+   * same NPC at the same instant — no bandwidth, no host, no handoff. This is
+   * the same technique WeatherManager uses for weather.
+   *
+   * Caveat, deliberately not hidden: identical *decisions* do not guarantee
+   * identical *positions*. Two clients that started watching an NPC at
+   * different times, or that reached a wall from different places, can still
+   * drift apart. Full convergence would need the wander expressed as a
+   * closed-form function of time; this gets the shared-moment benefit
+   * ("look, the deer!") for a fraction of the risk.
+   */
+  private readonly WANDER_SLOT_MS = 2500;
   private readonly NPC_SIZE = PLAYER_SIZE; // Same size as player
 
   /**
@@ -743,24 +763,36 @@ class NPCManagerClass {
           }
         }
 
+        // Which absolute slot are we in? The per-NPC phase offset staggers
+        // decisions so the whole village does not turn on the same tick.
+        const phase = slotPhaseOffset(npc.id, this.WANDER_SLOT_MS);
+        const slot = Math.floor((currentTime + phase) / this.WANDER_SLOT_MS);
+
+        if (state.lastWanderSlot !== slot) {
+          // New slot: decide where to go and for how long, from the slot seed.
+          const random = createDecisionRandom(npc.id, slot);
+          const directions = npc.allowedDirections?.length
+            ? npc.allowedDirections
+            : [Direction.Up, Direction.Down, Direction.Left, Direction.Right];
+
+          state.lastWanderSlot = slot;
+          state.moveDirection = directions[Math.floor(random() * directions.length)];
+          // Move for part of the slot, then stand for the remainder — this
+          // preserves the old 1-3s amble/1-4s pause rhythm within a fixed slot.
+          state.moveDuration = 800 + random() * (this.WANDER_SLOT_MS - 1000);
+          state.waitDuration = this.WANDER_SLOT_MS - state.moveDuration;
+          state.isWaiting = false;
+          state.lastMoveTime = currentTime;
+          npc.direction = state.moveDirection;
+        }
+
         if (state.isWaiting) {
-          // Waiting between moves
-          if (timeSinceLastMove >= state.waitDuration) {
-            // Pick a random direction and duration
-            const directions = [Direction.Up, Direction.Down, Direction.Left, Direction.Right];
-            state.moveDirection = directions[Math.floor(Math.random() * directions.length)];
-            state.moveDuration = 1000 + Math.random() * 2000; // 1-3 seconds
-            state.isWaiting = false;
-            state.lastMoveTime = currentTime;
-            npc.direction = state.moveDirection;
-          }
+          // Standing still until the next slot boundary — nothing to do.
         } else {
           // Moving
           if (timeSinceLastMove >= state.moveDuration) {
-            // Stop moving, start waiting
+            // Stop moving for the rest of this slot
             state.isWaiting = true;
-            state.waitDuration = 1000 + Math.random() * 3000; // 1-4 seconds
-            state.lastMoveTime = currentTime;
           } else {
             // Continue moving in current direction
             const movement = this.NPC_SPEED * deltaTime;
@@ -790,9 +822,12 @@ class NPCManagerClass {
               const allDirections = [Direction.Up, Direction.Down, Direction.Left, Direction.Right];
               const otherDirections = allDirections.filter((d) => d !== state.moveDirection);
 
-              // Shuffle other directions for variety
+              // Shuffle other directions for variety. Seeded from the same
+              // (npc, slot) pair, so two clients that hit the same wall pick
+              // the same way out rather than diverging on the bounce.
+              const fallbackRandom = createDecisionRandom(`${npc.id}:fallback`, slot);
               for (let i = otherDirections.length - 1; i > 0; i--) {
-                const j = Math.floor(Math.random() * (i + 1));
+                const j = Math.floor(fallbackRandom() * (i + 1));
                 [otherDirections[i], otherDirections[j]] = [otherDirections[j], otherDirections[i]];
               }
 
@@ -824,11 +859,9 @@ class NPCManagerClass {
                 }
               }
 
-              // If no clear direction found, wait briefly then try again
+              // Boxed in: stand until the next slot picks a new direction.
               if (!foundAlternative) {
                 state.isWaiting = true;
-                state.waitDuration = 300 + Math.random() * 500; // Shorter wait
-                state.lastMoveTime = currentTime;
               }
             }
           }

--- a/components/EmoteWheel.tsx
+++ b/components/EmoteWheel.tsx
@@ -1,0 +1,91 @@
+/**
+ * EmoteWheel — the only way players talk to each other.
+ *
+ * The vocabulary is closed on purpose (see multiplayer/emotes.ts): this game is
+ * played by children, and a fixed set of gestures means it is not *possible* to
+ * say something harmful, rather than possible-but-moderated. There is no
+ * free-text channel and there is not meant to be one.
+ *
+ * Laid out as a bar rather than a true radial: eight targets around a circle are
+ * fiddly on a tablet, and this sits directly above the touch controls that open it.
+ */
+
+import React, { useEffect } from 'react';
+import { EMOTES } from '../multiplayer/emotes';
+import type { EmoteId } from '../multiplayer/emotes';
+import { Z_EMOTE_WHEEL, zClass } from '../zIndex';
+
+interface EmoteWheelProps {
+  onSelect: (emote: EmoteId) => void;
+  onClose: () => void;
+  /** Smaller targets for short screens, matching TouchControls' compact mode */
+  compact?: boolean;
+}
+
+const EmoteWheel: React.FC<EmoteWheelProps> = ({ onSelect, onClose, compact = false }) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      // 1-8 pick an emote directly, so a keyboard player never needs the mouse.
+      const index = Number.parseInt(e.key, 10) - 1;
+      if (!Number.isNaN(index) && index >= 0 && index < EMOTES.length) {
+        e.preventDefault();
+        onSelect(EMOTES[index].id);
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose, onSelect]);
+
+  const buttonSize = compact ? 'w-12 h-12 text-2xl' : 'w-14 h-14 text-3xl';
+
+  return (
+    <>
+      {/* Invisible backdrop — a tap anywhere else dismisses without choosing */}
+      <div
+        className={`fixed inset-0 ${zClass(Z_EMOTE_WHEEL)}`}
+        onClick={onClose}
+        onTouchStart={onClose}
+      />
+
+      <div
+        className={`fixed left-1/2 -translate-x-1/2 ${zClass(Z_EMOTE_WHEEL)}`}
+        style={{
+          bottom: compact
+            ? 'calc(180px + env(safe-area-inset-bottom, 0px))'
+            : 'calc(220px + env(safe-area-inset-bottom, 0px))',
+        }}
+      >
+        <div className="flex gap-1.5 rounded-2xl border-2 border-amber-200/70 bg-stone-800/95 px-3 py-2 shadow-xl">
+          {EMOTES.map((emote, index) => (
+            <button
+              key={emote.id}
+              title={`${emote.label} (${index + 1})`}
+              aria-label={emote.label}
+              onClick={(e) => {
+                e.stopPropagation();
+                onSelect(emote.id);
+                onClose();
+              }}
+              onTouchStart={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
+                onSelect(emote.id);
+                onClose();
+              }}
+              className={`${buttonSize} flex items-center justify-center rounded-xl bg-stone-700/80 transition-transform hover:scale-110 hover:bg-stone-600 active:scale-95`}
+            >
+              {emote.icon}
+            </button>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default EmoteWheel;

--- a/components/PresenceIndicator.tsx
+++ b/components/PresenceIndicator.tsx
@@ -1,0 +1,42 @@
+/**
+ * PresenceIndicator — "2 friends here".
+ *
+ * Small enough to ignore and useful enough to glance at: it tells you whether
+ * anyone else is in this map before you have spotted them behind a tree.
+ * Renders nothing at all when you are alone, so single-player is untouched.
+ */
+
+import React from 'react';
+import { Z_PRESENCE_INDICATOR, zClass } from '../zIndex';
+
+interface PresenceIndicatorProps {
+  count: number;
+  names: string[];
+  /** Smaller layout for short screens */
+  compact?: boolean;
+}
+
+const PresenceIndicator: React.FC<PresenceIndicatorProps> = ({ count, names, compact = false }) => {
+  if (count <= 0) return null;
+
+  const label = count === 1 ? '1 friend here' : `${count} friends here`;
+
+  return (
+    <div
+      className={`pointer-events-none fixed left-1/2 -translate-x-1/2 ${zClass(Z_PRESENCE_INDICATOR)}`}
+      style={{ top: compact ? '8px' : '14px' }}
+      title={names.join(', ')}
+    >
+      <div
+        className={`flex items-center gap-1.5 rounded-full border border-amber-200/50 bg-stone-800/75 text-amber-50 shadow-md ${
+          compact ? 'px-2.5 py-0.5 text-xs' : 'px-3 py-1 text-sm'
+        }`}
+      >
+        <span aria-hidden="true">🧑‍🤝‍🧑</span>
+        <span>{label}</span>
+      </div>
+    </div>
+  );
+};
+
+export default PresenceIndicator;

--- a/components/RemotePlayerOverlay.tsx
+++ b/components/RemotePlayerOverlay.tsx
@@ -1,0 +1,110 @@
+/**
+ * RemotePlayerOverlay — DOM rendering of other players.
+ *
+ * The fallback for USE_PIXI_RENDERER = false. Positioning mirrors the DOM
+ * player and NPC renderers exactly (top-left corner derived from the centre,
+ * grid offset added, z-index from the feet Y) so remote players sort with
+ * everything else in that path.
+ *
+ * It drives its own requestAnimationFrame rather than taking a trigger prop:
+ * interpolated positions change every frame, and pushing that through React
+ * state from the manager would make every remote player cost a re-render for
+ * the PixiJS path too, where nothing needs it.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { PLAYER_SIZE } from '../constants';
+import { Z_PLAYER } from '../zIndex';
+import type { Position } from '../types';
+import { remotePlayerManager } from '../multiplayer/RemotePlayerManager';
+import { getRemoteSpriteInfo } from '../multiplayer/remoteSprites';
+import { getEmoteIcon } from '../multiplayer/emotes';
+
+interface RemotePlayerOverlayProps {
+  /** Map-level scale multiplier for all characters */
+  characterScale?: number;
+  /** Offset for background-image rooms with centred layers */
+  gridOffset?: Position;
+  /** Viewport-scaled tile size */
+  tileSize: number;
+}
+
+const RemotePlayerOverlay: React.FC<RemotePlayerOverlayProps> = ({
+  characterScale = 1.0,
+  gridOffset,
+  tileSize,
+}) => {
+  const [, forceRender] = useState(0);
+
+  useEffect(() => {
+    let frameId = 0;
+    const loop = () => {
+      forceRender((n) => n + 1);
+      frameId = requestAnimationFrame(loop);
+    };
+    frameId = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(frameId);
+  }, []);
+
+  const offsetX = gridOffset?.x ?? 0;
+  const offsetY = gridOffset?.y ?? 0;
+
+  return (
+    <>
+      {remotePlayerManager.getRemotePlayers().map((player) => {
+        const { url, spriteScale, shouldFlip } = getRemoteSpriteInfo(player);
+        const effectiveScale = spriteScale * characterScale;
+        const size = PLAYER_SIZE * effectiveScale * tileSize;
+        const left = (player.position.x - (PLAYER_SIZE * effectiveScale) / 2) * tileSize + offsetX;
+        const top = (player.position.y - (PLAYER_SIZE * effectiveScale) / 2) * tileSize + offsetY;
+        const zIndex = Z_PLAYER + Math.floor(player.position.y + 0.3);
+        const emoteIcon = player.emote ? getEmoteIcon(player.emote) : null;
+
+        return (
+          <React.Fragment key={player.uid}>
+            <img
+              src={url}
+              alt={player.name}
+              className="absolute pointer-events-none"
+              style={{
+                left,
+                top,
+                width: size,
+                height: size,
+                zIndex,
+                transform: shouldFlip ? 'scaleX(-1)' : undefined,
+              }}
+            />
+            <div
+              className="absolute pointer-events-none whitespace-nowrap text-center text-sm font-semibold text-white"
+              style={{
+                left: player.position.x * tileSize + offsetX,
+                top: (player.position.y - 0.85 * characterScale) * tileSize + offsetY,
+                transform: 'translate(-50%, -100%)',
+                textShadow: '0 0 4px #2b2b3a, 0 0 4px #2b2b3a',
+                zIndex: zIndex + 1,
+              }}
+            >
+              {player.name}
+            </div>
+            {emoteIcon && (
+              <div
+                className="absolute pointer-events-none text-2xl"
+                style={{
+                  left: player.position.x * tileSize + offsetX,
+                  top: (player.position.y - 1.35 * characterScale) * tileSize + offsetY,
+                  transform: 'translate(-50%, -100%)',
+                  zIndex: zIndex + 2,
+                }}
+              >
+                {emoteIcon}
+              </div>
+            )}
+          </React.Fragment>
+        );
+      })}
+    </>
+  );
+};
+
+export default RemotePlayerOverlay;

--- a/components/TouchControls.tsx
+++ b/components/TouchControls.tsx
@@ -8,6 +8,8 @@ interface TouchControlsProps {
   onResetPress: () => void;
   /** Called when the photo button is pressed (only rendered when provided) */
   onPhotoPress?: () => void;
+  /** Called when the emote button is pressed (only rendered when provided) */
+  onEmotePress?: () => void;
   /** Use smaller controls for small screens (< 600px height) */
   compact?: boolean;
 }
@@ -29,6 +31,7 @@ const TouchControls: React.FC<TouchControlsProps> = ({
   onDirectionRelease,
   onResetPress,
   onPhotoPress,
+  onEmotePress,
   compact = false,
 }) => {
   const handleTouchStart = (direction: 'up' | 'down' | 'left' | 'right') => {
@@ -120,6 +123,19 @@ const TouchControls: React.FC<TouchControlsProps> = ({
             title="Take Photo"
           >
             <img src={itemAssets.camera} alt="Take Photo" className={`${compact ? 'w-8 h-8' : 'w-10 h-10'} object-contain`} />
+          </button>
+        )}
+        {/* Emote button — the only player-to-player channel (see multiplayer/emotes.ts) */}
+        {onEmotePress && (
+          <button
+            onTouchStart={(e) => {
+              e.preventDefault();
+              onEmotePress();
+            }}
+            className={`${compact ? 'w-12 h-12' : 'w-14 h-14'} bg-amber-700/90 hover:bg-amber-600/90 active:bg-amber-500/90 rounded-full border-2 border-amber-400/70 flex items-center justify-center text-white ${compact ? 'text-xl' : 'text-2xl'} shadow-md`}
+            title="Emotes"
+          >
+            👋
           </button>
         )}
         {/* Reset button - small, for getting unstuck */}

--- a/constants.ts
+++ b/constants.ts
@@ -18,6 +18,68 @@ export const USE_PIXI_RENDERER = true; // Enabled for testing
 // Set to false to disable shadows (minimal performance impact, mostly aesthetic preference)
 export const USE_SPRITE_SHADOWS = true;
 
+// ═══════════════════════════════════════════════════════════════════════════
+//  MULTIPLAYER — shared world, soft sync
+//  See design_docs/planned/MULTIPLAYER.md
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Multiplayer feature flag. When false, every subscription, publish and remote
+ * render path is disabled at the controller boundary and the game is identical
+ * to single-player. Also disabled automatically when Firebase is unavailable.
+ */
+export const MULTIPLAYER_ENABLED = import.meta.env.VITE_MULTIPLAYER_ENABLED !== 'false';
+
+export const MULTIPLAYER = {
+  /**
+   * Maps where other players are visible. Everything else — home interiors,
+   * personal garden, and all RANDOM_* procedural maps — is private.
+   * Procedural maps must stay out: each client generates its own forest from a
+   * different seed, so two players "in the forest" are not in the same forest.
+   */
+  SHARED_MAPS: new Set([
+    'village',
+    'farm_area',
+    'orchard',
+    'sea_side',
+    'magical_lake',
+    'ruins',
+    'mushroom_map',
+  ]),
+
+  /** Maximum position writes per second while moving */
+  PUBLISH_HZ: 5,
+
+  /** Don't publish movement smaller than this (tiles) — kills sub-pixel jitter */
+  MOVE_THRESHOLD_TILES: 0.08,
+
+  /** Republish even when idle, so `t` stays fresh and staleness eviction is meaningful */
+  HEARTBEAT_MS: 15000,
+
+  /** Evict a remote player we have not heard from for this long */
+  STALE_AFTER_MS: 45000,
+
+  /** Render remote players this far in the past, so interpolation always has two samples */
+  INTERPOLATION_DELAY_MS: 120,
+
+  /** Beyond this gap between samples, snap instead of lerping (teleport / map change) */
+  SNAP_DISTANCE_TILES: 3,
+
+  /** How long an emote stays above a player's head */
+  EMOTE_DURATION_MS: 3000,
+
+  /** Tiles of travel per walk-cycle frame. Remote animation is derived from
+   *  distance moved rather than sent over the wire — one less field, and the
+   *  legs move because the character moved, which is always right. */
+  ANIM_TILES_PER_FRAME: 0.35,
+
+  /** Below this speed (tiles/sec) a remote player is considered standing still */
+  IDLE_SPEED_TILES_PER_SEC: 0.15,
+
+  /** Max samples kept per remote player for interpolation */
+  SAMPLE_BUFFER_SIZE: 4,
+} as const;
+
 /**
  * DEBUG - Verbose logging flags for development
  *
@@ -35,6 +97,7 @@ export const DEBUG = {
   QUEST: import.meta.env.DEV && false, // Quest progression and dialogue actions
   FORAGE: import.meta.env.DEV && false, // Foraging actions and loot rolls
   CLICK: import.meta.env.DEV && false, // Click targeting and interaction detection
+  MULTIPLAYER: import.meta.env.DEV && false, // Presence publish/receive and remote player lifecycle
 } as const;
 
 /**

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,43 @@
+{
+  "rules": {
+    "presence": {
+      "$mapId": {
+        ".read": "auth != null",
+        "$uid": {
+          ".write": "auth != null && auth.uid === $uid",
+          ".validate": "newData.hasChildren(['n','c','x','y','d','t'])",
+          "n": {
+            ".validate": "newData.isString() && newData.val().length > 0 && newData.val().length <= 20"
+          },
+          "c": {
+            ".validate": "newData.val() === 'character1' || newData.val() === 'character2'"
+          },
+          "x": {
+            ".validate": "newData.isNumber() && newData.val() >= 0 && newData.val() <= 200"
+          },
+          "y": {
+            ".validate": "newData.isNumber() && newData.val() >= 0 && newData.val() <= 200"
+          },
+          "d": {
+            ".validate": "newData.val() === 'u' || newData.val() === 'd' || newData.val() === 'l' || newData.val() === 'r'"
+          },
+          "s": {
+            ".validate": "newData.isNumber() && newData.val() >= -3 && newData.val() <= 3"
+          },
+          "ff": {
+            ".validate": "newData.isBoolean()"
+          },
+          "e": {
+            ".validate": "newData.val() === null || newData.val() === 'wave' || newData.val() === 'laugh' || newData.val() === 'heart' || newData.val() === 'question' || newData.val() === 'yes' || newData.val() === 'sad' || newData.val() === 'dance' || newData.val() === 'followme'"
+          },
+          "t": {
+            ".validate": "newData.val() === now"
+          },
+          "$other": {
+            ".validate": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/design_docs/planned/MULTIPLAYER.md
+++ b/design_docs/planned/MULTIPLAYER.md
@@ -1,0 +1,662 @@
+# Multiplayer Design — Shared World, Soft Sync
+
+**Status**: **Implemented** — Phases 0–4 built; see the Implementation Notes appendix
+**Remaining**: Phase 5 (phrase book, shared decorations, mailbox gifting) — not built
+**Feature flag**: `MULTIPLAYER_ENABLED` in `constants.ts` (+ `VITE_MULTIPLAYER_ENABLED`)
+**Setup**: set `VITE_FIREBASE_DATABASE_URL` in `.env.local`, then
+`firebase deploy --only database` to publish `database.rules.json`. Without the URL the game
+runs exactly as single-player.
+
+---
+
+## 1. What we are building
+
+Two to eight players — realistically a family and their friends — inhabit **the same Clover Village
+at the same time**. You walk into the village and Sanne's character is already there, watering the
+bed you tilled yesterday. She waves. You wave back. You both wander off to forage and meet again by
+the pond.
+
+That is the whole ambition. It is a peaceful game and the multiplayer should feel peaceful too:
+*presence and traces*, not competition.
+
+### Goals
+
+1. **See each other** — remote players render as animated characters, correctly depth-sorted, with
+   name tags, moving smoothly.
+2. **Share the spaces that matter** — Clover Village, the farm area, the orchard. The world one
+   player changes is the world the others see.
+3. **Leave traces** — "Sanne watered your carrots", gifts in a mailbox, shared discoveries.
+4. **Communicate safely** — emotes and a closed phrase book. No free-text chat (this game has a
+   young audience; see §9).
+5. **Degrade to single-player perfectly** — no Firebase, no network, bad Wi-Fi: the game plays
+   exactly as it does today.
+
+### Non-goals
+
+- An authoritative game server. There is no server-side simulation and there will not be one.
+- Anti-cheat. The threat model is "a nine-year-old with the dev console", and the cost of cheating
+  is that they get extra carrots. Rules validate *shape*, not *fairness*.
+- Lobbies, matchmaking, friend requests, instancing. One world, everyone in it.
+- PvP or contested combat.
+- Scale beyond ~20 concurrent players. The design would need a different transport at 100+.
+
+---
+
+## 2. Why this codebase is unusually ready for this
+
+Most of the hard parts of a shared world are already solved here, by accident or by good design.
+This is worth stating precisely, because it changes what the work actually is.
+
+| Already true | Where | What it buys us |
+|---|---|---|
+| **Time is wall-clock derived** — `GAME_START_DATE + Date.now()`, 2 real hours per game day | `utils/TimeManager.ts:62` | Every client already agrees on the hour, day, season and year with **zero synchronisation**. Nothing to build. |
+| **Weather is a seeded PRNG** keyed on time-slot index + season | `utils/WeatherManager.ts` | Every client already sees the same rain at the same moment. Guarded by `tests/deterministicWeather.test.ts`. |
+| **A shared-world subsystem already ships** — the community garden | `firebase/communityGardenService.ts`, `utils/farmManager.ts` (`startSharedSync`) | The pattern is proven in production: optimistic local write → dirty set → batched flush every 10s → `onSnapshot` for remote changes → echo-suppression grace period. Generalise it; don't reinvent it. |
+| **Auth exists, including anonymous** | `firebase/authService.ts:161` | A player can be identified without an account. Anonymous → linked account is already implemented. |
+| **A layer that renders N animated characters with depth sorting** | `utils/pixi/NPCLayer.ts` | Remote players are, structurally, *NPCs we do not control*. The renderer barely changes. |
+| **EventBus decouples managers from React** | `utils/EventBus.ts` | A `RemotePlayerManager` can drive re-renders exactly like `NPCManager` does. |
+| **`firebase/safe.ts` stub pattern** | `firebase/safe.ts` | Multiplayer disables itself when the package or env is missing, with no call-site changes. |
+| **Character appearance is one string** | `utils/characterSprites.ts:63` | Sprites resolve to `/assets/{characterId}/base/{dir}_{n}.png`. Replicating a player's look costs **one field**: `characterId`. |
+
+So the remaining work is narrower than "make it multiplayer". It is four things:
+
+1. A **presence transport** (who is here, where are they).
+2. A **`RemotePlayerManager`** mirroring `NPCManager`.
+3. A **render layer** mirroring `NPCLayer`.
+4. A **classification decision** for every other piece of world state (§3) — which is mostly a game
+   design question, not an engineering one.
+
+---
+
+## 3. The model: three tiers of state
+
+Everything in the game falls into exactly one of these. Getting each item into the right row is the
+single most important design decision in this document.
+
+| Tier | Meaning | Transport | Conflict rule |
+|---|---|---|---|
+| **Ephemeral** | Only true while you are online: position, facing, current emote | Realtime Database | Last write wins; `onDisconnect()` removes it |
+| **Shared durable** | A change one player makes that others must see later | Firestore (existing pattern) | Last-write-wins, plus *claim transactions* for consumables (§8) |
+| **Private** | Yours alone; nobody else can observe it | Firestore per-user cloud save (already built) | None — single writer |
+| **Derived** | Recomputed identically on every client from time + seeds | **None** | Must stay deterministic (§7) |
+
+### Classification of every subsystem
+
+| System | Tier | Notes |
+|---|---|---|
+| Player position / direction / animation | Ephemeral | §5 |
+| Emote, "is typing a phrase" | Ephemeral | Short TTL |
+| Farm plots on `village` + `farm_area` | Shared durable | **Already shared.** Extend with claims (§8) |
+| Placed items / decoration on shared maps | Shared durable | Phase 4. Currently `gameState.getPlacedItems(mapId)` is local |
+| Community wreath / Yule decorations | Shared durable | Natural co-op showpiece |
+| Player mailbox (gifts) | Shared durable | New; write to *recipient's* subcollection |
+| World events / discoveries | Shared durable | **Already exists** — `sharedEvents` collection |
+| NPC gossip / conversation summaries | Shared durable | **Already exists** — `conversations/{npcId}/summaries` |
+| Inventory, gold, stamina | Private | Never replicate. Two players harvesting is not two players sharing a bag |
+| Quests, event chains, magic level, cooking book | Private | Each player has their own story. Do not share |
+| Friendships with NPCs | Private | Mum can be everyone's mum |
+| Photos, paintings | Private, with opt-in share | Paintings already have Firestore storage; a "hang in the village gallery" feature is a Phase 5 idea |
+| Foraging, berry bushes, fruit trees, cobwebs, mess piles | **Private (recommended)** | See the design note below |
+| Shop stock | Private | Shared stock means the first player online empties the shop. Bad |
+| Time, date, season, weather | Derived | Already correct |
+| NPC positions and states | Derived | Currently **non-deterministic** — see §7 |
+| Procedural `RANDOM_*` maps | Derived, currently **broken for sharing** — see §7 |
+
+**Design note — renewables stay private.** It is tempting to make berry bushes and fruit trees
+shared, for "realism". Don't. A shared renewable means whoever logs in first strips the map and
+everyone else walks through an empty world. Private renewables mean the world is always generous,
+which is the tone this game is going for. Share the things players *build* (farm beds, decorations);
+keep the things the world *gives* per-player.
+
+---
+
+## 4. Transport: Realtime Database for presence, Firestore for everything else
+
+We are already on Firestore and it is the right tool for durable shared state. It is the **wrong**
+tool for position updates.
+
+Firestore bills per document write. A player publishing position at 5 Hz for a two-hour session is
+36,000 writes. The Firestore free tier is 20,000 writes **per day, across the whole project**. One
+child playing one afternoon would exhaust it, and paid pricing is ~£0.14 per 100k writes — survivable
+but absurd for data with a 200 ms shelf life.
+
+Realtime Database bills by bandwidth and stored bytes, has sub-100 ms fan-out, and — decisively —
+has **`onDisconnect()`**, which lets the *server* delete a player's presence node when their socket
+drops. Without it, every crashed tab leaves a ghost standing in the village forever, and we would
+have to invent a heartbeat-and-reap scheme to clean them up.
+
+**Decision: add Realtime Database alongside Firestore, used only for ephemeral presence.**
+
+New files, following the existing config/safe pattern exactly:
+
+- `firebase/realtimeConfig.ts` — `getFirebaseRtdb()`, reads `VITE_FIREBASE_DATABASE_URL`
+- `firebase/index.ts` — export the presence service
+- `firebase/safe.ts` — `getPresenceService()` + a stub whose methods are all no-ops
+
+### Presence schema
+
+Keyed by map, so a client only subscribes to the players it can actually see:
+
+```
+presence/
+  {mapId}/
+    {uid}: {
+      n:  "Sanne",        // display name, <= 20 chars
+      c:  "character2",   // characterId — the whole of appearance
+      x:  14.32,          // tile coords, 2dp
+      y:  8.91,
+      d:  "d",            // direction code: 'u' | 'd' | 'l' | 'r'
+      s:  0,              // size tier (-3..3), for potion effects
+      ff: false,          // fairy form
+      e:  "wave",         // current emote id, or null
+      t:  1735689600000   // server timestamp (rules-enforced)
+    }
+```
+
+`Direction` is a *numeric* enum in `types/core.ts`, so sending the raw value would break every
+older client the day somebody reorders that enum. Four bytes of stable single-character codes is a
+fair price for not leaving a compatibility landmine in a shared data format.
+
+About 90 bytes per player. `onDisconnect(ref).remove()` is registered immediately after the first
+write, so a closed tab, a killed browser or a dead Wi-Fi connection cleans itself up.
+
+**Rooms are map IDs.** A client subscribes to `presence/{currentMapId}` only. Bandwidth therefore
+scales with *co-located* players, not total players — which is the property that makes this cheap.
+
+**Private maps are excluded.** `home_interior`, `home_upstairs`, `mums_kitchen`, `personal_garden`
+and all `RANDOM_*` maps publish no presence. Define the shared set explicitly in `constants.ts`:
+
+```ts
+export const MULTIPLAYER = {
+  /** Maps where other players are visible. Everything else is private. */
+  SHARED_MAPS: new Set(['village', 'farm_area', 'orchard', 'sea_side', 'magical_lake']),
+  PUBLISH_HZ: 5,               // max position writes per second
+  MOVE_THRESHOLD_TILES: 0.08,  // don't publish sub-pixel jitter
+  HEARTBEAT_MS: 15000,         // republish even when idle, so `t` stays fresh
+  STALE_AFTER_MS: 45000,       // evict a remote player we stopped hearing from
+  INTERPOLATION_DELAY_MS: 120, // render remote players this far in the past
+  SNAP_DISTANCE_TILES: 3,      // teleport instead of lerping beyond this
+  EMOTE_DURATION_MS: 3000,
+} as const;
+```
+
+---
+
+## 5. Presence protocol
+
+### Publishing (local player → RTDB)
+
+Driven from the existing `gameLoop` in `App.tsx`, through the controller hook — not from a timer, so
+it stops when the tab is backgrounded:
+
+1. Every frame, compare `playerPosRef.current` to the last published position.
+2. Publish if `distance > MOVE_THRESHOLD_TILES` **and** at least `1000 / PUBLISH_HZ` ms have passed.
+3. Publish unconditionally on direction change, emote, map change, and every `HEARTBEAT_MS`.
+4. On map change: remove the node from the old map, register a fresh `onDisconnect` on the new one.
+
+**Do not publish the animation frame.** Derive the remote walk cycle from distance travelled between
+snapshots. This saves a field and, more importantly, makes the animation smooth regardless of packet
+timing — the legs move because the character moved, which is always right.
+
+### Subscribing (RTDB → remote players)
+
+`presenceService` attaches `child_added` / `child_changed` / `child_removed` on
+`presence/{currentMapId}`, filters out our own uid, and hands raw snapshots to `RemotePlayerManager`.
+
+### Interpolation
+
+Each remote player keeps a small buffer of the last two snapshots. On every game-loop tick we render
+their position at `now - INTERPOLATION_DELAY_MS`, linearly interpolating between the bracketing
+snapshots. 120 ms of deliberate lag buys completely smooth motion at 5 Hz updates, and nobody can
+perceive it on another player's character.
+
+If the gap between consecutive snapshots exceeds `SNAP_DISTANCE_TILES`, snap instead of lerping —
+that is a teleport or a map transition, not movement.
+
+The interpolation function must be **pure and exported**, so it can be unit-tested without Firebase:
+
+```ts
+// multiplayer/interpolation.ts
+export function interpolateAt(
+  buffer: PresenceSnapshot[],
+  renderTimeMs: number
+): { pos: Position; direction: Direction; speed: number } | null
+```
+
+---
+
+## 6. Client architecture
+
+Per the golden rule in `App.tsx`'s navigation header: **new system → new hook**. `App.tsx` gains
+wiring only.
+
+```
+multiplayer/
+  types.ts                    RemotePlayer, PresenceSnapshot, EmoteId
+  presenceService.ts          Transport only. RTDB read/write/onDisconnect/room switching.
+                              Mirrors the shape of firebase/communityGardenService.ts.
+  RemotePlayerManager.ts      SSoT for remote players. Mirrors NPCManager:
+                              getCurrentMapRemotePlayers(), tick(deltaTime), stale eviction,
+                              emits REMOTE_PLAYER_* on the EventBus.
+  interpolation.ts            Pure functions. Fully unit-tested.
+  emotes.ts                   The closed emote/phrase vocabulary (SSoT, also used by rules).
+
+hooks/
+  useMultiplayerController.ts Domain controller. Subscribes on map change, pumps local position
+                              out, ticks interpolation from the game loop, returns
+                              { remotePlayers, remotePlayerUpdateTrigger, sendEmote }.
+
+utils/pixi/
+  RemotePlayerLayer.ts        extends PixiLayer. setDepthContainer() like NPCLayer/PlayerSprite,
+                              zIndex = Z_DEPTH_SORTED_BASE + feetY, name-tag text, emote bubble.
+
+components/
+  RemotePlayerOverlay.tsx     DOM fallback for USE_PIXI_RENDERER=false + name tags + prompts.
+  EmoteWheel.tsx              Radial emote picker (reuse RadialMenu conventions).
+```
+
+Plus:
+
+- `utils/EventBus.ts` — `REMOTE_PLAYER_JOINED`, `REMOTE_PLAYER_LEFT`, `REMOTE_PLAYER_MOVED`,
+  `REMOTE_PLAYER_EMOTED`, with payload types
+- `hooks/useGameEvents.ts` — a `remotePlayerUpdateTrigger`, exactly like `npcUpdateTrigger`
+- `constants.ts` — the `MULTIPLAYER` block above, `MULTIPLAYER_ENABLED`, `DEBUG.MULTIPLAYER`
+- `zIndex.ts` — `Z_PLAYER_NAME_TAG` in the overlay range if tags are DOM-rendered
+
+### Data flow
+
+```
+  local movement (usePlayerMovement)
+        │
+        ▼
+  useMultiplayerController ──throttle──▶ presenceService.publish() ──▶ RTDB
+                                                                        │
+  RemotePlayerLayer.render() ◀── RemotePlayerManager ◀──child_changed────┘
+        ▲                              │
+        └──── gameLoop tick ───────────┘  (interpolate, evict stale, emit events)
+```
+
+### Failure isolation
+
+A presence failure must **never** touch the game loop. Commit `dec0da7` fixed a splash screen that
+blocked game init; the same class of bug is easy to reintroduce here. Rules:
+
+- `presenceService` never throws to callers — it logs and returns `false`, like `writePlot` does.
+- `RemotePlayerManager.tick()` is wrapped so an exception cannot break the frame.
+- Presence subscription is **not** awaited during map load.
+
+---
+
+## 7. Determinism: the parts that will silently disagree
+
+Three systems are in the "Derived" tier but are not actually deterministic today. Each will produce
+visible disagreement between players.
+
+### 7.1 NPC wander (will diverge — must fix)
+
+`NPCManager.updateNPCs` picks directions and durations with `Math.random()` in five places
+(`NPCManager.ts:751`, `752`, `762`, `795`, `830`). Alice's deer is by the pond; Bob's is in the
+trees. When they say "look at the deer!" they are pointing at nothing.
+
+Three options:
+
+| Option | Cost | Verdict |
+|---|---|---|
+| **A. Accept it** — NPCs are local scenery | Zero | Cheapest, but kills shared moments. Acceptable for Phase 1 only |
+| **B. Seeded wander** — replace `Math.random()` with a PRNG keyed on `(npcId, floor(now / DECISION_INTERVAL_MS))` | ~40 lines in `NPCManager` | **Recommended, and what was built.** Zero bandwidth, testable, and it makes NPC behaviour reproducible for debugging too. See the caveat below — this converges *decisions*, not *positions* |
+| **C. Host-authoritative NPCs** — elect the lowest-uid client in the room to publish NPC positions | High | Adds a host-handoff failure mode for a purely cosmetic benefit. No |
+
+Option B follows the pattern `WeatherManager` already uses and that `tests/deterministicWeather.test.ts`
+already guards. Same trick, same test shape.
+
+**Caveat, stated plainly because it was overclaimed in the first draft of this document.**
+Identical decisions do *not* guarantee identical positions. Every client now picks the same
+direction for the same NPC at the same instant, but two clients that started watching an NPC at
+different times — or that reached a wall from slightly different places — can still drift apart.
+Full convergence would mean expressing the wander as a closed-form function of time (smooth noise
+around a base position, evaluated at `now`), which would replace the behaviour of every wandering
+NPC wholesale, including its interaction with animated states, `allowedDirections`, `canFly` and
+follow behaviour. That is a large, risky rewrite of a working system for a cosmetic benefit. What
+is built gets the shared-moment payoff — "look, the deer!" — for a fraction of the risk. Revisit
+if drift turns out to be noticeable in practice.
+
+Note that NPC *dialogue* state stays local and should: `isInDialogue` freezes an NPC for the player
+talking to them. Two players can both be mid-conversation with Mum, each seeing her attentive. That
+is the correct behaviour, not a bug.
+
+`fairyAttractionManager` has two `Math.random()` calls and needs the same treatment; its spawn
+condition is already time-and-bluebell keyed, so it is nearly deterministic already.
+
+### 7.2 Procedural maps (currently per-player instances)
+
+`generateRandomForest(seed: number = Date.now())` (`maps/procedural.ts:208`) — every client that
+walks into the forest generates a *different forest*. Two players "in the forest together" are in
+different worlds with differently-placed lakes, wolves and bears.
+
+Two acceptable answers:
+
+- **Exclude `RANDOM_*` maps from presence** (Phase 1 default — they are already off `SHARED_MAPS`).
+- **Make the seed global**: `seed = floor(Date.now() / MS_PER_GAME_DAY) * 1000 + depth`. Everyone
+  who enters the forest at depth 2 today gets the same forest, and it reshuffles daily. This is a
+  small change with a large payoff and is the recommended Phase 3 follow-up.
+
+The second option also fixes a latent single-player oddity: today, stepping out of the forest and
+back in regenerates it entirely.
+
+### 7.3 Add a determinism test file
+
+`tests/determinism.test.ts` — instantiate two `NPCManager`s, tick both with an identical fixed clock,
+assert identical positions after N steps. Follow the collect-then-assert style of `tests/itemSSoT.test.ts`.
+
+---
+
+## 8. Contention: the double-harvest problem
+
+There is exactly one genuinely contended action in a peaceful game: **two players harvest the same
+crop at the same moment**. Both clients optimistically grant an item and both write `FALLOW`. Two
+carrots exist where one grew.
+
+This is **already possible today** on the shared farm — `farmManager` flushes dirty plots on a 10 s
+interval with last-write-wins, so the window is up to ten seconds wide. It is a pre-existing bug
+that multiplayer will make visible.
+
+### Solution: optimistic grant with claim transaction and silent rollback
+
+```
+1. Player clicks harvest.
+2. Client grants the item immediately and plays the animation. (Feel is preserved — no round-trip.)
+3. Client fires runTransaction() on shared/farming/plots/{plotId}:
+     read state; if state === HARVESTABLE → set FALLOW, claimedBy = uid, claimedAt = ts
+     else → abort
+4. On abort: silently remove the item from inventory, show
+   "Sanne got there first!" as a toast, and revert the plot.
+```
+
+Blocking on the transaction before granting would be *correct* and would feel awful — a 200 ms stall
+on every harvest, in a game whose whole appeal is unhurried tactility. Optimistic-with-rollback puts
+the cost entirely on the rare collision.
+
+The `claimedBy` field is also what powers the nice half of this: `"Sanne watered your carrots"`
+notifications. `communityGardenService` already writes `plantedBy` / `plantedByUid` — extend, don't
+add.
+
+Non-farm contention does not exist, because renewables are private (§3).
+
+---
+
+## 9. Player-to-player interaction, in risk order
+
+This game is played by children. Interaction design here is a safety decision before it is a feature
+decision, and the safest system is one where **the vocabulary is closed** — where it is not possible
+to say something harmful, rather than possible-but-moderated.
+
+| Tier | Feature | Risk | Phase |
+|---|---|---|---|
+| 1 | See each other, name tags | Display names are user-set → needs a filter or a generator (§12) | 1 |
+| 2 | **Emote wheel** — ~8 fixed emotes (wave, laugh, heart, question, thumbs up, sad, dance, follow-me) | None. Closed vocabulary | 2 |
+| 3 | **Phrase book** — ~20 fixed sentences ("Hello!", "Come and see this", "Thank you", "Want to farm together?") | None. Closed vocabulary, and trivially localisable | 5 |
+| 4 | **Mailbox gifting** — leave an item for a named player, collected later | Low. Item-only, no text | 4 |
+| 5 | Free-text chat | High. Requires moderation, reporting, parental controls | **Not recommended. Do not build.** |
+
+Emotes render through the existing `ThoughtBubbleLayer` / `components/ThoughtBubble.tsx` — the art
+and the positioning logic are already there.
+
+The emote and phrase vocabularies live in `multiplayer/emotes.ts` as the single source of truth, and
+the **security rules validate against the same list** (§10). A client cannot publish an emote id that
+is not in the allowlist, so an inspected-console child cannot make their character say anything.
+
+### Co-op activities worth building on top
+
+- **Community garden** — exists. Surface attribution in the UI so it feels collaborative.
+- **Shared Yule / seasonal decorating** — `YuleCelebrationManager`, `SeasonalEventManager` and
+  `WreathWorkshopManager` already coordinate world-wide events on a shared clock. A wreath that
+  everyone contributes a flower to is a small change with a big feeling.
+- **Shared discoveries** — `sharedEvents` already exists and is already read by the gossip system.
+  "Mark found the Fairy Queen's ring" appearing in Sanne's NPC dialogue is nearly free.
+
+---
+
+## 10. Security rules
+
+### Realtime Database (`database.rules.json` — new file)
+
+```json
+{
+  "rules": {
+    "presence": {
+      "$mapId": {
+        ".read": "auth != null",
+        "$uid": {
+          ".write": "auth != null && auth.uid === $uid",
+          ".validate": "newData.hasChildren(['n','c','x','y','d','t'])",
+          "n":  { ".validate": "newData.isString() && newData.val().length <= 20" },
+          "c":  { ".validate": "newData.val() === 'character1' || newData.val() === 'character2'" },
+          "x":  { ".validate": "newData.isNumber() && newData.val() >= 0 && newData.val() <= 200" },
+          "y":  { ".validate": "newData.isNumber() && newData.val() >= 0 && newData.val() <= 200" },
+          "d":  { ".validate": "newData.val() === 'up' || newData.val() === 'down' || newData.val() === 'left' || newData.val() === 'right'" },
+          "e":  { ".validate": "newData.val() === null || newData.val() === 'wave' || newData.val() === 'laugh' || newData.val() === 'heart' || newData.val() === 'question' || newData.val() === 'thumbsup' || newData.val() === 'sad' || newData.val() === 'dance' || newData.val() === 'followme'" },
+          "t":  { ".validate": "newData.val() === now" },
+          "$other": { ".validate": false }
+        }
+      }
+    }
+  }
+}
+```
+
+`"t": newData.val() === now` forces a server timestamp, so stale-eviction cannot be gamed by a
+client lying about its clock. `"$other": false` rejects arbitrary extra keys — without it, presence
+becomes an unmoderated free-text channel by the back door, which defeats §9 entirely.
+
+The emote allowlist is duplicated here from `multiplayer/emotes.ts`. **Add a test that asserts the
+two lists match** — this is exactly the kind of drift `tests/` exists to catch.
+
+### Firestore (`firestore.rules` — extend the existing file)
+
+- `shared/farming/plots/{plotId}` — add `claimedBy` / `claimedAt` to `isValidSharedPlot()`
+- `users/{uid}/mailbox/{giftId}` — `allow create: if isAuthenticated()` with validation that the
+  item id is a string and quantity is a small positive int; `allow read, delete: if isOwner(uid)`.
+  A gift is written by the *sender* into the *recipient's* subcollection, which is the one place
+  this design lets a user write outside their own document tree
+
+---
+
+## 11. Cost
+
+Four players, two hours a day, all in the village:
+
+| | Per player | Total/month |
+|---|---|---|
+| Presence upload | 90 B × 5/s × 7200 s ≈ 3.2 MB/day | ~390 MB |
+| Presence download | 3.2 MB × 3 peers ≈ 9.7 MB/day | ~1.2 GB |
+| Firestore writes | Unchanged (farm flush every 10 s only when dirty) | Well under free tier |
+
+RTDB free tier is 1 GB stored / 10 GB downloaded per month and 100 simultaneous connections. This
+sits comfortably inside it. Storage is negligible — presence nodes are deleted on disconnect.
+
+The design breaks down somewhere around 30–50 concurrent players in one map, where fan-out becomes
+quadratic. At that point the answer is interest management (only subscribe to players within N tiles,
+via geohash-style bucket keys) — worth noting, not worth building now.
+
+---
+
+## 12. Risks and open questions
+
+| Risk | Mitigation |
+|---|---|
+| **Display names.** They come from the account `displayName`, which is user-set free text — a hole in the closed-vocabulary safety model of §9 | Generate names from a curated word list (`Brave Otter`, `Quiet Fern`) and let players *pick*, not type. Decide before Phase 1 ships |
+| **Same account, two devices.** `syncManager` is last-write-wins; two live sessions on one account will clobber each other's saves | Take a session lock in `users/{uid}/meta/session` at sign-in; warn and go read-only on the second device |
+| **NPC divergence noticed before Phase 3** | Ship Phase 1 to a small group who know; or pull §7.1 forward |
+| **Only two character sprite sets exist** (`character1`, `character2`) | Everyone looks like one of two people. Fine for family scale; a real limitation later. Tint/palette variation via Pixi `tint` is a cheap partial answer |
+| **Interiors.** Should two players be able to stand in the same kitchen? | Recommend private interiors for Phase 1 — the maps are 15×9 and two characters would be in each other's way. Revisit for shops |
+| **Testing multiplayer locally** needs two identities | Two browser profiles + two anonymous sign-ins. RTDB emulator (`firebase emulators:start`) for the automated path — `connectFirestoreEmulator` is already wired in `firebase/config.ts:91` |
+
+---
+
+## 13. Phased plan
+
+Each phase is independently shippable behind `MULTIPLAYER_ENABLED` and leaves the game working.
+
+### Phase 0 — Foundations (no visible change)
+
+- `firebase/realtimeConfig.ts`, RTDB env var, `database.rules.json`
+- `multiplayer/types.ts`, `multiplayer/emotes.ts`, `multiplayer/interpolation.ts`
+- `constants.ts`: `MULTIPLAYER` block, `MULTIPLAYER_ENABLED`, `DEBUG.MULTIPLAYER`
+- `firebase/safe.ts`: `getPresenceService()` + stub
+
+**Done when**: `make verify` green, game behaviour byte-identical, stub-parity test passes.
+
+### Phase 1 — Ghosts (the milestone that proves it)
+
+- `multiplayer/presenceService.ts`, `multiplayer/RemotePlayerManager.ts`
+- `hooks/useMultiplayerController.ts`, wired into `App.tsx` gameLoop and map-change effect
+- `utils/pixi/RemotePlayerLayer.ts` + `components/RemotePlayerOverlay.tsx` (DOM fallback)
+- EventBus events + `useGameEvents` trigger
+
+**Done when**: two browser profiles, two anonymous accounts, both in Clover Village — each sees the
+other walk, correctly depth-sorted behind and in front of trees, name tag above, and the ghost
+disappears within a second of closing the other tab.
+
+### Phase 2 — Presence polish
+
+- Interpolation + walk-cycle-from-speed
+- Emote wheel (`components/EmoteWheel.tsx`, keyboard `T`, touch button — **both**, per CLAUDE.md)
+- Map-change room switching, stale eviction, heartbeat
+- HUD indicator: "2 friends in the village"
+
+### Phase 3 — Determinism
+
+- Seeded NPC wander (§7.1) + `fairyAttractionManager`
+- Global daily seed for `RANDOM_*` maps (§7.2)
+- `tests/determinism.test.ts`
+
+### Phase 4 — Shared world correctness
+
+- Harvest claim transactions + optimistic rollback (§8)
+- `"Sanne watered your carrots"` attribution surfaced in the UI
+- Shared placed items / decorations on `SHARED_MAPS`
+- Mailbox gifting
+
+### Phase 5 — Optional social
+
+- Phrase book, shared Yule wreath, village painting gallery
+
+---
+
+## 14. Testing
+
+Follow `tests/README.md` conventions — node environment, collect every violation, assert once, and
+write the failure message so it says how to fix the problem.
+
+| File | Guards |
+|---|---|
+| `tests/multiplayerSafeStubs.test.ts` | Every method on the real presence service exists on the stub. Catches the drift that makes the game crash *only* when Firebase is absent |
+| `tests/presenceProtocol.test.ts` | Throttle logic, move threshold, heartbeat, stale eviction — against a fake transport. Mirror the `firebase/safe` mocking in `tests/sharedFarmSyncRetry.test.ts` |
+| `tests/remotePlayerInterpolation.test.ts` | `interpolateAt()` — pure, no Firebase. Buffer under/overrun, snap threshold, direction selection |
+| `tests/determinism.test.ts` | Two `NPCManager` instances + fixed clock ⇒ identical positions |
+| `tests/emoteVocabulary.test.ts` | `multiplayer/emotes.ts` and `database.rules.json` list the *same* emote ids. This is the safety-critical one |
+
+Manual: `make dev`, two browser profiles, watch the console with `DEBUG.MULTIPLAYER` on.
+
+---
+
+## 15. Rollback
+
+`MULTIPLAYER_ENABLED = false` in `constants.ts` disables every subscription, publish and render path
+at the controller boundary. No other code changes behaviour. Every network call routes through
+`firebase/safe.ts`, so an uninstalled `firebase` package or missing `VITE_FIREBASE_DATABASE_URL`
+produces a silent, fully-playable single-player game — the same guarantee the cloud-save and
+community-garden features already provide.
+
+---
+
+## Appendix: Implementation Notes
+
+What was actually built, and where it differs from the design above.
+
+### Files
+
+**New — transport and state**
+| File | Role |
+|---|---|
+| `firebase/realtimeConfig.ts` | Realtime Database init, keyed on `VITE_FIREBASE_DATABASE_URL` |
+| `firebase/presenceService.ts` | Presence transport: rooms, `onDisconnect`, publish, child events |
+| `multiplayer/types.ts` | `PresenceWire`, `LocalPresenceState`, `PresenceSample`, `RemotePlayer` |
+| `multiplayer/wire.ts` | Pure encode/decode + inbound validation (no Firebase import) |
+| `multiplayer/interpolation.ts` | Pure lerp/snap/hold |
+| `multiplayer/publishPolicy.ts` | Pure `shouldPublish()` decision |
+| `multiplayer/emotes.ts` | The closed vocabulary, SSoT |
+| `multiplayer/localEmote.ts` | Your own emote + expiry |
+| `multiplayer/RemotePlayerManager.ts` | SSoT for other players; mirrors `NPCManager` |
+| `multiplayer/remoteSprites.ts` | Frame/scale/flip resolution, cached per character |
+| `utils/seededRandom.ts` | mulberry32 + FNV-1a, for determinism |
+
+**New — UI**
+`utils/pixi/RemotePlayerLayer.ts`, `components/RemotePlayerOverlay.tsx` (DOM fallback),
+`components/EmoteWheel.tsx`, `components/PresenceIndicator.tsx`,
+`hooks/useMultiplayerController.ts`.
+
+**Changed**: `constants.ts` (`MULTIPLAYER` block, flag, `DEBUG.MULTIPLAYER`), `zIndex.ts`,
+`utils/EventBus.ts` (4 events), `hooks/useGameEvents.ts`, `hooks/usePixiRenderer.ts`,
+`hooks/useKeyboardControls.ts` (T), `components/TouchControls.tsx` (emote button), `App.tsx`
+(wiring only), `NPCManager.ts` + `utils/fairyAttractionManager.ts` + `maps/index.ts`
+(determinism), `firebase/communityGardenService.ts` (`claimPlot`), `utils/farmManager.ts`
+(claim + rollback), `firebase/safe.ts`, `firebase/index.ts`, `database.rules.json`,
+`firebase.json`, `.env.example`, `vite-env.d.ts`.
+
+### Decisions taken during implementation
+
+**Positions never touch React.** The design implied a `remotePlayerUpdateTrigger` driving
+re-renders. That would have cost a full React render per frame per remote player. Instead
+`usePixiRenderer`'s per-frame `updateAnimations()` polls `remotePlayerManager` directly — the same
+way it already reads `npcManager` — and the EventBus trigger fires only on **join/leave**, which
+is what the HUD actually needs. The DOM fallback drives its own `requestAnimationFrame`, so the
+PixiJS path pays nothing for it.
+
+**The transport moved into `firebase/`.** It was first written as `multiplayer/presenceService.ts`,
+which statically imported `firebase/database` and so would have crashed a build without the
+`firebase` package — exactly the failure `firebase/safe.ts` exists to prevent. It now lives beside
+`communityGardenService` and is reached through `getPresenceService()`, resolved once via dynamic
+import and cached in a ref for the game loop. `tests/multiplayerSafeStubs.test.ts` guards the
+parity, and `PresenceService.#emit` is a true `#private` method rather than a TypeScript `private`
+one so it does not appear in that runtime comparison.
+
+**Animation frames are not sent.** The walk cycle is derived from distance travelled between
+interpolated positions. One less wire field, and the legs move because the character moved, which
+looks right at any update rate.
+
+**Claims are optimistic with silent rollback, and asymmetric.** A *proven* loss (the plot doc
+exists and its state has moved on) rolls the harvest back. A network failure or a missing doc keeps
+the crop: confiscating something a player legitimately picked is a far worse experience than one
+duplicate carrot. Both directions are asserted in `tests/sharedFarmHarvestClaim.test.ts`.
+
+**Procedural maps now use a shared daily seed** (`hash(kind:totalDays:depth)` rather than
+`Date.now()`). Besides making forests shareable in principle, this fixes a long-standing
+single-player oddity: stepping out of the forest and straight back in used to regenerate it
+entirely. They remain off `SHARED_MAPS` for now.
+
+### Verification
+
+`make verify`: 63 files, 654 tests, typecheck clean. `npm run lint`: 0 errors.
+
+Runtime behaviour was compared against a pristine worktree of `main` under headless Chrome
+(puppeteer, SwiftShader). Both render identically and produce the same two pre-existing
+`src=""` React warnings, so the change is behaviourally inert with multiplayer unconfigured —
+which is the default. Note that PixiJS does **not** finish initialising under SwiftShader, so the
+world renders black and the game sits on the loading screen in headless; the multiplayer UI is
+therefore covered by `tests/multiplayerUI.test.tsx` instead.
+
+**Not verified end-to-end**: two real browsers, two accounts, seeing each other move. That needs a
+Realtime Database instance and `firebase deploy --only database`, which this session did not have.
+Everything up to the network boundary is tested.
+
+### Not built (Phase 5 and one Phase 4 item)
+
+- **Mailbox gifting** — needs a Firestore subcollection, security rules for cross-user writes, and
+  inventory UI. Deliberately deferred as a feature in its own right.
+- **Shared placed items / decorations** on shared maps — `gameState.getPlacedItems()` is still local.
+- **Phrase book**, shared Yule wreath, village painting gallery.
+- **Display-name generation.** Names still come from the in-game character name, which is free
+  text. §12 flags this: a curated adjective-plus-animal generator should land before this is
+  shown to anyone outside the family.
+- **Session lock** for the same account signed in on two devices at once.

--- a/design_docs/planned/README.md
+++ b/design_docs/planned/README.md
@@ -6,6 +6,22 @@ This directory contains design documents for planned features and architectural 
 
 ## Active Plans
 
+### 🧑‍🤝‍🧑 Multiplayer — Shared World
+
+**Status**: Implemented (Phases 0-4). Inert until `VITE_FIREBASE_DATABASE_URL` is set.
+**Remaining**: Phase 5 - phrase book, shared decorations, mailbox gifting
+
+**Documents**:
+- [MULTIPLAYER.md](./MULTIPLAYER.md) - Shared-world multiplayer: presence, state tiering, determinism, safety
+
+**Why This Matters**:
+- Players see each other move around Clover Village, with emotes and name tags
+- Firestore for durable shared state, Realtime Database for ephemeral presence
+- Also fixes the shared farm's double-harvest race, and makes procedural forests
+  reproducible per day instead of regenerating on every entry
+
+---
+
 ### 🎮 PixiJS Migration (High Priority)
 
 **Status**: Ready to implement

--- a/firebase.json
+++ b/firebase.json
@@ -2,5 +2,8 @@
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
+  },
+  "database": {
+    "rules": "database.rules.json"
   }
 }

--- a/firebase/communityGardenService.ts
+++ b/firebase/communityGardenService.ts
@@ -18,6 +18,7 @@ import {
   deleteDoc,
   collection,
   onSnapshot,
+  runTransaction,
   serverTimestamp,
   Unsubscribe,
   Timestamp,
@@ -47,6 +48,9 @@ export interface SharedPlotDoc {
   quality: 'normal' | 'good' | 'excellent';
   fertiliserApplied: boolean;
   abundantHarvest?: boolean;
+  /** Display name of the player who last harvested this plot */
+  claimedBy?: string | null;
+  claimedAtTimestamp?: number | null;
   updatedAt: ReturnType<typeof serverTimestamp> | Timestamp;
 }
 
@@ -183,6 +187,74 @@ class SharedFarmService {
     } catch (error) {
       console.error(`[SharedFarm] Failed to clear plot ${plotId}:`, error);
       return false;
+    }
+  }
+
+  /**
+   * Atomically claim a harvestable plot.
+   *
+   * The shared farm is otherwise last-write-wins on a 10s flush, which means two
+   * players clicking the same ripe carrot within ten seconds of each other both
+   * get a carrot. This is the one genuinely contended action in the game, and a
+   * transaction is the only way to settle it.
+   *
+   * Returns true if we won the plot (or if there is nothing to lose it to).
+   * Returns false ONLY when we can prove somebody else got there first — a
+   * network failure counts as a win, because confiscating a crop the player
+   * legitimately harvested is a far worse outcome than one duplicate carrot.
+   */
+  async claimPlot(plotId: string, expectedState: number, resultPlot: FarmPlot): Promise<boolean> {
+    if (!isFirebaseInitialized() || !authService.isAuthenticated()) {
+      return true; // Local-only play: nobody to race against.
+    }
+
+    try {
+      const db = getFirebaseDb();
+      const plotRef = doc(db, SHARED_PLOTS_COLLECTION, plotId);
+      const user = authService.getUser();
+      const claimedBy = user?.displayName || user?.email || 'Someone';
+
+      return await runTransaction(db, async (transaction) => {
+        const snapshot = await transaction.get(plotRef);
+
+        // Never synced (or already tidied away): we cannot prove a loss, so the
+        // player keeps what they picked.
+        if (!snapshot.exists()) return true;
+
+        const remote = snapshot.data() as SharedPlotDoc;
+        if (remote.state !== expectedState) {
+          // Somebody moved this plot on before us — that is a real, provable loss.
+          return false;
+        }
+
+        if (resultPlot.state === FarmPlotState.FALLOW) {
+          // Matches the flush path, which deletes rather than storing fallow plots.
+          transaction.delete(plotRef);
+        } else {
+          transaction.set(plotRef, {
+            mapId: resultPlot.mapId,
+            x: resultPlot.position.x,
+            y: resultPlot.position.y,
+            state: resultPlot.state,
+            cropType: resultPlot.cropType,
+            plantedBy: remote.plantedBy ?? null,
+            plantedByUid: remote.plantedByUid ?? null,
+            plantedAtTimestamp: resultPlot.plantedAtTimestamp,
+            lastWateredTimestamp: resultPlot.lastWateredTimestamp,
+            stateChangedAtTimestamp: resultPlot.stateChangedAtTimestamp,
+            quality: resultPlot.quality ?? 'normal',
+            fertiliserApplied: resultPlot.fertiliserApplied ?? false,
+            abundantHarvest: resultPlot.abundantHarvest ?? false,
+            claimedBy,
+            claimedAtTimestamp: Date.now(),
+            updatedAt: serverTimestamp(),
+          });
+        }
+        return true;
+      });
+    } catch (error) {
+      console.warn(`[SharedFarm] Claim transaction failed for ${plotId} — keeping harvest:`, error);
+      return true;
     }
   }
 

--- a/firebase/index.ts
+++ b/firebase/index.ts
@@ -47,6 +47,9 @@ export { paintingStorageService } from './paintingStorage';
 // Community Garden (Shared Farming)
 export { communityGardenService } from './communityGardenService';
 
+// Presence (Multiplayer — ephemeral, Realtime Database)
+export { presenceService } from './presenceService';
+
 // Types
 export type {
   UserProfile,

--- a/firebase/presenceService.ts
+++ b/firebase/presenceService.ts
@@ -1,0 +1,196 @@
+/**
+ * Presence transport — Realtime Database.
+ *
+ * Responsible only for moving bytes: entering/leaving a room, publishing the
+ * local player, and emitting raw presence events. It holds no game state and
+ * makes no rendering decisions — that is RemotePlayerManager's job.
+ *
+ * Rooms are map IDs (`presence/{mapId}/{uid}`), so a client only subscribes to
+ * the players it could actually see. Bandwidth therefore scales with
+ * *co-located* players rather than total players, which is what makes this
+ * affordable.
+ *
+ * Nothing here throws to callers. A presence failure must never be able to
+ * break the game loop, so every path logs and returns false instead.
+ */
+
+import {
+  ref,
+  set,
+  remove,
+  onChildAdded,
+  onChildChanged,
+  onChildRemoved,
+  onDisconnect,
+  serverTimestamp,
+  type DatabaseReference,
+} from 'firebase/database';
+import { getRealtimeDb } from './realtimeConfig';
+import { authService } from './authService';
+import { DEBUG } from '../constants';
+import { encodePresence, decodePresence } from '../multiplayer/wire';
+import type { LocalPresenceState, PresenceEvent } from '../multiplayer/types';
+
+const PRESENCE_ROOT = 'presence';
+
+/** Minimal shape of the snapshots the RTDB child callbacks hand us. */
+interface ChildSnapshot {
+  key: string | null;
+  val: () => unknown;
+}
+
+class PresenceService {
+  private roomMapId: string | null = null;
+  private unsubscribers: Array<() => void> = [];
+  private selfRef: DatabaseReference | null = null;
+  private listeners = new Set<(event: PresenceEvent) => void>();
+
+  /** True when presence can actually be published — Firebase up and signed in. */
+  isAvailable(): boolean {
+    return getRealtimeDb() !== null && authService.isAuthenticated();
+  }
+
+  getUid(): string | null {
+    return authService.getUserId();
+  }
+
+  getCurrentRoom(): string | null {
+    return this.roomMapId;
+  }
+
+  /**
+   * Subscribe to presence events. Returns an unsubscribe function.
+   * Safe to call before any room is entered.
+   */
+  onPresence(callback: (event: PresenceEvent) => void): () => void {
+    this.listeners.add(callback);
+    return () => {
+      this.listeners.delete(callback);
+    };
+  }
+
+  // A true #private method, not a TypeScript `private` one: TS privacy is erased
+  // at runtime, and tests/multiplayerSafeStubs.test.ts compares the runtime
+  // method surface against the no-Firebase stub. Internal helpers must not
+  // appear there or the parity check needs a hand-maintained exclusion list.
+  #emit(event: PresenceEvent): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch (error) {
+        console.warn('[Presence] Listener threw:', error);
+      }
+    }
+  }
+
+  /**
+   * Join a map's presence room: subscribe to its members and arm the
+   * disconnect cleanup for our own record.
+   */
+  async enterRoom(mapId: string): Promise<boolean> {
+    if (this.roomMapId === mapId) return true;
+    await this.leaveRoom();
+
+    const db = getRealtimeDb();
+    const uid = this.getUid();
+    if (!db || !uid) return false;
+
+    try {
+      const roomRef = ref(db, `${PRESENCE_ROOT}/${mapId}`);
+      this.selfRef = ref(db, `${PRESENCE_ROOT}/${mapId}/${uid}`);
+      this.roomMapId = mapId;
+
+      // Arm before the first write, so a crash between the two cannot leave a
+      // ghost behind.
+      await onDisconnect(this.selfRef).remove();
+
+      const handle = (type: 'joined' | 'changed') => (snapshot: ChildSnapshot) => {
+        const otherUid = snapshot.key;
+        if (!otherUid || otherUid === uid) return;
+        const wire = decodePresence(snapshot.val());
+        if (!wire) {
+          if (DEBUG.MULTIPLAYER) {
+            console.warn(`[Presence] Dropped malformed record from ${otherUid}`);
+          }
+          return;
+        }
+        this.#emit({ type, uid: otherUid, wire });
+      };
+
+      this.unsubscribers.push(
+        onChildAdded(roomRef, handle('joined')),
+        onChildChanged(roomRef, handle('changed')),
+        onChildRemoved(roomRef, (snapshot) => {
+          const otherUid = snapshot.key;
+          if (!otherUid || otherUid === uid) return;
+          this.#emit({ type: 'left', uid: otherUid });
+        })
+      );
+
+      if (DEBUG.MULTIPLAYER) console.log(`[Presence] Entered room "${mapId}"`);
+      return true;
+    } catch (error) {
+      console.warn(`[Presence] Failed to enter room "${mapId}":`, error);
+      this.roomMapId = null;
+      this.selfRef = null;
+      return false;
+    }
+  }
+
+  /** Leave the current room, removing our record and detaching listeners. */
+  async leaveRoom(): Promise<void> {
+    for (const unsubscribe of this.unsubscribers) {
+      try {
+        unsubscribe();
+      } catch {
+        /* detaching a dead listener is not worth reporting */
+      }
+    }
+    this.unsubscribers = [];
+
+    const selfRef = this.selfRef;
+    this.selfRef = null;
+    const leftRoom = this.roomMapId;
+    this.roomMapId = null;
+
+    if (selfRef) {
+      try {
+        // Cancel first: otherwise the old room's disconnect handler stays armed
+        // and could delete a record we have since written elsewhere.
+        await onDisconnect(selfRef).cancel();
+        await remove(selfRef);
+      } catch (error) {
+        if (DEBUG.MULTIPLAYER) console.warn('[Presence] Cleanup on leave failed:', error);
+      }
+    }
+
+    if (leftRoom && DEBUG.MULTIPLAYER) console.log(`[Presence] Left room "${leftRoom}"`);
+  }
+
+  /**
+   * Write the local player's presence. Callers decide *when* via
+   * shouldPublish(); this just performs the write.
+   */
+  async publish(state: LocalPresenceState): Promise<boolean> {
+    if (!this.selfRef) return false;
+
+    const wire = { ...encodePresence(state), t: serverTimestamp() };
+
+    try {
+      await set(this.selfRef, wire);
+      return true;
+    } catch (error) {
+      // Losing a position update is harmless — the next one is 200 ms away.
+      if (DEBUG.MULTIPLAYER) console.warn('[Presence] Publish failed:', error);
+      return false;
+    }
+  }
+
+  /** Tear down completely (sign-out, unmount). */
+  async destroy(): Promise<void> {
+    await this.leaveRoom();
+    this.listeners.clear();
+  }
+}
+
+export const presenceService = new PresenceService();

--- a/firebase/realtimeConfig.ts
+++ b/firebase/realtimeConfig.ts
@@ -1,0 +1,58 @@
+/**
+ * Realtime Database configuration — ephemeral presence only.
+ *
+ * Why a second database when the project already has Firestore: Firestore bills
+ * per document write, and a player publishing position at 5 Hz for a two-hour
+ * session is ~36,000 writes — more than the entire daily free tier, for data
+ * with a 200 ms shelf life. Realtime Database bills bandwidth instead, and —
+ * decisively — supports `onDisconnect()`, which lets the *server* delete a
+ * player's presence when their socket drops. Without that, every crashed tab
+ * leaves a ghost standing in the village forever.
+ *
+ * Durable shared state (the community garden, world events, cloud saves) stays
+ * on Firestore. See design_docs/planned/MULTIPLAYER.md §4.
+ */
+
+import { getDatabase, Database } from 'firebase/database';
+import { getFirebaseApp, isFirebaseInitialized } from './config';
+
+let rtdb: Database | null = null;
+let initAttempted = false;
+
+/**
+ * True when a database URL is configured. Presence is optional: the game is
+ * fully playable without it, so a missing URL is a log line, not an error.
+ */
+export function isRealtimeConfigured(): boolean {
+  return !!import.meta.env.VITE_FIREBASE_DATABASE_URL;
+}
+
+/**
+ * Get the Realtime Database instance, or null when unavailable.
+ * Safe to call repeatedly; initialisation happens once.
+ */
+export function getRealtimeDb(): Database | null {
+  if (rtdb) return rtdb;
+  if (initAttempted) return null;
+  initAttempted = true;
+
+  if (!isFirebaseInitialized() || !isRealtimeConfigured()) {
+    console.log('[Presence] Realtime Database not configured — multiplayer disabled');
+    return null;
+  }
+
+  try {
+    rtdb = getDatabase(getFirebaseApp(), import.meta.env.VITE_FIREBASE_DATABASE_URL);
+    console.log('[Presence] Realtime Database ready');
+    return rtdb;
+  } catch (error) {
+    console.warn('[Presence] Realtime Database init failed — multiplayer disabled', error);
+    return null;
+  }
+}
+
+/** Reset cached state. Test seam only. */
+export function resetRealtimeDbForTests(): void {
+  rtdb = null;
+  initAttempted = false;
+}

--- a/firebase/safe.ts
+++ b/firebase/safe.ts
@@ -11,6 +11,7 @@
 
 // Re-export types that don't need the package at runtime
 export type { AuthState } from './authService';
+import type { PresenceEvent, LocalPresenceState } from '../multiplayer/types';
 
 /** Stub authService when Firebase is not available */
 const stubAuthService = {
@@ -96,11 +97,29 @@ const stubCommunityGardenService = {
   onPlotsChanged: (_cb: (plots: Map<string, unknown>) => void) => () => {},
   writePlot: async () => false as boolean,
   clearPlot: async () => false as boolean,
+  // Local-only play has nobody to lose a race to, so every claim succeeds.
+  claimPlot: async () => true as boolean,
   docToFarmPlot: (_doc: unknown) => null as any,
   getPlotId: (mapId: string, x: number, y: number) => `${mapId}:${x}:${y}`,
   getRemotePlots: () => new Map<string, unknown>(),
   isActive: () => false,
   destroy: () => {},
+};
+
+/**
+ * Stub presenceService when Firebase is not available.
+ * Every method must exist here or the game crashes only in the no-Firebase
+ * configuration — tests/multiplayerSafeStubs.test.ts guards the parity.
+ */
+const stubPresenceService = {
+  isAvailable: () => false,
+  getUid: () => null as string | null,
+  getCurrentRoom: () => null as string | null,
+  onPresence: (_cb: (event: PresenceEvent) => void) => () => {},
+  enterRoom: async (_mapId: string) => false as boolean,
+  leaveRoom: async () => {},
+  publish: async (_state: LocalPresenceState) => false as boolean,
+  destroy: async () => {},
 };
 
 /** Stub cloudSaveService when Firebase is not available */
@@ -194,6 +213,15 @@ export function getCloudSaveService() {
  */
 export function getSyncManager() {
   return firebaseModule?.syncManager ?? stubSyncManager;
+}
+
+/**
+ * Get presenceService (real or stub).
+ * Returns the stub until loadFirebase() has resolved, which is exactly right:
+ * before then there is nothing to publish to.
+ */
+export function getPresenceService() {
+  return firebaseModule?.presenceService ?? stubPresenceService;
 }
 
 /**

--- a/hooks/useGameEvents.ts
+++ b/hooks/useGameEvents.ts
@@ -26,6 +26,14 @@ export interface UseGameEventsReturn {
 
   /** Increments when placed items change on maps */
   placedItemsUpdateTrigger: number;
+
+  /**
+   * Increments when another player joins or leaves the current map.
+   * Deliberately NOT bumped on remote movement — remote positions are polled
+   * straight from remotePlayerManager by the renderer each frame, so they never
+   * cost a React re-render.
+   */
+  remotePlayerUpdateTrigger: number;
 }
 
 /**
@@ -35,6 +43,7 @@ export function useGameEvents(): UseGameEventsReturn {
   const [farmUpdateTrigger, setFarmUpdateTrigger] = useState(0);
   const [npcUpdateTrigger, setNpcUpdateTrigger] = useState(0);
   const [placedItemsUpdateTrigger, setPlacedItemsUpdateTrigger] = useState(0);
+  const [remotePlayerUpdateTrigger, setRemotePlayerUpdateTrigger] = useState(0);
 
   useEffect(() => {
     // Subscribe to all relevant events
@@ -62,6 +71,14 @@ export function useGameEvents(): UseGameEventsReturn {
       eventBus.on(GameEvent.PLACED_ITEMS_CHANGED, () => {
         setPlacedItemsUpdateTrigger((prev) => prev + 1);
       }),
+
+      // Multiplayer presence events (join/leave only — see the doc comment above)
+      eventBus.on(GameEvent.REMOTE_PLAYER_JOINED, () => {
+        setRemotePlayerUpdateTrigger((prev) => prev + 1);
+      }),
+      eventBus.on(GameEvent.REMOTE_PLAYER_LEFT, () => {
+        setRemotePlayerUpdateTrigger((prev) => prev + 1);
+      }),
     ];
 
     // Cleanup: unsubscribe from all events
@@ -74,5 +91,6 @@ export function useGameEvents(): UseGameEventsReturn {
     farmUpdateTrigger,
     npcUpdateTrigger,
     placedItemsUpdateTrigger,
+    remotePlayerUpdateTrigger,
   };
 }

--- a/hooks/useKeyboardControls.ts
+++ b/hooks/useKeyboardControls.ts
@@ -94,6 +94,8 @@ export interface KeyboardControlsConfig {
   onForageResult?: (result: ForageResult) => void;
   onShowToast?: (message: string, type: 'info' | 'warning' | 'error' | 'success') => void;
   onSetSelectedItemSlot?: (slot: number | null) => void;
+  /** T key — open/close the multiplayer emote picker (only wired when multiplayer is on) */
+  onToggleEmoteWheel?: () => void;
 }
 
 export function useKeyboardControls(config: KeyboardControlsConfig) {
@@ -150,6 +152,7 @@ export function useKeyboardControls(config: KeyboardControlsConfig) {
     onForageResult,
     onShowToast,
     onSetSelectedItemSlot,
+    onToggleEmoteWheel,
   } = config;
 
   // Create refs for values that need to be accessed in the event handler with latest values
@@ -242,6 +245,13 @@ export function useKeyboardControls(config: KeyboardControlsConfig) {
     if ((e.key === 'i' || e.key === 'I') && !showMiniGameRef.current) {
       e.preventDefault();
       handleInventoryToggle(uiHandlers);
+      return;
+    }
+
+    // T key to toggle the emote picker (the only player-to-player channel)
+    if ((e.key === 't' || e.key === 'T') && onToggleEmoteWheel && !showMiniGameRef.current) {
+      e.preventDefault();
+      onToggleEmoteWheel();
       return;
     }
 

--- a/hooks/useMultiplayerController.ts
+++ b/hooks/useMultiplayerController.ts
@@ -1,0 +1,241 @@
+/**
+ * MultiplayerController — domain controller for shared-world presence.
+ *
+ * Owns the whole multiplayer lifecycle so App.tsx only has to wire it:
+ *  - joins and leaves a map's presence room as the player moves between maps
+ *  - feeds inbound presence into RemotePlayerManager
+ *  - publishes the local player at a throttled rate from the game loop
+ *  - exposes the emote action and the "who else is here" count for the HUD
+ *
+ * Nothing here is allowed to break the game loop. Presence is a garnish: if
+ * Firebase is missing, the database URL is unset, the player is signed out, or
+ * the current map is private, this hook quietly does nothing and the game is
+ * exactly the single-player game.
+ *
+ * See design_docs/planned/MULTIPLAYER.md
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { MULTIPLAYER, MULTIPLAYER_ENABLED, DEBUG } from '../constants';
+import { eventBus, GameEvent } from '../utils/EventBus';
+import { getPresenceService } from '../firebase/safe';
+import { remotePlayerManager } from '../multiplayer/RemotePlayerManager';
+import { shouldPublish } from '../multiplayer/publishPolicy';
+import { getLocalEmote, setLocalEmote, clearLocalEmote } from '../multiplayer/localEmote';
+import type { EmoteId } from '../multiplayer/emotes';
+import type { LocalPresenceState } from '../multiplayer/types';
+
+export interface UseMultiplayerControllerProps {
+  /** Map the player is currently on */
+  currentMapId: string;
+
+  /**
+   * Read the local player's publishable state. Called from the game loop, so it
+   * must be cheap and must read from refs rather than React state.
+   * Return null to suppress publishing (e.g. before the character exists).
+   */
+  getLocalPresence: () => LocalPresenceState | null;
+}
+
+export interface UseMultiplayerControllerReturn {
+  /** True when presence is actually running on this map */
+  isActive: boolean;
+
+  /** How many other players are on this map */
+  remotePlayerCount: number;
+
+  /** Their display names, for the HUD */
+  remotePlayerNames: string[];
+
+  /** Call once per frame from the game loop */
+  tickMultiplayer: (now: number) => void;
+
+  /** Play an emote — publishes it and shows it above the local player */
+  sendEmote: (emote: EmoteId) => void;
+}
+
+/** Presence only runs on maps players are meant to share. */
+function isSharedMap(mapId: string): boolean {
+  return MULTIPLAYER.SHARED_MAPS.has(mapId);
+}
+
+/**
+ * Resolve the presence transport through firebase/safe, so a build without the
+ * `firebase` package gets the no-op stub rather than a module-resolution crash.
+ * Matches how farmManager reaches communityGardenService.
+ */
+type PresenceTransport = ReturnType<typeof getPresenceService>;
+
+async function loadPresenceService(): Promise<PresenceTransport | null> {
+  try {
+    const { getPresenceService: get } = await import('../firebase/safe');
+    return get();
+  } catch {
+    return null;
+  }
+}
+
+export function useMultiplayerController(
+  props: UseMultiplayerControllerProps
+): UseMultiplayerControllerReturn {
+  const { currentMapId, getLocalPresence } = props;
+
+  const [isActive, setIsActive] = useState(false);
+  const [remotePlayerCount, setRemotePlayerCount] = useState(0);
+  const [remotePlayerNames, setRemotePlayerNames] = useState<string[]>([]);
+
+  // Always-fresh mirror, so the game-loop callback below never goes stale.
+  const getLocalPresenceRef = useRef(getLocalPresence);
+  getLocalPresenceRef.current = getLocalPresence;
+
+  const lastPublishedRef = useRef<LocalPresenceState | null>(null);
+  const lastPublishAtRef = useRef(0);
+  const activeRef = useRef(false);
+  // Resolved once, then read synchronously from the game loop.
+  const presenceRef = useRef<PresenceTransport | null>(null);
+
+  // -------------------------------------------------------------------------
+  // Inbound presence → RemotePlayerManager
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    if (!MULTIPLAYER_ENABLED) return;
+
+    let unsubscribe: (() => void) | null = null;
+    let cancelled = false;
+
+    void loadPresenceService().then((service) => {
+      if (!service || cancelled) return;
+      presenceRef.current = service;
+      unsubscribe = service.onPresence((event) => {
+        if (event.type === 'left') {
+          remotePlayerManager.remove(event.uid);
+        } else {
+          remotePlayerManager.apply(event.uid, event.wire);
+        }
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Room membership follows the current map
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    if (!MULTIPLAYER_ENABLED) return;
+
+    let cancelled = false;
+
+    const join = async () => {
+      const presence = presenceRef.current ?? (await loadPresenceService());
+      if (!presence) return;
+      presenceRef.current = presence;
+
+      // A private map (home, personal garden, any RANDOM_* forest) or an
+      // unavailable backend both mean the same thing: nobody to see here.
+      if (!isSharedMap(currentMapId) || !presence.isAvailable()) {
+        await presence.leaveRoom();
+        remotePlayerManager.setMap(null);
+        if (!cancelled) {
+          activeRef.current = false;
+          setIsActive(false);
+          setRemotePlayerCount(0);
+          setRemotePlayerNames([]);
+        }
+        return;
+      }
+
+      remotePlayerManager.setMap(currentMapId);
+      // Force a publish on arrival, so we appear immediately rather than after
+      // the first movement threshold is crossed.
+      lastPublishedRef.current = null;
+      lastPublishAtRef.current = 0;
+
+      const joined = await presence.enterRoom(currentMapId);
+      if (cancelled) return;
+
+      activeRef.current = joined;
+      setIsActive(joined);
+      if (joined && DEBUG.MULTIPLAYER) {
+        console.log(`[Multiplayer] Presence active on "${currentMapId}"`);
+      }
+    };
+
+    void join();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentMapId]);
+
+  // Leave cleanly on unmount so we do not rely solely on onDisconnect().
+  useEffect(() => {
+    return () => {
+      clearLocalEmote();
+      remotePlayerManager.clear();
+      void presenceRef.current?.leaveRoom();
+    };
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Join/leave → HUD state (positions never come through here)
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    const refresh = () => {
+      setRemotePlayerCount(remotePlayerManager.getCount());
+      setRemotePlayerNames(remotePlayerManager.getNames());
+    };
+    const unsubscribers = [
+      eventBus.on(GameEvent.REMOTE_PLAYER_JOINED, refresh),
+      eventBus.on(GameEvent.REMOTE_PLAYER_LEFT, refresh),
+    ];
+    return () => unsubscribers.forEach((unsubscribe) => unsubscribe());
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Game loop tick: interpolate remote players, publish ourselves
+  // -------------------------------------------------------------------------
+  const tickMultiplayer = useCallback((now: number) => {
+    if (!MULTIPLAYER_ENABLED) return;
+
+    try {
+      // Interpolation must keep running even when we are not publishing, so
+      // remote players glide rather than freeze while a modal is open.
+      remotePlayerManager.tick(now);
+
+      if (!activeRef.current) return;
+
+      const base = getLocalPresenceRef.current();
+      if (!base) return;
+
+      const next: LocalPresenceState = { ...base, emote: getLocalEmote(now) };
+      const reason = shouldPublish(lastPublishedRef.current, next, now, lastPublishAtRef.current, {
+        publishHz: MULTIPLAYER.PUBLISH_HZ,
+        moveThresholdTiles: MULTIPLAYER.MOVE_THRESHOLD_TILES,
+        heartbeatMs: MULTIPLAYER.HEARTBEAT_MS,
+      });
+      if (!reason) return;
+
+      lastPublishedRef.current = next;
+      lastPublishAtRef.current = now;
+      if (DEBUG.MULTIPLAYER) console.log(`[Multiplayer] Publishing (${reason})`);
+      // Fire and forget: a dropped position update is replaced 200 ms later,
+      // and awaiting here would stall the frame.
+      void presenceRef.current?.publish(next);
+    } catch (error) {
+      // A presence bug must never be able to stop the game loop.
+      console.warn('[Multiplayer] Tick failed:', error);
+    }
+  }, []);
+
+  const sendEmote = useCallback((emote: EmoteId) => {
+    setLocalEmote(emote);
+    // Emotes bypass the movement throttle in shouldPublish() via the
+    // state-change branch, so the next tick sends this immediately.
+  }, []);
+
+  return { isActive, remotePlayerCount, remotePlayerNames, tickMultiplayer, sendEmote };
+}

--- a/hooks/usePixiRenderer.ts
+++ b/hooks/usePixiRenderer.ts
@@ -23,6 +23,9 @@ import { TileLayer } from '../utils/pixi/TileLayer';
 import { PlayerSprite } from '../utils/pixi/PlayerSprite';
 import { SpriteLayer } from '../utils/pixi/SpriteLayer';
 import { NPCLayer } from '../utils/pixi/NPCLayer';
+import { RemotePlayerLayer } from '../utils/pixi/RemotePlayerLayer';
+import { remotePlayerManager } from '../multiplayer/RemotePlayerManager';
+import { getLocalEmote } from '../multiplayer/localEmote';
 import { ShadowLayer } from '../utils/pixi/ShadowLayer';
 import { WeatherLayer } from '../utils/pixi/WeatherLayer';
 import { DarknessLayer, LightSource } from '../utils/pixi/DarknessLayer';
@@ -128,6 +131,9 @@ export interface UsePixiRendererReturn {
   /** NPC layer ref (for collision detection and interactions) */
   npcLayerRef: React.RefObject<NPCLayer | null>;
 
+  /** Remote player layer ref (for pruning display objects on map change) */
+  remotePlayerLayerRef: React.RefObject<RemotePlayerLayer | null>;
+
   /** Background image layer ref (for layer NPC access) */
   backgroundImageLayerRef: React.RefObject<BackgroundImageLayer | null>;
 
@@ -164,6 +170,7 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
   const spriteLayerRef = useRef<SpriteLayer | null>(null);
   const playerSpriteRef = useRef<PlayerSprite | null>(null);
   const npcLayerRef = useRef<NPCLayer | null>(null);
+  const remotePlayerLayerRef = useRef<RemotePlayerLayer | null>(null);
   const placedItemsLayerRef = useRef<PlacedItemsLayer | null>(null);
   const shadowLayerRef = useRef<ShadowLayer | null>(null);
   const highlightLayerRef = useRef<HighlightLayer | null>(null);
@@ -174,6 +181,18 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
   const torchPositionsRef = useRef<LightSource[]>([]);
   const weatherManagerRef = useRef<WeatherManager | null>(null);
   const depthSortedContainerRef = useRef<PIXI.Container | null>(null);
+
+  /**
+   * Latest per-frame render parameters, mirrored into a ref so the game-loop
+   * callbacks below (which are intentionally dependency-free) can read them
+   * without being rebuilt every time the camera moves.
+   */
+  const frameParamsRef = useRef({
+    gridOffset: { x: 0, y: 0 } as { x: number; y: number },
+    tileSize: 64,
+    characterScale: 1,
+    playerPos: { x: 0, y: 0 } as { x: number; y: number },
+  });
 
   // Destructure for cleaner access
   const { isMapInitialized, currentMapId, currentMap, currentWeather } = mapConfig;
@@ -201,6 +220,16 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
   const { seasonKey, timeOfDay } = timing;
   const { farmUpdateTrigger, placedItemsUpdateTrigger, renderVersion, npcUpdateTrigger } = triggers;
 
+  // Mirror the current frame parameters into the ref read by updateAnimations.
+  // Assigning during render (rather than in an effect) keeps them one frame
+  // fresher and matches the currentMapIdRef pattern used in App.tsx.
+  frameParamsRef.current = {
+    gridOffset: effectiveGridOffset,
+    tileSize: effectiveTileSize,
+    characterScale: currentMap?.characterScale ?? 1.0,
+    playerPos,
+  };
+
   // Animation update function (called from game loop)
   const updateAnimations = useCallback((deltaTime: number) => {
     if (weatherLayerRef.current) {
@@ -214,6 +243,28 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
     }
     // Tick player flicker (no-op when not flickering)
     playerSpriteRef.current?.tickFlicker(deltaTime);
+
+    // Remote players are polled straight from the manager every frame rather
+    // than pushed through React state — interpolated positions change on every
+    // frame and must never cost a re-render.
+    if (remotePlayerLayerRef.current) {
+      const { gridOffset, tileSize, characterScale, playerPos: localPos } = frameParamsRef.current;
+      void remotePlayerLayerRef.current.renderRemotePlayers(
+        remotePlayerManager.getRemotePlayers(),
+        characterScale,
+        gridOffset,
+        tileSize
+      );
+      // Your own emote, drawn the same way as everybody else's so pressing one
+      // gives immediate feedback instead of a silent hope somebody saw it.
+      remotePlayerLayerRef.current.renderLocalEmote(
+        getLocalEmote(),
+        localPos,
+        characterScale,
+        gridOffset,
+        tileSize
+      );
+    }
   }, []);
 
   // =========================================================================
@@ -312,6 +363,12 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
         npcLayer.setStage(app.stage);
         npcLayer.setDepthContainer(depthSortedContainer);
         app.stage.addChild(npcLayer.getContainer());
+
+        // Create remote player layer (other players — depth-sorted with player/NPCs)
+        const remotePlayerLayer = new RemotePlayerLayer();
+        remotePlayerLayerRef.current = remotePlayerLayer;
+        remotePlayerLayer.setDepthContainer(depthSortedContainer);
+        app.stage.addChild(remotePlayerLayer.getContainer());
 
         // Create placed items layer (depth-sorted with player/NPCs)
         const placedItemsLayer = new PlacedItemsLayer();
@@ -513,6 +570,10 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
       if (playerSpriteRef.current) {
         playerSpriteRef.current.destroy();
         playerSpriteRef.current = null;
+      }
+      if (remotePlayerLayerRef.current) {
+        remotePlayerLayerRef.current.clear();
+        remotePlayerLayerRef.current = null;
       }
       if (npcLayerRef.current) {
         npcLayerRef.current.clear();
@@ -921,6 +982,7 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
     isPixiInitialized,
     pixiAppRef,
     npcLayerRef,
+    remotePlayerLayerRef,
     backgroundImageLayerRef,
     weatherManagerRef,
     weatherLayerRef,

--- a/maps/index.ts
+++ b/maps/index.ts
@@ -1,4 +1,6 @@
 import { mapManager } from './MapManager';
+import { TimeManager } from '../utils/TimeManager';
+import { hashString } from '../utils/seededRandom';
 import { COLOR_SCHEMES } from './colorSchemes';
 import { homeUpstairs } from './definitions/homeUpstairs';
 import { village } from './definitions/village';
@@ -118,12 +120,24 @@ export function transitionToMap(
     const type = mapId.replace('RANDOM_', '').toLowerCase();
     let newMap;
 
+    // Seed procedural maps from the game day and depth rather than Date.now().
+    //
+    // Two reasons. Multiplayer: with a per-call clock seed, two players who walk
+    // into "the forest" together arrive in *different* forests, with the lakes,
+    // wolves and bears in different places — so RANDOM_* maps could never be
+    // shared. Single-player: it also fixes the long-standing oddity where
+    // stepping out of the forest and straight back in regenerated it entirely.
+    // The world still reshuffles daily, which is the variety the seed was for.
+    const { totalDays } = TimeManager.getCurrentTime();
+    const dailySeed = (kind: string, depth: number) =>
+      hashString(`${kind}:${totalDays}:${depth}`);
+
     switch (type) {
       case 'forest':
-        newMap = generateRandomForest();
+        newMap = generateRandomForest(dailySeed('forest', gameState.getForestDepth()));
         break;
       case 'cave':
-        newMap = generateRandomCave();
+        newMap = generateRandomCave(dailySeed('cave', gameState.getCaveDepth()));
         break;
       case 'shop': {
         // Generate shop with exit back to the current map location from game state
@@ -132,7 +146,7 @@ export function transitionToMap(
         break;
       }
       case 'lava': {
-        newMap = generateLavaMap();
+        newMap = generateLavaMap(dailySeed('lava', gameState.getLavaDepth()));
         break;
       }
       default:

--- a/multiplayer/RemotePlayerManager.ts
+++ b/multiplayer/RemotePlayerManager.ts
@@ -1,0 +1,206 @@
+/**
+ * RemotePlayerManager — single source of truth for other players.
+ *
+ * Deliberately shaped like NPCManager: the renderer asks it "who is on this map
+ * and where are they", and it owns everything else — interpolation buffers,
+ * walk-cycle derivation, emote expiry and staleness eviction.
+ *
+ * It is fed by presenceService but knows nothing about Firebase, so it can be
+ * driven from a test with hand-written snapshots and a fake clock.
+ *
+ * Positions are NOT pushed through React. The Pixi layer polls this manager
+ * once per frame from the game loop; only join/leave/emote — which are rare and
+ * do change UI — go out on the EventBus.
+ */
+
+import { Direction } from '../types';
+import type { Position } from '../types';
+import { MULTIPLAYER, DEBUG } from '../constants';
+import { eventBus, GameEvent } from '../utils/EventBus';
+import { interpolateAt, pushSample } from './interpolation';
+import { decodeDirection } from './wire';
+import type { EmoteId } from './emotes';
+import type { PresenceSample, PresenceWire, RemotePlayer } from './types';
+
+interface RemotePlayerState {
+  uid: string;
+  name: string;
+  characterId: string;
+  sizeTier: number;
+  fairyForm: boolean;
+  emote: EmoteId | null;
+  emoteStartedAt: number;
+  /** Recent position samples, oldest first, on the local clock */
+  buffer: PresenceSample[];
+  /** Local clock at last received update — the basis for staleness eviction */
+  lastSeenAt: number;
+  // ---- Render state, recomputed every tick ----
+  position: Position;
+  direction: Direction;
+  /** Tiles travelled since the walk frame last advanced */
+  animAccumulator: number;
+  animStep: number;
+  isMoving: boolean;
+}
+
+class RemotePlayerManagerClass {
+  private players = new Map<string, RemotePlayerState>();
+  private mapId: string | null = null;
+
+  /** The map whose presence room we are currently mirroring. */
+  getMapId(): string | null {
+    return this.mapId;
+  }
+
+  /**
+   * Switch rooms. Everything is dropped: presence is per-map, and a player we
+   * saw in the village tells us nothing about who is in the orchard.
+   */
+  setMap(mapId: string | null): void {
+    if (this.mapId === mapId) return;
+    this.clear();
+    this.mapId = mapId;
+  }
+
+  /** Apply an inbound presence record for one player. */
+  apply(uid: string, wire: PresenceWire, now: number = Date.now()): void {
+    const direction = decodeDirection(wire.d) ?? Direction.Down;
+    const position: Position = { x: wire.x, y: wire.y };
+    const sample: PresenceSample = { position, direction, receivedAt: now };
+
+    let state = this.players.get(uid);
+
+    if (!state) {
+      state = {
+        uid,
+        name: wire.n,
+        characterId: wire.c,
+        sizeTier: wire.s,
+        fairyForm: wire.ff,
+        emote: null,
+        emoteStartedAt: 0,
+        buffer: [sample],
+        lastSeenAt: now,
+        position,
+        direction,
+        animAccumulator: 0,
+        animStep: 0,
+        isMoving: false,
+      };
+      this.players.set(uid, state);
+      if (DEBUG.MULTIPLAYER) console.log(`[Multiplayer] ${wire.n} joined (${uid})`);
+      eventBus.emit(GameEvent.REMOTE_PLAYER_JOINED, { uid, name: wire.n });
+    } else {
+      state.name = wire.n;
+      state.characterId = wire.c;
+      state.sizeTier = wire.s;
+      state.fairyForm = wire.ff;
+      state.buffer = pushSample(state.buffer, sample, MULTIPLAYER.SAMPLE_BUFFER_SIZE);
+      state.lastSeenAt = now;
+    }
+
+    // A repeat of the same emote id is a *new* emote — the sender restarted it,
+    // so restart the timer rather than letting the old one expire mid-wave.
+    if (wire.e !== null && (state.emote !== wire.e || now - state.emoteStartedAt > 250)) {
+      state.emote = wire.e;
+      state.emoteStartedAt = now;
+      eventBus.emit(GameEvent.REMOTE_PLAYER_EMOTED, { uid, name: state.name, emote: wire.e });
+    } else if (wire.e === null) {
+      state.emote = null;
+    }
+  }
+
+  /** Drop a player who left the room (their presence record was removed). */
+  remove(uid: string): void {
+    const state = this.players.get(uid);
+    if (!state) return;
+    this.players.delete(uid);
+    if (DEBUG.MULTIPLAYER) console.log(`[Multiplayer] ${state.name} left (${uid})`);
+    eventBus.emit(GameEvent.REMOTE_PLAYER_LEFT, { uid, name: state.name });
+  }
+
+  /**
+   * Advance interpolation, walk cycles and expiries. Called once per frame from
+   * the game loop.
+   */
+  tick(now: number = Date.now()): void {
+    const renderTime = now - MULTIPLAYER.INTERPOLATION_DELAY_MS;
+
+    for (const [uid, state] of this.players) {
+      // onDisconnect() handles the common cases; this is the backstop for a
+      // client whose socket never actually closed (suspended laptop, dead Wi-Fi).
+      if (now - state.lastSeenAt > MULTIPLAYER.STALE_AFTER_MS) {
+        this.remove(uid);
+        continue;
+      }
+
+      if (state.emote && now - state.emoteStartedAt > MULTIPLAYER.EMOTE_DURATION_MS) {
+        state.emote = null;
+      }
+
+      const result = interpolateAt(state.buffer, renderTime, {
+        snapDistanceTiles: MULTIPLAYER.SNAP_DISTANCE_TILES,
+        bufferSize: MULTIPLAYER.SAMPLE_BUFFER_SIZE,
+      });
+      if (!result) continue;
+
+      const dx = result.position.x - state.position.x;
+      const dy = result.position.y - state.position.y;
+      const travelled = Math.sqrt(dx * dx + dy * dy);
+
+      state.position = result.position;
+      state.direction = result.direction;
+      state.isMoving = result.speed > MULTIPLAYER.IDLE_SPEED_TILES_PER_SEC;
+
+      // The walk cycle is driven by distance covered, not by a timer and not by
+      // a frame index sent over the wire. The legs move because the character
+      // moved, so the animation stays in step at any update rate.
+      if (state.isMoving) {
+        state.animAccumulator += travelled;
+        while (state.animAccumulator >= MULTIPLAYER.ANIM_TILES_PER_FRAME) {
+          state.animAccumulator -= MULTIPLAYER.ANIM_TILES_PER_FRAME;
+          state.animStep++;
+        }
+      } else {
+        state.animAccumulator = 0;
+      }
+    }
+  }
+
+  /** Everyone currently visible, for the renderer. */
+  getRemotePlayers(): RemotePlayer[] {
+    const out: RemotePlayer[] = [];
+    for (const state of this.players.values()) {
+      out.push({
+        uid: state.uid,
+        name: state.name,
+        characterId: state.characterId,
+        position: state.position,
+        direction: state.direction,
+        sizeTier: state.sizeTier,
+        fairyForm: state.fairyForm,
+        animStep: state.animStep,
+        isMoving: state.isMoving,
+        emote: state.emote,
+      });
+    }
+    return out;
+  }
+
+  /** How many other players are here — drives the HUD indicator. */
+  getCount(): number {
+    return this.players.size;
+  }
+
+  /** Names of everyone here, for the HUD tooltip. */
+  getNames(): string[] {
+    return [...this.players.values()].map((p) => p.name);
+  }
+
+  /** Forget everyone without emitting leave events (map change, shutdown). */
+  clear(): void {
+    this.players.clear();
+  }
+}
+
+export const remotePlayerManager = new RemotePlayerManagerClass();

--- a/multiplayer/emotes.ts
+++ b/multiplayer/emotes.ts
@@ -1,0 +1,40 @@
+/**
+ * Emote vocabulary — the single source of truth.
+ *
+ * This game is played by children. The safety model is a *closed vocabulary*:
+ * it is not possible to say something harmful, rather than possible-but-
+ * moderated. There is no free-text channel between players, by design.
+ *
+ * The same ids are enumerated in `database.rules.json`, so a client with an
+ * open dev console still cannot publish anything that is not on this list.
+ * `tests/emoteVocabulary.test.ts` asserts the two lists never drift apart —
+ * that test is the safety-critical one in this feature.
+ */
+
+export const EMOTES = [
+  { id: 'wave', icon: '👋', label: 'Wave' },
+  { id: 'laugh', icon: '😄', label: 'Laugh' },
+  { id: 'heart', icon: '💛', label: 'Thank you' },
+  { id: 'question', icon: '❓', label: 'What?' },
+  { id: 'yes', icon: '👍', label: 'Yes' },
+  { id: 'sad', icon: '😢', label: 'Sad' },
+  { id: 'dance', icon: '💃', label: 'Dance' },
+  { id: 'followme', icon: '✨', label: 'Come and see' },
+] as const;
+
+export type EmoteId = (typeof EMOTES)[number]['id'];
+
+/** Every valid emote id, for validation and for the security-rules test. */
+export const EMOTE_IDS: readonly EmoteId[] = EMOTES.map((e) => e.id);
+
+const EMOTE_BY_ID = new Map<string, (typeof EMOTES)[number]>(EMOTES.map((e) => [e.id, e]));
+
+/** Type guard used on every inbound presence record — never trust the wire. */
+export function isEmoteId(value: unknown): value is EmoteId {
+  return typeof value === 'string' && EMOTE_BY_ID.has(value);
+}
+
+/** Display glyph for an emote, or null if the id is unknown. */
+export function getEmoteIcon(id: string): string | null {
+  return EMOTE_BY_ID.get(id)?.icon ?? null;
+}

--- a/multiplayer/interpolation.ts
+++ b/multiplayer/interpolation.ts
@@ -1,0 +1,124 @@
+/**
+ * Remote player interpolation — pure functions, no Firebase, no globals.
+ *
+ * Presence arrives at ~5 Hz. Rendering at that rate looks like a slideshow, and
+ * extrapolating forward makes players rubber-band when they stop. Instead we
+ * render every remote player `INTERPOLATION_DELAY_MS` in the *past*, which
+ * guarantees we almost always have a sample on both sides of the render time
+ * and can simply lerp between them. 120 ms of deliberate lag is imperceptible
+ * on somebody else's character.
+ *
+ * Everything here is deliberately dependency-free so it can be unit-tested
+ * without a network, a clock, or a Pixi context — see
+ * tests/remotePlayerInterpolation.test.ts.
+ */
+
+import type { Position, Direction } from '../types';
+import type { PresenceSample } from './types';
+
+export interface InterpolationConfig {
+  /** Beyond this gap between two samples, snap rather than lerp */
+  snapDistanceTiles: number;
+  /** Max samples to retain per player */
+  bufferSize: number;
+}
+
+export interface InterpolationResult {
+  position: Position;
+  direction: Direction;
+  /** Tiles per second between the bracketing samples; 0 when holding or snapping */
+  speed: number;
+  /** True when the render time fell between two real samples */
+  interpolated: boolean;
+}
+
+/**
+ * Append a sample, keeping the buffer sorted by receipt time and bounded.
+ * Returns a new array — callers hold the result, so buffers are never aliased.
+ *
+ * Out-of-order arrivals are inserted in place rather than dropped: RTDB
+ * delivers in order in practice, but a reordered pair would otherwise make a
+ * player jump backwards for one frame.
+ */
+export function pushSample(
+  buffer: readonly PresenceSample[],
+  sample: PresenceSample,
+  bufferSize: number
+): PresenceSample[] {
+  const next = [...buffer];
+  let i = next.length;
+  while (i > 0 && next[i - 1].receivedAt > sample.receivedAt) i--;
+  next.splice(i, 0, sample);
+  return next.length > bufferSize ? next.slice(next.length - bufferSize) : next;
+}
+
+function distance(a: Position, b: Position): number {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+/**
+ * Resolve a remote player's position at `renderTimeMs` (a local clock value,
+ * normally `Date.now() - INTERPOLATION_DELAY_MS`).
+ *
+ * Returns null only for an empty buffer — a player we have heard nothing from
+ * yet, who should not be rendered.
+ */
+export function interpolateAt(
+  buffer: readonly PresenceSample[],
+  renderTimeMs: number,
+  config: InterpolationConfig
+): InterpolationResult | null {
+  if (buffer.length === 0) return null;
+
+  const first = buffer[0];
+  const last = buffer[buffer.length - 1];
+
+  // Render time is older than anything we have (just joined): hold the oldest.
+  if (renderTimeMs <= first.receivedAt) {
+    return { position: first.position, direction: first.direction, speed: 0, interpolated: false };
+  }
+
+  // Render time has run past the newest sample: they stopped sending, either
+  // because they stopped moving or because they are gone. Hold, don't guess.
+  if (renderTimeMs >= last.receivedAt) {
+    return { position: last.position, direction: last.direction, speed: 0, interpolated: false };
+  }
+
+  // Find the bracketing pair.
+  let a = first;
+  let b = last;
+  for (let i = 0; i < buffer.length - 1; i++) {
+    if (buffer[i].receivedAt <= renderTimeMs && renderTimeMs <= buffer[i + 1].receivedAt) {
+      a = buffer[i];
+      b = buffer[i + 1];
+      break;
+    }
+  }
+
+  const gap = distance(a.position, b.position);
+
+  // A jump this large is a teleport or a map transition, not walking. Snap to
+  // the destination rather than sliding the character across the map.
+  if (gap > config.snapDistanceTiles) {
+    return { position: b.position, direction: b.direction, speed: 0, interpolated: false };
+  }
+
+  const span = b.receivedAt - a.receivedAt;
+  if (span <= 0) {
+    return { position: b.position, direction: b.direction, speed: 0, interpolated: false };
+  }
+
+  const t = (renderTimeMs - a.receivedAt) / span;
+  return {
+    position: {
+      x: a.position.x + (b.position.x - a.position.x) * t,
+      y: a.position.y + (b.position.y - a.position.y) * t,
+    },
+    // The newer sample carries the player's current intent.
+    direction: b.direction,
+    speed: gap / (span / 1000),
+    interpolated: true,
+  };
+}

--- a/multiplayer/localEmote.ts
+++ b/multiplayer/localEmote.ts
@@ -1,0 +1,36 @@
+/**
+ * The local player's current emote.
+ *
+ * Two unrelated consumers need this: the controller, which publishes it, and
+ * the renderer, which draws the bubble above your own head so pressing an emote
+ * gives immediate feedback rather than a silent hope that somebody else saw it.
+ * A three-field singleton is cheaper and clearer than threading it through
+ * props into a hook that is deliberately dependency-free.
+ */
+
+import { MULTIPLAYER } from '../constants';
+import type { EmoteId } from './emotes';
+
+let current: EmoteId | null = null;
+let startedAt = 0;
+
+/** Start (or restart) an emote. */
+export function setLocalEmote(emote: EmoteId, now: number = Date.now()): void {
+  current = emote;
+  startedAt = now;
+}
+
+/** The active emote, or null once it has run its course. */
+export function getLocalEmote(now: number = Date.now()): EmoteId | null {
+  if (current === null) return null;
+  if (now - startedAt > MULTIPLAYER.EMOTE_DURATION_MS) {
+    current = null;
+  }
+  return current;
+}
+
+/** Clear immediately (map change, sign-out). */
+export function clearLocalEmote(): void {
+  current = null;
+  startedAt = 0;
+}

--- a/multiplayer/publishPolicy.ts
+++ b/multiplayer/publishPolicy.ts
@@ -1,0 +1,63 @@
+/**
+ * When to publish the local player's presence — pure decision function.
+ *
+ * Publishing every frame would be 60 writes/second of data with a 200 ms shelf
+ * life. Publishing only on a timer makes turning on the spot feel dead. This
+ * encodes the compromise in one testable place so no caller can get it wrong:
+ * see tests/presenceProtocol.test.ts.
+ */
+
+import type { LocalPresenceState } from './types';
+
+export interface PublishPolicyConfig {
+  publishHz: number;
+  moveThresholdTiles: number;
+  heartbeatMs: number;
+}
+
+export type PublishReason = 'first' | 'state-change' | 'moved' | 'heartbeat' | null;
+
+/**
+ * Decide whether `next` is worth sending, given what we last sent and when.
+ * Returns the reason (useful for debug logging), or null to stay quiet.
+ *
+ * Non-positional changes — turning to face a new direction, starting an emote,
+ * drinking a size potion — bypass the rate limit. They are rare and they are
+ * exactly the moments another player is looking at you.
+ */
+export function shouldPublish(
+  previous: LocalPresenceState | null,
+  next: LocalPresenceState,
+  nowMs: number,
+  lastPublishAtMs: number,
+  config: PublishPolicyConfig
+): PublishReason {
+  if (previous === null) return 'first';
+
+  if (
+    previous.direction !== next.direction ||
+    previous.emote !== next.emote ||
+    previous.fairyForm !== next.fairyForm ||
+    previous.sizeTier !== next.sizeTier ||
+    previous.characterId !== next.characterId ||
+    previous.name !== next.name
+  ) {
+    return 'state-change';
+  }
+
+  const elapsed = nowMs - lastPublishAtMs;
+
+  // Keep `t` fresh even when standing still, so staleness eviction on other
+  // clients means "this player is gone", not "this player is idle".
+  if (elapsed >= config.heartbeatMs) return 'heartbeat';
+
+  const dx = next.position.x - previous.position.x;
+  const dy = next.position.y - previous.position.y;
+  const moved = Math.sqrt(dx * dx + dy * dy);
+
+  if (moved >= config.moveThresholdTiles && elapsed >= 1000 / config.publishHz) {
+    return 'moved';
+  }
+
+  return null;
+}

--- a/multiplayer/remoteSprites.ts
+++ b/multiplayer/remoteSprites.ts
@@ -1,0 +1,103 @@
+/**
+ * Sprite resolution for remote players.
+ *
+ * A player's whole appearance travels over the wire as one field — the
+ * `characterId` — because sprites resolve to static paths under
+ * /assets/{characterId}/base/. Nothing has to be composited or transferred.
+ *
+ * Frame sets are cached per character: they are pure path arrays, and rebuilding
+ * them for every remote player every frame would be pointless garbage.
+ */
+
+import { Direction } from '../types';
+import {
+  generateCharacterSprites,
+  generateFairySprites,
+  getDirectionScale,
+  shouldFlipFairySprite,
+} from '../utils/characterSprites';
+import { getScaleForTier, clampTier } from '../utils/MagicEffects';
+import type { CharacterCustomization } from '../GameState';
+import type { RemotePlayer } from './types';
+
+type FrameSet = Record<Direction, string[]>;
+
+const frameCache = new Map<string, FrameSet>();
+let fairyFrames: FrameSet | null = null;
+
+/**
+ * generateCharacterSprites only reads `characterId` (and requires a non-empty
+ * `name` to pass its own validity check), so a minimal stand-in is enough — we
+ * never have another player's full customisation and do not need it.
+ */
+function minimalCustomisation(characterId: string): CharacterCustomization {
+  return {
+    characterId,
+    name: 'Remote',
+    skin: '',
+    hairStyle: '',
+    hairColor: '',
+    eyeColor: '',
+    clothesStyle: '',
+    clothesColor: '',
+    shoesStyle: '',
+    shoesColor: '',
+    glasses: 'none',
+    weapon: 'sword',
+  };
+}
+
+function getFrames(characterId: string): FrameSet {
+  let frames = frameCache.get(characterId);
+  if (!frames) {
+    frames = generateCharacterSprites(minimalCustomisation(characterId));
+    frameCache.set(characterId, frames);
+  }
+  return frames;
+}
+
+function getFairyFrames(): FrameSet {
+  if (!fairyFrames) fairyFrames = generateFairySprites();
+  return fairyFrames;
+}
+
+export interface RemoteSpriteInfo {
+  url: string;
+  /** Multiplier on PLAYER_SIZE, before the map's characterScale is applied */
+  spriteScale: number;
+  shouldFlip: boolean;
+}
+
+/**
+ * Pick the sprite frame, scale and flip for one remote player this frame.
+ *
+ * Frame 0 of every direction is the idle pose; frames 1..n-1 are the walk
+ * cycle. `animStep` is a monotonic counter derived from distance travelled, so
+ * it is wrapped here rather than by the manager, which does not know how many
+ * frames a given character has.
+ */
+export function getRemoteSpriteInfo(player: RemotePlayer): RemoteSpriteInfo {
+  const frames = player.fairyForm ? getFairyFrames() : getFrames(player.characterId);
+  const directionFrames = frames[player.direction] ?? frames[Direction.Down];
+
+  let url: string;
+  if (!player.isMoving || directionFrames.length <= 1) {
+    url = directionFrames[0];
+  } else {
+    const walkFrameCount = directionFrames.length - 1;
+    url = directionFrames[1 + (player.animStep % walkFrameCount)];
+  }
+
+  // Matches getPlayerSpriteInfo() in hooks/useCharacterSprites.ts: the custom
+  // artwork is authored at a higher resolution than the placeholder SVGs.
+  const isCustomSprite = url.includes('/assets/character') || url.startsWith('data:image');
+  const baseScale = isCustomSprite ? 3.0 : 1.0;
+  const directionScale = getDirectionScale(player.characterId, player.direction);
+  const sizeScale = getScaleForTier(clampTier(player.sizeTier));
+
+  return {
+    url,
+    spriteScale: baseScale * directionScale * sizeScale,
+    shouldFlip: player.fairyForm && shouldFlipFairySprite(player.direction),
+  };
+}

--- a/multiplayer/types.ts
+++ b/multiplayer/types.ts
@@ -1,0 +1,83 @@
+/**
+ * Multiplayer types — shared world, soft sync.
+ *
+ * See design_docs/planned/MULTIPLAYER.md for the model. In short:
+ * position and emotes are *ephemeral* (Realtime Database, deleted on
+ * disconnect), the farm and other durable shared state stays on Firestore,
+ * and inventory/quests/friendships are never replicated at all.
+ */
+
+import type { Position, Direction } from '../types';
+import type { EmoteId } from './emotes';
+
+/**
+ * Wire format for a presence record, as stored at `presence/{mapId}/{uid}`.
+ *
+ * Deliberately terse: every byte here is multiplied by (players × PUBLISH_HZ),
+ * and the RTDB security rules enumerate these keys exactly — an unknown key is
+ * rejected, so presence can never become a free-text channel by the back door.
+ */
+export interface PresenceWire {
+  /** Display name (<= 20 chars, rules-enforced) */
+  n: string;
+  /** characterId — the whole of a player's appearance */
+  c: string;
+  /** Tile position */
+  x: number;
+  y: number;
+  /** Facing, as a stable single-character code ('u'|'d'|'l'|'r') — see wire.ts */
+  d: string;
+  /** Size tier from potion effects (-3..3) */
+  s: number;
+  /** Fairy form active */
+  ff: boolean;
+  /** Current emote, or null. Rules validate against the closed vocabulary. */
+  e: EmoteId | null;
+  /** Server timestamp. Rules force this to be the server clock, so a client
+   *  cannot forge freshness. */
+  t: number;
+}
+
+/** The local player's publishable state, before it is encoded to the wire. */
+export interface LocalPresenceState {
+  name: string;
+  characterId: string;
+  position: Position;
+  direction: Direction;
+  sizeTier: number;
+  fairyForm: boolean;
+  emote: EmoteId | null;
+}
+
+/** One received position sample, timestamped on the *local* clock. */
+export interface PresenceSample {
+  position: Position;
+  direction: Direction;
+  /** Local Date.now() at receipt. Never the server's `t` — clocks differ
+   *  between players, and interpolation must run on a single clock. */
+  receivedAt: number;
+}
+
+/** A remote player as the renderer sees them, after interpolation. */
+export interface RemotePlayer {
+  uid: string;
+  name: string;
+  characterId: string;
+  /** Interpolated position for this frame */
+  position: Position;
+  direction: Direction;
+  sizeTier: number;
+  fairyForm: boolean;
+  /** Walk-cycle step, derived from distance travelled (not sent over the wire) */
+  animStep: number;
+  /** False when standing still — the renderer shows the idle frame */
+  isMoving: boolean;
+  /** Active emote, or null once it has expired */
+  emote: EmoteId | null;
+}
+
+/** Events emitted by the presence transport. */
+export type PresenceEvent =
+  | { type: 'joined'; uid: string; wire: PresenceWire }
+  | { type: 'changed'; uid: string; wire: PresenceWire }
+  | { type: 'left'; uid: string };

--- a/multiplayer/wire.ts
+++ b/multiplayer/wire.ts
@@ -1,0 +1,117 @@
+/**
+ * Presence wire encoding — pure, no Firebase imports.
+ *
+ * Kept separate from presenceService so it can be unit-tested without pulling
+ * in the Realtime Database SDK, and so the one place that decides what is
+ * allowed onto (and off) the wire is small enough to read in one sitting.
+ */
+
+import { Direction } from '../types';
+import type { Position } from '../types';
+import { isEmoteId } from './emotes';
+import type { LocalPresenceState, PresenceWire } from './types';
+
+/**
+ * Direction is a *numeric* enum in types/core.ts. Sending the raw number would
+ * silently break every older client the day somebody reorders that enum, so
+ * the wire uses stable single-character codes instead. Four bytes is a fair
+ * price for not having a compatibility landmine.
+ */
+const DIRECTION_TO_CODE: Record<Direction, string> = {
+  [Direction.Up]: 'u',
+  [Direction.Down]: 'd',
+  [Direction.Left]: 'l',
+  [Direction.Right]: 'r',
+};
+
+const CODE_TO_DIRECTION: Record<string, Direction> = {
+  u: Direction.Up,
+  d: Direction.Down,
+  l: Direction.Left,
+  r: Direction.Right,
+};
+
+export function encodeDirection(direction: Direction): string {
+  return DIRECTION_TO_CODE[direction] ?? 'd';
+}
+
+export function decodeDirection(code: unknown): Direction | null {
+  if (typeof code !== 'string') return null;
+  const direction = CODE_TO_DIRECTION[code];
+  return direction === undefined ? null : direction;
+}
+
+/** Display names are player-supplied. Cap and strip before they reach the wire. */
+export function sanitiseName(name: unknown): string {
+  if (typeof name !== 'string') return '';
+  // Drop C0/C1 control characters: they render as invisible boxes in a name tag
+  // and are the obvious way to smuggle noise past a length cap. Filtered by
+  // code point rather than by regex, which keeps eslint's no-control-regex happy.
+  let cleaned = '';
+  for (const character of name) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code < 0x20 || (code >= 0x7f && code <= 0x9f)) continue;
+    cleaned += character;
+  }
+  return cleaned.trim().slice(0, 20);
+}
+
+/** Only these appearances exist in /public/assets. Anything else is a forgery. */
+const VALID_CHARACTER_IDS = new Set(['character1', 'character2']);
+
+/** Round to 2dp — well below one rendered pixel, and it keeps records small. */
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/** Encode the local player's state for publication. `t` is added by the caller. */
+export function encodePresence(state: LocalPresenceState): Omit<PresenceWire, 't'> {
+  return {
+    n: sanitiseName(state.name) || 'Traveller',
+    c: VALID_CHARACTER_IDS.has(state.characterId) ? state.characterId : 'character1',
+    x: round2(state.position.x),
+    y: round2(state.position.y),
+    d: encodeDirection(state.direction),
+    s: Math.max(-3, Math.min(3, Math.round(state.sizeTier))),
+    ff: state.fairyForm === true,
+    e: state.emote,
+  };
+}
+
+/**
+ * Validate an inbound presence record.
+ *
+ * The security rules already enforce this shape, but rules can lag a deploy and
+ * a malformed record must degrade to "ignore this player" — never to a crash
+ * mid-frame. Returns null for anything we cannot render safely.
+ */
+export function decodePresence(raw: unknown): PresenceWire | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const d = raw as Record<string, unknown>;
+
+  const name = sanitiseName(d.n);
+  if (!name) return null;
+
+  if (typeof d.x !== 'number' || typeof d.y !== 'number') return null;
+  if (!Number.isFinite(d.x) || !Number.isFinite(d.y)) return null;
+
+  const direction = decodeDirection(d.d);
+  if (direction === null) return null;
+
+  return {
+    n: name,
+    c: typeof d.c === 'string' && VALID_CHARACTER_IDS.has(d.c) ? d.c : 'character1',
+    x: d.x,
+    y: d.y,
+    d: encodeDirection(direction),
+    s: typeof d.s === 'number' && Number.isFinite(d.s) ? Math.max(-3, Math.min(3, d.s)) : 0,
+    ff: d.ff === true,
+    e: isEmoteId(d.e) ? d.e : null,
+    t: typeof d.t === 'number' ? d.t : 0,
+  };
+}
+
+/** Convenience: the decoded position of a wire record. */
+export function wirePosition(wire: PresenceWire): Position {
+  return { x: wire.x, y: wire.y };
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -79,6 +79,13 @@ box, an out-of-bounds transition dumps the player somewhere arbitrary. Nothing t
 | `mapUtils.test.ts` | Tile coordinate helpers | Touching coordinate maths |
 | `firebasePaths.test.ts` | Firestore path construction | Touching cloud saves |
 | `anthropicClient.test.ts` | AI dialogue client behaviour | Touching AI dialogue |
+| `emoteVocabulary.test.ts` | **Safety-critical.** `multiplayer/emotes.ts` and `database.rules.json` listing different emotes — a hole in the closed vocabulary that is the whole reason player-to-player chat is safe | Adding or renaming an emote |
+| `presenceProtocol.test.ts` | Wire encode/decode, publish throttling, staleness eviction, remote-player interpolation lifecycle | Touching presence, the wire format, or RemotePlayerManager |
+| `remotePlayerInterpolation.test.ts` | The lerp/snap/hold maths that makes other players glide instead of teleport | Touching `multiplayer/interpolation.ts` |
+| `multiplayerSafeStubs.test.ts` | A method on the real presence service missing from the `firebase/safe` stub — crashes **only** in a build without the `firebase` package | Adding a method to any Firebase service |
+| `determinism.test.ts` | `Math.random()` creeping back into NPC wander or fairy spawning, which silently desyncs what two players see | Touching NPC movement, fairies, or `utils/seededRandom.ts` |
+| `sharedFarmHarvestClaim.test.ts` | Two players both harvesting one ripe crop; and the opposite error — confiscating a crop on a network blip | Touching harvesting or the shared farm |
+| `multiplayerUI.test.tsx` | Render-time crashes in the emote wheel / presence indicator, which headless Chrome cannot reach (PixiJS never initialises under SwiftShader) | Touching multiplayer UI |
 
 ## Writing a new test
 

--- a/tests/determinism.test.ts
+++ b/tests/determinism.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @vitest-environment node
+ *
+ * Shared-world determinism.
+ *
+ * A large part of this game costs nothing to synchronise because it is already a
+ * pure function of the wall clock: TimeManager derives the date from
+ * Date.now(), and weather is a seeded PRNG over time slots. Multiplayer leans
+ * hard on that — every player sees the same season, the same rain, the same
+ * fairy on the same bluebell, with zero bytes on the wire.
+ *
+ * The property that keeps it true is that these decisions must depend on
+ * (identity, time) and nothing else — never on how long this particular client
+ * has been running. Reintroduce a Math.random() or an accumulated local counter
+ * anywhere in that chain and two players quietly stop seeing the same world.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  createSeededRandom,
+  createDecisionRandom,
+  hashString,
+  slotPhaseOffset,
+} from '../utils/seededRandom';
+
+describe('hashString', () => {
+  it('is stable for the same input', () => {
+    expect(hashString('deer_1')).toBe(hashString('deer_1'));
+  });
+
+  it('separates ids that differ by one character', () => {
+    expect(hashString('deer_1')).not.toBe(hashString('deer_2'));
+  });
+
+  it('always produces a non-negative 32-bit integer', () => {
+    for (const id of ['', 'a', 'deer_1', 'a very long npc identifier indeed', '🦌']) {
+      const hash = hashString(id);
+      expect(Number.isInteger(hash)).toBe(true);
+      expect(hash).toBeGreaterThanOrEqual(0);
+      expect(hash).toBeLessThan(2 ** 32);
+    }
+  });
+});
+
+describe('createSeededRandom', () => {
+  it('replays the same sequence for the same seed', () => {
+    const first = createSeededRandom(12345);
+    const second = createSeededRandom(12345);
+    const a = Array.from({ length: 20 }, () => first());
+    const b = Array.from({ length: 20 }, () => second());
+    expect(a).toEqual(b);
+  });
+
+  it('produces different sequences for different seeds', () => {
+    const a = createSeededRandom(1)();
+    const b = createSeededRandom(2)();
+    expect(a).not.toBe(b);
+  });
+
+  it('stays within [0, 1)', () => {
+    const random = createSeededRandom(99);
+    for (let i = 0; i < 1000; i++) {
+      const value = random();
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+    }
+  });
+
+  it('spreads values across the range rather than clustering', () => {
+    // A weak generator here would make every NPC pick the same direction.
+    const random = createSeededRandom(7);
+    const buckets = new Array(10).fill(0);
+    for (let i = 0; i < 10_000; i++) buckets[Math.floor(random() * 10)]++;
+
+    const underfilled = buckets.filter((count) => count < 700);
+    expect(underfilled, `Poor distribution across deciles: ${buckets.join(', ')}`).toEqual([]);
+  });
+});
+
+describe('createDecisionRandom', () => {
+  it('gives two clients the same decision for the same (npc, slot)', () => {
+    // This is the whole multiplayer property: the two calls stand in for two
+    // players' browsers, which share nothing but the id and the clock.
+    const clientA = createDecisionRandom('deer_1', 4821);
+    const clientB = createDecisionRandom('deer_1', 4821);
+    expect(clientA()).toBe(clientB());
+  });
+
+  it('gives a different decision in the next slot', () => {
+    expect(createDecisionRandom('deer_1', 100)()).not.toBe(createDecisionRandom('deer_1', 101)());
+  });
+
+  it('gives different NPCs different decisions in the same slot', () => {
+    expect(createDecisionRandom('deer_1', 100)()).not.toBe(createDecisionRandom('deer_2', 100)());
+  });
+
+  it('does not depend on how long a client has been running', () => {
+    // The failure this guards: a client that joined 500 slots ago must not have
+    // "advanced" its generator relative to one that just arrived.
+    const longRunning = createDecisionRandom('deer_1', 500);
+    for (let i = 0; i < 500; i++) longRunning();
+
+    const justArrived = createDecisionRandom('deer_1', 501);
+    const alsoLongRunning = createDecisionRandom('deer_1', 501);
+    expect(alsoLongRunning()).toBe(justArrived());
+  });
+});
+
+describe('slotPhaseOffset', () => {
+  it('is stable per id, so clients agree on when an NPC decides', () => {
+    expect(slotPhaseOffset('deer_1', 2500)).toBe(slotPhaseOffset('deer_1', 2500));
+  });
+
+  it('stays inside the slot', () => {
+    for (const id of ['deer_1', 'duck_2', 'mum', 'possum_7']) {
+      const offset = slotPhaseOffset(id, 2500);
+      expect(offset).toBeGreaterThanOrEqual(0);
+      expect(offset).toBeLessThan(2500);
+    }
+  });
+
+  it('staggers different NPCs, so the village does not turn in unison', () => {
+    const ids = ['deer_1', 'deer_2', 'deer_3', 'duck_1', 'duck_2', 'possum_1'];
+    const offsets = new Set(ids.map((id) => slotPhaseOffset(id, 2500)));
+    expect(offsets.size).toBeGreaterThan(1);
+  });
+});
+
+describe('no unseeded randomness in the shared simulation', () => {
+  it('leaves no Math.random() in NPC wander or fairy spawning', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+
+    // These two drive things players point at and talk about ("look, the
+    // deer!", "there's a fairy by the bluebells"), so they must agree across
+    // clients. Anything reintroducing Math.random() here breaks that silently.
+    const guarded = ['NPCManager.ts', 'utils/fairyAttractionManager.ts'];
+
+    const offenders = guarded.filter((file) =>
+      readFileSync(join(__dirname, '..', file), 'utf-8').includes('Math.random()')
+    );
+
+    expect(
+      offenders,
+      'These files feed the shared simulation and must not use Math.random(). ' +
+        'Use createDecisionRandom(id, slot) or createSeededRandom(seed) from ' +
+        'utils/seededRandom.ts so every player computes the same result.'
+    ).toEqual([]);
+  });
+});

--- a/tests/emoteVocabulary.test.ts
+++ b/tests/emoteVocabulary.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment node
+ *
+ * The safety-critical test in the multiplayer feature.
+ *
+ * Emotes are the only channel between players, and the reason that is safe is
+ * that the vocabulary is *closed*: a player with the dev console open still
+ * cannot publish anything that is not on the list, because the Realtime
+ * Database rules enumerate the allowed values server-side.
+ *
+ * That means the list exists twice — once in multiplayer/emotes.ts and once in
+ * database.rules.json — and if the two ever drift, the guarantee quietly
+ * evaporates. Add an emote to the code and forget the rules and it silently
+ * stops working; add one to the rules and forget the code and the closed
+ * vocabulary has a hole in it. This test makes either mistake loud.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { EMOTE_IDS, EMOTES, isEmoteId } from '../multiplayer/emotes';
+
+const rulesPath = join(__dirname, '..', 'database.rules.json');
+const rules = JSON.parse(readFileSync(rulesPath, 'utf-8'));
+
+/** The `e` field's validate expression, e.g. "newData.val() === null || ..." */
+function emoteRuleExpression(): string {
+  const expression = rules?.rules?.presence?.$mapId?.$uid?.e?.['.validate'];
+  expect(
+    typeof expression,
+    'database.rules.json has no validate rule for presence/$mapId/$uid/e — ' +
+      'without it any string can be published as an emote'
+  ).toBe('string');
+  return expression as string;
+}
+
+/** Pull every 'literal' out of the rule expression. */
+function emoteIdsInRules(): string[] {
+  const matches = emoteRuleExpression().matchAll(/'([^']+)'/g);
+  return [...matches].map((match) => match[1]);
+}
+
+describe('emote vocabulary', () => {
+  it('lists exactly the same ids in the code and the security rules', () => {
+    const inCode: string[] = [...EMOTE_IDS].sort();
+    const inRules: string[] = emoteIdsInRules().sort();
+
+    const missingFromRules = inCode.filter((id) => !inRules.includes(id));
+    const missingFromCode = inRules.filter((id) => !inCode.includes(id));
+
+    expect(
+      { missingFromRules, missingFromCode },
+      'multiplayer/emotes.ts and database.rules.json have drifted. Add the ids in ' +
+        '`missingFromRules` to the "e" validate rule in database.rules.json, and remove ' +
+        'the ids in `missingFromCode` from it (or add them to EMOTES).'
+    ).toEqual({ missingFromRules: [], missingFromCode: [] });
+  });
+
+  it('allows null so a player can clear their emote', () => {
+    expect(
+      emoteRuleExpression(),
+      'The "e" rule must accept null, or an expired emote can never be cleared'
+    ).toContain('newData.val() === null');
+  });
+
+  it('rejects arbitrary extra keys on a presence record', () => {
+    // Without this rule, presence becomes an unmoderated free-text channel by
+    // the back door, which defeats the whole closed-vocabulary design.
+    expect(
+      rules?.rules?.presence?.$mapId?.$uid?.$other?.['.validate'],
+      'presence/$mapId/$uid must have "$other": { ".validate": false }'
+    ).toBe(false);
+  });
+
+  it('only lets a player write their own presence record', () => {
+    expect(rules?.rules?.presence?.$mapId?.$uid?.['.write']).toBe(
+      'auth != null && auth.uid === $uid'
+    );
+  });
+
+  it('forces the server clock for the freshness timestamp', () => {
+    // Staleness eviction on other clients is only meaningful if a client cannot
+    // lie about when it last spoke.
+    expect(rules?.rules?.presence?.$mapId?.$uid?.t?.['.validate']).toBe('newData.val() === now');
+  });
+});
+
+describe('emote definitions', () => {
+  it('has no duplicate ids', () => {
+    expect(new Set(EMOTE_IDS).size).toBe(EMOTE_IDS.length);
+  });
+
+  it('gives every emote an icon and a label', () => {
+    const incomplete = EMOTES.filter((emote) => !emote.icon || !emote.label);
+    expect(incomplete, 'Every emote needs an icon and a label for the picker').toEqual([]);
+  });
+
+  it('accepts only known ids through the type guard', () => {
+    expect(isEmoteId('wave')).toBe(true);
+    expect(isEmoteId('definitely-not-an-emote')).toBe(false);
+    expect(isEmoteId(null)).toBe(false);
+    expect(isEmoteId(42)).toBe(false);
+  });
+});

--- a/tests/multiplayerSafeStubs.test.ts
+++ b/tests/multiplayerSafeStubs.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment node
+ *
+ * firebase/safe.ts exists so the game still runs when the `firebase` package is
+ * absent: every service is reached through a getter that falls back to a stub.
+ * The failure mode this guards is nasty and asymmetric — a method added to the
+ * real service but forgotten on the stub works perfectly in every environment
+ * that has Firebase, and crashes only in the one that does not.
+ *
+ * Presence is the most exposed case, because it is called from inside the game
+ * loop: a missing stub method there is a `TypeError` sixty times a second.
+ */
+import { describe, it, expect } from 'vitest';
+import { presenceService } from '../firebase/presenceService';
+import { getPresenceService, getCommunityGardenService } from '../firebase/safe';
+
+/** Own + prototype methods, minus the Object.prototype furniture. */
+function methodNames(target: object): string[] {
+  const names = new Set<string>();
+  let current: object | null = target;
+  while (current && current !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(current)) {
+      if (key === 'constructor') continue;
+      const value = (target as Record<string, unknown>)[key];
+      if (typeof value === 'function') names.add(key);
+    }
+    current = Object.getPrototypeOf(current);
+  }
+  return [...names].sort();
+}
+
+describe('presence stub parity', () => {
+  it('implements every public method of the real presence service', () => {
+    // Note this test runs *with* firebase installed, so getPresenceService()
+    // may hand back the real service; the stub is compared directly instead.
+    const realMethods = methodNames(presenceService);
+    const stub = getPresenceService();
+    const stubMethods = methodNames(stub);
+
+    const missing = realMethods.filter((name) => !stubMethods.includes(name));
+
+    expect(
+      missing,
+      'These methods exist on firebase/presenceService but not on the stub in ' +
+        'firebase/safe.ts. The game would crash on them in a build without the ' +
+        '`firebase` package. Add a no-op to stubPresenceService.'
+    ).toEqual([]);
+  });
+
+  it('returns something callable even before Firebase has loaded', () => {
+    const stub = getPresenceService();
+    expect(typeof stub.isAvailable).toBe('function');
+    expect(typeof stub.enterRoom).toBe('function');
+    expect(typeof stub.leaveRoom).toBe('function');
+    expect(typeof stub.publish).toBe('function');
+    expect(typeof stub.onPresence).toBe('function');
+  });
+
+  it('hands back a working unsubscribe from onPresence', () => {
+    // The controller calls this in an effect cleanup; a stub returning
+    // undefined would throw on unmount.
+    const unsubscribe = getPresenceService().onPresence(() => {});
+    expect(typeof unsubscribe).toBe('function');
+    expect(() => unsubscribe()).not.toThrow();
+  });
+});
+
+describe('community garden stub parity', () => {
+  it('still exposes the shared-farm API the same way', () => {
+    // Sanity check on the pattern presence follows, so a regression in the
+    // older service is caught by the same run.
+    const service = getCommunityGardenService();
+    expect(typeof service.startListening).toBe('function');
+    expect(typeof service.writePlot).toBe('function');
+    expect(typeof service.onPlotsChanged).toBe('function');
+  });
+});

--- a/tests/multiplayerUI.test.tsx
+++ b/tests/multiplayerUI.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Component tests for the two pieces of multiplayer UI.
+ *
+ * These exist because the multiplayer UI cannot be verified in the headless
+ * browser: PixiJS never finishes initialising under SwiftShader, so the game
+ * sits on the loading screen and the `isInWorld` gate (correctly) keeps both
+ * components hidden. A render-time crash — a bad import, a missing prop, an
+ * undefined access — would otherwise reach a real player before anyone noticed.
+ *
+ * Uses jsdom (the project default environment), following tests/splashScreen.test.tsx.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import EmoteWheel from '../components/EmoteWheel';
+import PresenceIndicator from '../components/PresenceIndicator';
+import { EMOTES } from '../multiplayer/emotes';
+
+describe('EmoteWheel', () => {
+  it('offers exactly the emotes in the vocabulary, and nothing else', () => {
+    // The picker is the only player-to-player channel; anything here that is
+    // not in EMOTES would be rejected by the security rules anyway.
+    render(<EmoteWheel onSelect={() => {}} onClose={() => {}} />);
+
+    for (const emote of EMOTES) {
+      expect(screen.getByRole('button', { name: emote.label })).toBeInTheDocument();
+    }
+    expect(screen.getAllByRole('button')).toHaveLength(EMOTES.length);
+  });
+
+  it('sends the chosen emote and closes', () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(<EmoteWheel onSelect={onSelect} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Wave' }));
+
+    expect(onSelect).toHaveBeenCalledWith('wave');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('picks an emote by number key, so a keyboard player never needs the mouse', () => {
+    const onSelect = vi.fn();
+    render(<EmoteWheel onSelect={onSelect} onClose={() => {}} />);
+
+    fireEvent.keyDown(window, { key: '2' });
+
+    expect(onSelect).toHaveBeenCalledWith(EMOTES[1].id);
+  });
+
+  it('ignores a number key with no emote behind it', () => {
+    const onSelect = vi.fn();
+    render(<EmoteWheel onSelect={onSelect} onClose={() => {}} />);
+
+    fireEvent.keyDown(window, { key: '9' });
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('closes on Escape without sending anything', () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(<EmoteWheel onSelect={onSelect} onClose={onClose} />);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe('PresenceIndicator', () => {
+  it('renders nothing when you are alone — single-player is untouched', () => {
+    const { container } = render(<PresenceIndicator count={0} names={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('uses the singular for one friend', () => {
+    render(<PresenceIndicator count={1} names={['Sanne']} />);
+    expect(screen.getByText('1 friend here')).toBeInTheDocument();
+  });
+
+  it('uses the plural for several', () => {
+    render(<PresenceIndicator count={3} names={['Sanne', 'Mark', 'Juniper']} />);
+    expect(screen.getByText('3 friends here')).toBeInTheDocument();
+  });
+});

--- a/tests/presenceProtocol.test.ts
+++ b/tests/presenceProtocol.test.ts
@@ -1,0 +1,252 @@
+/**
+ * @vitest-environment node
+ *
+ * The presence protocol: what goes on the wire, when it goes, and what happens
+ * to it on the way in. None of this needs Firebase — the transport is a thin
+ * shell over these pure pieces, which is the point of splitting them out.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../constants', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    DEBUG: { ...(actual.DEBUG as object), MULTIPLAYER: false },
+  };
+});
+
+import {
+  encodePresence,
+  decodePresence,
+  encodeDirection,
+  decodeDirection,
+} from '../multiplayer/wire';
+import { shouldPublish } from '../multiplayer/publishPolicy';
+import { remotePlayerManager } from '../multiplayer/RemotePlayerManager';
+import { MULTIPLAYER } from '../constants';
+import { Direction } from '../types';
+import type { LocalPresenceState, PresenceWire } from '../multiplayer/types';
+
+const POLICY = {
+  publishHz: 5,
+  moveThresholdTiles: 0.08,
+  heartbeatMs: 15000,
+};
+
+function localState(overrides: Partial<LocalPresenceState> = {}): LocalPresenceState {
+  return {
+    name: 'Sanne',
+    characterId: 'character1',
+    position: { x: 10, y: 10 },
+    direction: Direction.Down,
+    sizeTier: 0,
+    fairyForm: false,
+    emote: null,
+    ...overrides,
+  };
+}
+
+function wire(overrides: Partial<PresenceWire> = {}): PresenceWire {
+  return {
+    n: 'Mark',
+    c: 'character2',
+    x: 5,
+    y: 6,
+    d: 'd',
+    s: 0,
+    ff: false,
+    e: null,
+    t: 1000,
+    ...overrides,
+  };
+}
+
+describe('direction codes', () => {
+  it('round-trips every direction', () => {
+    for (const direction of [Direction.Up, Direction.Down, Direction.Left, Direction.Right]) {
+      expect(decodeDirection(encodeDirection(direction))).toBe(direction);
+    }
+  });
+
+  it('rejects an unknown code rather than guessing', () => {
+    expect(decodeDirection('x')).toBeNull();
+    expect(decodeDirection(2)).toBeNull();
+    expect(decodeDirection(undefined)).toBeNull();
+  });
+});
+
+describe('encodePresence', () => {
+  it('rounds coordinates to 2dp to keep records small', () => {
+    const encoded = encodePresence(localState({ position: { x: 10.123456, y: 4.987654 } }));
+    expect(encoded.x).toBe(10.12);
+    expect(encoded.y).toBe(4.99);
+  });
+
+  it('caps a long display name at 20 characters', () => {
+    const encoded = encodePresence(localState({ name: 'x'.repeat(50) }));
+    expect(encoded.n).toHaveLength(20);
+  });
+
+  it('falls back to character1 for an appearance that does not exist', () => {
+    expect(encodePresence(localState({ characterId: 'character99' })).c).toBe('character1');
+  });
+
+  it('clamps the size tier to the potion range', () => {
+    expect(encodePresence(localState({ sizeTier: 99 })).s).toBe(3);
+    expect(encodePresence(localState({ sizeTier: -99 })).s).toBe(-3);
+  });
+});
+
+describe('decodePresence', () => {
+  it('accepts a well-formed record', () => {
+    expect(decodePresence(wire())).not.toBeNull();
+  });
+
+  it('rejects records we could not render', () => {
+    expect(decodePresence(null)).toBeNull();
+    expect(decodePresence('nope')).toBeNull();
+    expect(decodePresence(wire({ x: Number.NaN }))).toBeNull();
+    expect(decodePresence({ ...wire(), x: '5' })).toBeNull();
+    expect(decodePresence(wire({ d: 'diagonal' }))).toBeNull();
+    expect(decodePresence(wire({ n: '' }))).toBeNull();
+  });
+
+  it('drops an emote that is not in the closed vocabulary', () => {
+    // The RTDB rules reject these too, but rules can lag a deploy and this is
+    // the safety property the whole emote design rests on.
+    expect(decodePresence(wire({ e: 'something-nasty' as never })!).e).toBeNull();
+    expect(decodePresence(wire({ e: 'wave' })!).e).toBe('wave');
+  });
+
+  it('strips control characters from a display name', () => {
+    const decoded = decodePresence(wire({ n: 'Ma\u0007r\u001bk' }));
+    expect(decoded!.n).toBe('Mark');
+  });
+
+  it('falls back to character1 for a forged appearance', () => {
+    expect(decodePresence(wire({ c: '../../../etc/passwd' }))!.c).toBe('character1');
+  });
+});
+
+describe('shouldPublish', () => {
+  it('always publishes the first record', () => {
+    expect(shouldPublish(null, localState(), 0, 0, POLICY)).toBe('first');
+  });
+
+  it('stays quiet when nothing has changed and the rate limit is live', () => {
+    const state = localState();
+    expect(shouldPublish(state, state, 1000, 1000, POLICY)).toBeNull();
+  });
+
+  it('ignores sub-threshold jitter', () => {
+    const previous = localState();
+    const next = localState({ position: { x: 10.01, y: 10 } });
+    expect(shouldPublish(previous, next, 5000, 0, POLICY)).toBeNull();
+  });
+
+  it('publishes real movement once the rate limit allows', () => {
+    const previous = localState();
+    const next = localState({ position: { x: 11, y: 10 } });
+    expect(shouldPublish(previous, next, 1000, 800, POLICY)).toBe('moved');
+    // 100ms after the last write is inside the 200ms budget at 5Hz.
+    expect(shouldPublish(previous, next, 900, 800, POLICY)).toBeNull();
+  });
+
+  it('lets a turn on the spot bypass the rate limit', () => {
+    // Rare, and exactly the moment another player is looking at you.
+    const previous = localState();
+    const next = localState({ direction: Direction.Left });
+    expect(shouldPublish(previous, next, 801, 800, POLICY)).toBe('state-change');
+  });
+
+  it('lets an emote bypass the rate limit', () => {
+    const previous = localState();
+    const next = localState({ emote: 'wave' });
+    expect(shouldPublish(previous, next, 801, 800, POLICY)).toBe('state-change');
+  });
+
+  it('heartbeats while standing still so staleness eviction stays meaningful', () => {
+    const state = localState();
+    expect(shouldPublish(state, state, 20000, 0, POLICY)).toBe('heartbeat');
+  });
+});
+
+describe('RemotePlayerManager', () => {
+  beforeEach(() => {
+    remotePlayerManager.setMap(null);
+    remotePlayerManager.clear();
+    remotePlayerManager.setMap('village');
+  });
+
+  it('tracks a player from first sighting', () => {
+    remotePlayerManager.apply('uid-1', wire({ n: 'Mark' }), 1000);
+    expect(remotePlayerManager.getCount()).toBe(1);
+    expect(remotePlayerManager.getNames()).toEqual(['Mark']);
+  });
+
+  it('drops a player who left the room', () => {
+    remotePlayerManager.apply('uid-1', wire(), 1000);
+    remotePlayerManager.remove('uid-1');
+    expect(remotePlayerManager.getCount()).toBe(0);
+  });
+
+  it('forgets everyone when the map changes — presence is per-map', () => {
+    remotePlayerManager.apply('uid-1', wire(), 1000);
+    remotePlayerManager.setMap('orchard');
+    expect(remotePlayerManager.getCount()).toBe(0);
+  });
+
+  it('evicts a player we stopped hearing from', () => {
+    // onDisconnect() covers the usual cases; this is the backstop for a socket
+    // that never actually closed (suspended laptop, dead Wi-Fi).
+    remotePlayerManager.apply('uid-1', wire(), 1000);
+    remotePlayerManager.tick(1000 + MULTIPLAYER.STALE_AFTER_MS - 1);
+    expect(remotePlayerManager.getCount()).toBe(1);
+
+    remotePlayerManager.tick(1000 + MULTIPLAYER.STALE_AFTER_MS + 1);
+    expect(remotePlayerManager.getCount()).toBe(0);
+  });
+
+  it('expires an emote locally rather than trusting the sender to clear it', () => {
+    remotePlayerManager.apply('uid-1', wire({ e: 'wave' }), 1000);
+    expect(remotePlayerManager.getRemotePlayers()[0].emote).toBe('wave');
+
+    remotePlayerManager.tick(1000 + MULTIPLAYER.EMOTE_DURATION_MS + 1);
+    expect(remotePlayerManager.getRemotePlayers()[0].emote).toBeNull();
+  });
+
+  it('interpolates a walking player between samples', () => {
+    const start = 10_000;
+    remotePlayerManager.apply('uid-1', wire({ x: 0, y: 0 }), start);
+    remotePlayerManager.apply('uid-1', wire({ x: 1, y: 0 }), start + 200);
+
+    // Render time is deliberately behind: now - INTERPOLATION_DELAY_MS must
+    // land between the two samples.
+    remotePlayerManager.tick(start + 100 + MULTIPLAYER.INTERPOLATION_DELAY_MS);
+
+    const player = remotePlayerManager.getRemotePlayers()[0];
+    expect(player.position.x).toBeGreaterThan(0);
+    expect(player.position.x).toBeLessThan(1);
+    expect(player.isMoving).toBe(true);
+  });
+
+  it('advances the walk cycle from distance travelled, not from a timer', () => {
+    const start = 10_000;
+    remotePlayerManager.apply('uid-1', wire({ x: 0, y: 0 }), start);
+    remotePlayerManager.apply('uid-1', wire({ x: 2, y: 0 }), start + 400);
+
+    remotePlayerManager.tick(start + 200 + MULTIPLAYER.INTERPOLATION_DELAY_MS);
+    remotePlayerManager.tick(start + 400 + MULTIPLAYER.INTERPOLATION_DELAY_MS);
+
+    expect(remotePlayerManager.getRemotePlayers()[0].animStep).toBeGreaterThan(0);
+  });
+
+  it('reports a stationary player as idle', () => {
+    const start = 10_000;
+    remotePlayerManager.apply('uid-1', wire({ x: 4, y: 4 }), start);
+    remotePlayerManager.apply('uid-1', wire({ x: 4, y: 4 }), start + 200);
+
+    remotePlayerManager.tick(start + 100 + MULTIPLAYER.INTERPOLATION_DELAY_MS);
+    expect(remotePlayerManager.getRemotePlayers()[0].isMoving).toBe(false);
+  });
+});

--- a/tests/remotePlayerInterpolation.test.ts
+++ b/tests/remotePlayerInterpolation.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @vitest-environment node
+ *
+ * Remote players are rendered 120ms in the past and lerped between the two
+ * presence samples that bracket that time. Getting this wrong is the difference
+ * between other players gliding and other players teleporting once a second, so
+ * the maths lives in a pure module and is pinned here.
+ */
+import { describe, it, expect } from 'vitest';
+import { interpolateAt, pushSample } from '../multiplayer/interpolation';
+import type { PresenceSample } from '../multiplayer/types';
+import { Direction } from '../types';
+
+const CONFIG = { snapDistanceTiles: 3, bufferSize: 4 };
+
+function sample(x: number, y: number, receivedAt: number, direction = Direction.Down) {
+  return { position: { x, y }, direction, receivedAt } satisfies PresenceSample;
+}
+
+describe('pushSample', () => {
+  it('keeps the buffer bounded to bufferSize, dropping the oldest', () => {
+    let buffer: PresenceSample[] = [];
+    for (let i = 0; i < 10; i++) {
+      buffer = pushSample(buffer, sample(i, 0, i * 100), 4);
+    }
+    expect(buffer).toHaveLength(4);
+    expect(buffer[0].position.x).toBe(6);
+    expect(buffer[3].position.x).toBe(9);
+  });
+
+  it('inserts an out-of-order arrival in time order rather than appending it', () => {
+    // Appending a reordered packet would make the player jump backwards for a
+    // frame, because interpolateAt assumes the buffer is sorted.
+    let buffer: PresenceSample[] = [];
+    buffer = pushSample(buffer, sample(0, 0, 1000), 4);
+    buffer = pushSample(buffer, sample(2, 0, 3000), 4);
+    buffer = pushSample(buffer, sample(1, 0, 2000), 4);
+
+    expect(buffer.map((s) => s.receivedAt)).toEqual([1000, 2000, 3000]);
+  });
+
+  it('does not mutate the buffer it was given', () => {
+    const original = [sample(0, 0, 1000)];
+    const next = pushSample(original, sample(1, 0, 2000), 4);
+    expect(original).toHaveLength(1);
+    expect(next).toHaveLength(2);
+  });
+});
+
+describe('interpolateAt', () => {
+  it('returns null for a player we have heard nothing from', () => {
+    expect(interpolateAt([], 1000, CONFIG)).toBeNull();
+  });
+
+  it('lerps midway between two bracketing samples', () => {
+    // A realistic step: the player walks at 5 tiles/sec and publishes at 5Hz,
+    // so consecutive samples are about a tile apart.
+    const buffer = [sample(0, 0, 1000), sample(2, 1, 2000)];
+    const result = interpolateAt(buffer, 1500, CONFIG);
+
+    expect(result).not.toBeNull();
+    expect(result!.position.x).toBeCloseTo(1);
+    expect(result!.position.y).toBeCloseTo(0.5);
+    expect(result!.interpolated).toBe(true);
+  });
+
+  it('reports speed in tiles per second', () => {
+    // 3 tiles across in 1000ms.
+    const buffer = [sample(0, 0, 1000), sample(3, 0, 2000)];
+    const result = interpolateAt(buffer, 1500, CONFIG);
+    expect(result!.speed).toBeCloseTo(3);
+  });
+
+  it('takes direction from the newer sample, which carries current intent', () => {
+    const buffer = [sample(0, 0, 1000, Direction.Left), sample(1, 0, 2000, Direction.Up)];
+    expect(interpolateAt(buffer, 1500, CONFIG)!.direction).toBe(Direction.Up);
+  });
+
+  it('holds at the newest sample once render time runs past it', () => {
+    // They stopped sending: either standing still or gone. Extrapolating here is
+    // what makes players rubber-band when they stop walking.
+    const buffer = [sample(0, 0, 1000), sample(4, 0, 2000)];
+    const result = interpolateAt(buffer, 9000, CONFIG);
+
+    expect(result!.position).toEqual({ x: 4, y: 0 });
+    expect(result!.speed).toBe(0);
+    expect(result!.interpolated).toBe(false);
+  });
+
+  it('holds at the oldest sample when render time predates the buffer', () => {
+    const buffer = [sample(7, 7, 5000)];
+    const result = interpolateAt(buffer, 1000, CONFIG);
+    expect(result!.position).toEqual({ x: 7, y: 7 });
+  });
+
+  it('snaps rather than sliding across the map on a teleport', () => {
+    // A map transition or a teleport, not a walk. Sliding would drag the
+    // character visibly through walls.
+    const buffer = [sample(0, 0, 1000), sample(40, 40, 2000)];
+    const result = interpolateAt(buffer, 1500, CONFIG);
+
+    expect(result!.position).toEqual({ x: 40, y: 40 });
+    expect(result!.interpolated).toBe(false);
+    expect(result!.speed).toBe(0);
+  });
+
+  it('survives two samples sharing a timestamp without dividing by zero', () => {
+    const buffer = [sample(0, 0, 1000), sample(1, 0, 1000), sample(2, 0, 2000)];
+    const result = interpolateAt(buffer, 1000, CONFIG);
+    expect(result).not.toBeNull();
+    expect(Number.isFinite(result!.position.x)).toBe(true);
+  });
+});

--- a/tests/sharedFarmHarvestClaim.test.ts
+++ b/tests/sharedFarmHarvestClaim.test.ts
@@ -1,0 +1,208 @@
+/**
+ * @vitest-environment node
+ *
+ * The double-harvest race on the shared farm.
+ *
+ * The community garden syncs on a 10s last-write-wins flush, so before claim
+ * transactions two players could both click the same ripe crop within ten
+ * seconds and both walk away with it. Harvesting is the one genuinely contended
+ * action in an otherwise cooperative game, and it is settled optimistically:
+ * grant immediately (blocking on a round-trip would put a visible stall on every
+ * harvest), then roll back in the rare case we can prove somebody won it first.
+ *
+ * The asymmetry matters and is asserted here: a *proven* loss rolls back, but a
+ * network failure keeps the crop. Confiscating something a player legitimately
+ * harvested is a far worse experience than one duplicate carrot.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../constants', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    DEBUG: { FARM: false, NPC: false, MAP: false, COLLISION: false },
+  };
+});
+
+vi.mock('../utils/TimeManager', () => ({
+  Season: { SPRING: 'Spring', SUMMER: 'Summer', AUTUMN: 'Autumn', WINTER: 'Winter' },
+  TimeManager: {
+    MS_PER_GAME_DAY: 7_200_000,
+    getCurrentTime: () => ({
+      year: 0,
+      season: 'Spring',
+      day: 1,
+      totalDays: 1,
+      hour: 12,
+      timeOfDay: 'Day',
+      totalHours: 36,
+    }),
+  },
+}));
+
+// vi.mock factories are hoisted above top-level consts. inventoryManager is
+// imported eagerly down the farmManager chain, so its spies must be hoisted too.
+const { addItem, removeItem } = vi.hoisted(() => ({
+  addItem: vi.fn(),
+  removeItem: vi.fn(),
+}));
+
+vi.mock('../utils/inventoryManager', () => ({
+  inventoryManager: {
+    addItem,
+    removeItem,
+    hasItem: vi.fn(() => true),
+    getInventoryData: vi.fn(() => ({ items: {}, tools: {} })),
+  },
+}));
+
+const { claimPlot } = vi.hoisted(() => ({ claimPlot: vi.fn() }));
+
+vi.mock('../firebase/safe', () => ({
+  getCommunityGardenService: () => ({
+    claimPlot,
+    writePlot: vi.fn(async () => true),
+    clearPlot: vi.fn(async () => true),
+    startListening: vi.fn(),
+    stopListening: vi.fn(),
+    onPlotsChanged: vi.fn(() => () => {}),
+    docToFarmPlot: vi.fn(),
+  }),
+}));
+
+import { farmManager } from '../utils/farmManager';
+import { eventBus, GameEvent } from '../utils/EventBus';
+import { FarmPlotState, type FarmPlot } from '../types';
+
+/** A ripe crop on the shared village farm, ready to be picked. */
+function readyPlot(mapId = 'village'): FarmPlot {
+  return {
+    mapId,
+    position: { x: 3, y: 4 },
+    state: FarmPlotState.READY,
+    cropType: 'tomato',
+    plantedAtDay: 1,
+    plantedAtHour: 8,
+    lastWateredDay: 1,
+    lastWateredHour: 9,
+    stateChangedAtDay: 1,
+    stateChangedAtHour: 8,
+    plantedAtTimestamp: Date.now(),
+    lastWateredTimestamp: Date.now(),
+    stateChangedAtTimestamp: Date.now(),
+    quality: 'normal',
+    fertiliserApplied: false,
+  };
+}
+
+function seedPlot(plot: FarmPlot, key: string) {
+  (farmManager as unknown as { plots: Map<string, FarmPlot> }).plots = new Map([[key, plot]]);
+  (farmManager as unknown as { dirtySharedPlots: Set<string> }).dirtySharedPlots = new Set();
+  (farmManager as unknown as { recentlyFlushed: Map<string, number> }).recentlyFlushed = new Map();
+}
+
+function currentPlot(key: string): FarmPlot | undefined {
+  return (farmManager as unknown as { plots: Map<string, FarmPlot> }).plots.get(key);
+}
+
+/** Let the fire-and-forget claim promise settle. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('shared farm — contested harvest', () => {
+  const key = 'village:3:4';
+
+  beforeEach(() => {
+    claimPlot.mockReset();
+    addItem.mockReset();
+    removeItem.mockReset();
+    seedPlot(readyPlot(), key);
+  });
+
+  it('grants the crop immediately, before the claim has resolved', async () => {
+    // Never resolves — stands in for a slow network. The player must not wait.
+    claimPlot.mockReturnValue(new Promise(() => {}));
+
+    const result = farmManager.harvestCrop('village', { x: 3, y: 4 });
+
+    expect(result).not.toBeNull();
+    expect(addItem).toHaveBeenCalled();
+    expect(currentPlot(key)!.state).toBe(FarmPlotState.FALLOW);
+  });
+
+  it('keeps the harvest when the claim is won', async () => {
+    claimPlot.mockResolvedValue(true);
+
+    farmManager.harvestCrop('village', { x: 3, y: 4 });
+    await settle();
+
+    expect(removeItem).not.toHaveBeenCalled();
+    expect(currentPlot(key)!.state).toBe(FarmPlotState.FALLOW);
+  });
+
+  it('marks a won plot recently-flushed so the snapshot echo cannot resurrect it', async () => {
+    claimPlot.mockResolvedValue(true);
+
+    farmManager.harvestCrop('village', { x: 3, y: 4 });
+    await settle();
+
+    const recentlyFlushed = (farmManager as unknown as { recentlyFlushed: Map<string, number> })
+      .recentlyFlushed;
+    expect(recentlyFlushed.has(key)).toBe(true);
+  });
+
+  it('takes the crop back and restores the plot when another player won it', async () => {
+    claimPlot.mockResolvedValue(false);
+
+    farmManager.harvestCrop('village', { x: 3, y: 4 });
+    await settle();
+
+    // Crop and seeds both returned
+    expect(removeItem).toHaveBeenCalled();
+    const removedItems = removeItem.mock.calls.map((call) => call[0]);
+    expect(removedItems).toContain('crop_tomato');
+
+    // Plot is ripe again — the other player's harvest will arrive via onSnapshot
+    expect(currentPlot(key)!.state).toBe(FarmPlotState.READY);
+  });
+
+  it('announces a lost race so the vanishing item does not look like a bug', async () => {
+    claimPlot.mockResolvedValue(false);
+    const contested = vi.fn();
+    const unsubscribe = eventBus.on(GameEvent.FARM_HARVEST_CONTESTED, contested);
+
+    farmManager.harvestCrop('village', { x: 3, y: 4 });
+    await settle();
+
+    expect(contested).toHaveBeenCalledTimes(1);
+    expect(contested.mock.calls[0][0]).toMatchObject({
+      mapId: 'village',
+      position: { x: 3, y: 4 },
+    });
+    unsubscribe();
+  });
+
+  it('keeps the harvest when the claim throws — an unproven loss is not a loss', async () => {
+    claimPlot.mockRejectedValue(new Error('offline'));
+
+    farmManager.harvestCrop('village', { x: 3, y: 4 });
+    await settle();
+
+    expect(removeItem).not.toHaveBeenCalled();
+    expect(currentPlot(key)!.state).toBe(FarmPlotState.FALLOW);
+    // Falls back to the batch flush so the plot still converges.
+    expect(
+      (farmManager as unknown as { dirtySharedPlots: Set<string> }).dirtySharedPlots.has(key)
+    ).toBe(true);
+  });
+
+  it('does not run a claim on a private map', async () => {
+    // The personal garden is nobody else's business.
+    const privateKey = 'personal_garden:3:4';
+    seedPlot(readyPlot('personal_garden'), privateKey);
+
+    farmManager.harvestCrop('personal_garden', { x: 3, y: 4 });
+    await settle();
+
+    expect(claimPlot).not.toHaveBeenCalled();
+  });
+});

--- a/utils/EventBus.ts
+++ b/utils/EventBus.ts
@@ -30,6 +30,8 @@ export enum GameEvent {
   FARM_PLOT_CHANGED = 'farm:plot_changed',
   FARM_CROP_GREW = 'farm:crop_grew',
   FARM_CROP_HARVESTED = 'farm:crop_harvested',
+  /** Another player harvested this plot first; our optimistic grant was rolled back */
+  FARM_HARVEST_CONTESTED = 'farm:harvest_contested',
 
   // NPC events
   NPC_MOVED = 'npc:moved',
@@ -100,6 +102,11 @@ export enum GameEvent {
   // Fruit tree events
   FRUIT_TREE_CHANGED = 'fruitTree:changed',
 
+  // Multiplayer presence events (other players entering/leaving the map)
+  REMOTE_PLAYER_JOINED = 'multiplayer:player_joined',
+  REMOTE_PLAYER_LEFT = 'multiplayer:player_left',
+  REMOTE_PLAYER_EMOTED = 'multiplayer:player_emoted',
+
   // Yule celebration events
   YULE_CELEBRATION_STARTED = 'yule:celebration_started',
   YULE_CELEBRATION_ENDED = 'yule:celebration_ended',
@@ -127,6 +134,11 @@ export interface EventPayloads {
     mapId: string;
     cropId: string;
     position: Position;
+  };
+  [GameEvent.FARM_HARVEST_CONTESTED]: {
+    mapId: string;
+    position: Position;
+    cropDisplayName: string;
   };
   [GameEvent.NPC_MOVED]: {
     npcId: string;
@@ -256,6 +268,19 @@ export interface EventPayloads {
     x: number;
     y: number;
     action: 'pruned' | 'mulched' | 'harvested';
+  };
+  [GameEvent.REMOTE_PLAYER_JOINED]: {
+    uid: string;
+    name: string;
+  };
+  [GameEvent.REMOTE_PLAYER_LEFT]: {
+    uid: string;
+    name: string;
+  };
+  [GameEvent.REMOTE_PLAYER_EMOTED]: {
+    uid: string;
+    name: string;
+    emote: string;
   };
   [GameEvent.YULE_CELEBRATION_STARTED]: {
     year: number;

--- a/utils/fairyAttractionManager.ts
+++ b/utils/fairyAttractionManager.ts
@@ -15,6 +15,7 @@ import { farmManager } from './farmManager';
 import { NPC, FarmPlotState } from '../types';
 import { Position } from '../types';
 import { createMorganNPC, createStellaNPC } from './npcs/forestNPCs';
+import { createSeededRandom, hashString } from './seededRandom';
 
 // Night time hours (22:00 to 06:00)
 const NIGHT_START_HOUR = 22;
@@ -119,8 +120,15 @@ class FairyAttractionManager {
     // Spawn fairies (up to max)
     const fairiesNeeded = maxFairies - existingFairyCount;
 
-    // Shuffle bluebells to randomize which ones get fairies
-    const shuffledBluebells = [...matureBluebells].sort(() => Math.random() - 0.5);
+    // Shuffle bluebells to pick which ones get fairies. Seeded on the game day
+    // and map so every player finds the same fairy on the same bluebell tonight
+    // — fairies are a thing you tell each other about, so they must agree.
+    const { totalDays } = TimeManager.getCurrentTime();
+    const nightRandom = createSeededRandom(hashString(`fairies:${mapId}:${totalDays}`));
+    const shuffledBluebells = [...matureBluebells]
+      .map((bluebell) => ({ bluebell, order: nightRandom() }))
+      .sort((a, b) => a.order - b.order)
+      .map((entry) => entry.bluebell);
 
     // Track which fairies we've already spawned
     const spawnedFairyTypes = currentNPCs
@@ -144,8 +152,8 @@ class FairyAttractionManager {
         // Stella already spawned, spawn Morgan
         fairyType = 'morgan';
       } else {
-        // Neither spawned yet, 50/50 chance
-        fairyType = Math.random() < 0.5 ? 'morgan' : 'stella';
+        // Neither spawned yet — 50/50, but the same 50/50 on every client.
+        fairyType = nightRandom() < 0.5 ? 'morgan' : 'stella';
       }
 
       // Create the fairy NPC

--- a/utils/farmManager.ts
+++ b/utils/farmManager.ts
@@ -667,7 +667,19 @@ class FarmManager {
       cropId: plot.cropType,
       position: plot.position,
     });
-    this.syncSharedPlot(mapId, position);
+
+    // On the shared farm, settle the race with the other players who might have
+    // clicked this same ripe crop. The grant above is deliberately optimistic —
+    // blocking on a round-trip would put a visible stall on every harvest in a
+    // game whose whole appeal is unhurried — so the cost falls entirely on the
+    // rare collision, which is rolled back below.
+    this.claimSharedHarvest(mapId, position, plot, updatedPlot, {
+      cropItemId,
+      cropYield: crop.harvestYield,
+      seedItemId: seedsDropped > 0 ? getSeedItemId(plot.cropType) : null,
+      seedsDropped,
+      cropDisplayName: crop.displayName,
+    });
 
     return {
       cropId: plot.cropType,
@@ -675,6 +687,71 @@ class FarmManager {
       seedsDropped,
       quality,
     };
+  }
+
+  /**
+   * Settle a contested harvest on the shared farm.
+   *
+   * Fire-and-forget: the caller has already granted the crop and moved on. If
+   * the claim transaction proves another player got there first, this puts
+   * everything back — items removed, plot restored — and emits
+   * FARM_HARVEST_CONTESTED so the UI can say so.
+   */
+  private claimSharedHarvest(
+    mapId: string,
+    position: Position,
+    plotBefore: FarmPlot,
+    plotAfter: FarmPlot,
+    granted: {
+      cropItemId: string;
+      cropYield: number;
+      seedItemId: string | null;
+      seedsDropped: number;
+      cropDisplayName: string;
+    }
+  ): void {
+    if (!SHARED_FARM_MAP_IDS.has(mapId)) return;
+
+    const plotId = this.getPlotKey(mapId, position);
+
+    void (async () => {
+      try {
+        const { getCommunityGardenService } = await import('../firebase/safe');
+        const won = await getCommunityGardenService().claimPlot(
+          plotId,
+          plotBefore.state,
+          plotAfter
+        );
+
+        if (won) {
+          // Our write went out inside the transaction; mark it flushed so the
+          // snapshot echo does not overwrite the plot we just harvested.
+          this.recentlyFlushed.set(plotId, Date.now());
+          return;
+        }
+
+        // Lost the race — take the crop back and restore the plot.
+        inventoryManager.removeItem(granted.cropItemId, granted.cropYield);
+        if (granted.seedItemId && granted.seedsDropped > 0) {
+          inventoryManager.removeItem(granted.seedItemId, granted.seedsDropped);
+        }
+        this.registerPlot({ ...plotBefore });
+        this.dirtySharedPlots.delete(plotId);
+
+        console.log(`[SharedFarm] Lost the race for ${plotId} — harvest rolled back`);
+        eventBus.emit(GameEvent.FARM_PLOT_CHANGED, { position, action: 'harvest' });
+        eventBus.emit(GameEvent.FARM_HARVEST_CONTESTED, {
+          mapId,
+          position,
+          cropDisplayName: granted.cropDisplayName,
+        });
+      } catch (error) {
+        // A failure here means we could not prove a loss, so the player keeps
+        // the crop. Falling back to the batch flush keeps the plot converging.
+        console.warn(`[SharedFarm] Claim failed for ${plotId} — keeping harvest:`, error);
+        this.syncSharedPlot(mapId, position);
+      }
+    })();
   }
 
   /**

--- a/utils/pixi/RemotePlayerLayer.ts
+++ b/utils/pixi/RemotePlayerLayer.ts
@@ -1,0 +1,279 @@
+/**
+ * RemotePlayerLayer - PixiJS rendering for other players.
+ *
+ * Structurally a sibling of NPCLayer: remote players are, for rendering
+ * purposes, NPCs we do not control. Sprites go into the shared depth-sorted
+ * container so a remote player passes correctly behind and in front of trees,
+ * buildings and the local player, and the camera comes for free with it.
+ *
+ * Each player gets three display objects — sprite, name tag, and an emote
+ * bubble that is only made visible while an emote is running.
+ *
+ * Usage:
+ *   const layer = new RemotePlayerLayer();
+ *   layer.setDepthContainer(depthSortedContainer);
+ *   app.stage.addChild(layer.getContainer());
+ *   layer.renderRemotePlayers(players, characterScale, gridOffset, tileSize);
+ */
+
+import * as PIXI from 'pixi.js';
+import { TILE_SIZE, PLAYER_SIZE } from '../../constants';
+import type { Position } from '../../types';
+import { textureManager } from '../TextureManager';
+import { PixiLayer } from './PixiLayer';
+import { Z_DEPTH_SORTED_BASE } from '../../zIndex';
+import { getRemoteSpriteInfo } from '../../multiplayer/remoteSprites';
+import { getEmoteIcon } from '../../multiplayer/emotes';
+import type { RemotePlayer } from '../../multiplayer/types';
+
+/** Same feet offset PlayerSprite uses, so remote and local players sort alike. */
+const PLAYER_FEET_OFFSET = 0.8;
+
+/** Name tag sits this far above the player's centre, in tiles. */
+const NAME_TAG_OFFSET_TILES = 0.85;
+
+/** Emote bubble sits above the name tag. */
+const EMOTE_OFFSET_TILES = 1.35;
+
+interface RemotePlayerDisplay {
+  sprite: PIXI.Sprite;
+  nameTag: PIXI.Text;
+  emote: PIXI.Text;
+  currentSpriteUrl: string | null;
+  currentName: string | null;
+}
+
+export class RemotePlayerLayer extends PixiLayer {
+  private displays = new Map<string, RemotePlayerDisplay>();
+  private depthContainer: PIXI.Container | null = null;
+  /** Bubble for the local player's own emote — immediate feedback on pressing one */
+  private localEmoteText: PIXI.Text | null = null;
+
+  constructor() {
+    super(Z_DEPTH_SORTED_BASE, true);
+  }
+
+  /**
+   * Use the shared depth-sorted container so remote players interleave with
+   * sprites, NPCs and the local player rather than sitting in a flat layer.
+   */
+  setDepthContainer(container: PIXI.Container): void {
+    this.depthContainer = container;
+    for (const display of this.displays.values()) {
+      for (const object of [display.sprite, display.nameTag, display.emote]) {
+        if (object.parent === this.container) {
+          this.container.removeChild(object);
+          container.addChild(object);
+        }
+      }
+    }
+    if (this.localEmoteText && this.localEmoteText.parent === this.container) {
+      this.container.removeChild(this.localEmoteText);
+      container.addChild(this.localEmoteText);
+    }
+  }
+
+  private getTargetContainer(): PIXI.Container {
+    return this.depthContainer ?? this.container;
+  }
+
+  private createDisplay(): RemotePlayerDisplay {
+    const target = this.getTargetContainer();
+
+    const sprite = new PIXI.Sprite();
+    sprite.anchor.set(0.5, 0.5);
+    sprite.visible = false;
+    target.addChild(sprite);
+
+    const nameTag = new PIXI.Text({
+      text: '',
+      style: {
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+        fontSize: 15,
+        fontWeight: '600',
+        fill: 0xffffff,
+        stroke: { color: 0x2b2b3a, width: 4, join: 'round' },
+        align: 'center',
+      },
+    });
+    nameTag.anchor.set(0.5, 1);
+    nameTag.visible = false;
+    // Names are UI, not world art: keep them a constant on-screen size rather
+    // than letting them scale with the map's characterScale.
+    nameTag.resolution = 2;
+    target.addChild(nameTag);
+
+    const emote = new PIXI.Text({
+      text: '',
+      style: { fontFamily: 'system-ui, sans-serif', fontSize: 28, align: 'center' },
+    });
+    emote.anchor.set(0.5, 1);
+    emote.visible = false;
+    emote.resolution = 2;
+    target.addChild(emote);
+
+    return { sprite, nameTag, emote, currentSpriteUrl: null, currentName: null };
+  }
+
+  /**
+   * Render every remote player. Called once per frame from the game loop, not
+   * from a React effect — remote positions must never cost a re-render.
+   */
+  async renderRemotePlayers(
+    players: RemotePlayer[],
+    characterScale: number = 1.0,
+    gridOffset?: Position,
+    tileSize: number = TILE_SIZE
+  ): Promise<void> {
+    const offsetX = gridOffset?.x ?? 0;
+    const offsetY = gridOffset?.y ?? 0;
+    const rendered = new Set<string>();
+
+    for (const player of players) {
+      rendered.add(player.uid);
+
+      let display = this.displays.get(player.uid);
+      if (!display) {
+        display = this.createDisplay();
+        this.displays.set(player.uid, display);
+      }
+
+      const { url, spriteScale, shouldFlip } = getRemoteSpriteInfo(player);
+
+      if (display.currentSpriteUrl !== url) {
+        try {
+          const texture = await textureManager.loadTexture(url, url);
+          if (texture) {
+            display.sprite.texture = texture;
+            display.currentSpriteUrl = url;
+          }
+        } catch (error) {
+          console.warn(`[RemotePlayerLayer] Failed to load texture: ${url}`, error);
+          continue;
+        }
+      }
+
+      const x = player.position.x * tileSize + offsetX;
+      const y = player.position.y * tileSize + offsetY;
+      const size = PLAYER_SIZE * spriteScale * characterScale * tileSize;
+
+      display.sprite.x = x;
+      display.sprite.y = y;
+
+      // Scale rather than width/height, so the horizontal flip survives.
+      if (display.sprite.texture && display.sprite.texture.width > 0) {
+        const scaleX = size / display.sprite.texture.width;
+        const scaleY = size / display.sprite.texture.height;
+        display.sprite.scale.x = shouldFlip ? -scaleX : scaleX;
+        display.sprite.scale.y = scaleY;
+      } else {
+        display.sprite.width = size;
+        display.sprite.height = size;
+      }
+
+      const feetY = player.position.y + PLAYER_FEET_OFFSET;
+      const zIndex = Z_DEPTH_SORTED_BASE + Math.floor(feetY * 10);
+      display.sprite.zIndex = zIndex;
+      display.sprite.visible = true;
+
+      if (display.currentName !== player.name) {
+        display.nameTag.text = player.name;
+        display.currentName = player.name;
+      }
+      display.nameTag.x = x;
+      display.nameTag.y = y - NAME_TAG_OFFSET_TILES * tileSize * characterScale;
+      // +1 keeps the tag above its own sprite without leapfrogging the player
+      // standing one tile in front.
+      display.nameTag.zIndex = zIndex + 1;
+      display.nameTag.visible = true;
+
+      const icon = player.emote ? getEmoteIcon(player.emote) : null;
+      if (icon) {
+        display.emote.text = icon;
+        display.emote.x = x;
+        display.emote.y = y - EMOTE_OFFSET_TILES * tileSize * characterScale;
+        display.emote.zIndex = zIndex + 2;
+        display.emote.visible = true;
+      } else {
+        display.emote.visible = false;
+      }
+    }
+
+    // Players who left this frame: hide rather than destroy, since they may
+    // well be back (a brief disconnect, or walking in and out of view).
+    for (const [uid, display] of this.displays) {
+      if (rendered.has(uid)) continue;
+      display.sprite.visible = false;
+      display.nameTag.visible = false;
+      display.emote.visible = false;
+    }
+  }
+
+  /**
+   * Draw the local player's own emote bubble. Uses the same positioning as a
+   * remote player's, so your wave looks exactly like everyone else's.
+   */
+  renderLocalEmote(
+    emote: string | null,
+    position: Position,
+    characterScale: number = 1.0,
+    gridOffset?: Position,
+    tileSize: number = TILE_SIZE
+  ): void {
+    const icon = emote ? getEmoteIcon(emote) : null;
+
+    if (!icon) {
+      if (this.localEmoteText) this.localEmoteText.visible = false;
+      return;
+    }
+
+    if (!this.localEmoteText) {
+      this.localEmoteText = new PIXI.Text({
+        text: '',
+        style: { fontFamily: 'system-ui, sans-serif', fontSize: 28, align: 'center' },
+      });
+      this.localEmoteText.anchor.set(0.5, 1);
+      this.localEmoteText.resolution = 2;
+      this.getTargetContainer().addChild(this.localEmoteText);
+    }
+
+    const x = position.x * tileSize + (gridOffset?.x ?? 0);
+    const y = position.y * tileSize + (gridOffset?.y ?? 0);
+
+    this.localEmoteText.text = icon;
+    this.localEmoteText.x = x;
+    this.localEmoteText.y = y - EMOTE_OFFSET_TILES * tileSize * characterScale;
+    this.localEmoteText.zIndex = Z_DEPTH_SORTED_BASE + Math.floor((position.y + PLAYER_FEET_OFFSET) * 10) + 2;
+    this.localEmoteText.visible = true;
+  }
+
+  /** Drop the display objects for players we no longer track. */
+  prune(activeUids: Set<string>): void {
+    for (const [uid, display] of this.displays) {
+      if (activeUids.has(uid)) continue;
+      this.destroyDisplay(display);
+      this.displays.delete(uid);
+    }
+  }
+
+  private destroyDisplay(display: RemotePlayerDisplay): void {
+    for (const object of [display.sprite, display.nameTag, display.emote]) {
+      if (object.parent) object.parent.removeChild(object);
+      object.destroy();
+    }
+  }
+
+  /** Clear all remote player sprites (required by PixiLayer). */
+  clear(): void {
+    for (const display of this.displays.values()) {
+      this.destroyDisplay(display);
+    }
+    this.displays.clear();
+
+    if (this.localEmoteText) {
+      if (this.localEmoteText.parent) this.localEmoteText.parent.removeChild(this.localEmoteText);
+      this.localEmoteText.destroy();
+      this.localEmoteText = null;
+    }
+  }
+}

--- a/utils/seededRandom.ts
+++ b/utils/seededRandom.ts
@@ -1,0 +1,67 @@
+/**
+ * Deterministic pseudo-random numbers.
+ *
+ * The game already relies on this idea in one place — WeatherManager derives
+ * each weather slot from a seed keyed to the slot index and season, which is
+ * why every player sees the same rain at the same moment without a byte of
+ * network traffic (guarded by tests/deterministicWeather.test.ts).
+ *
+ * This module generalises that trick so other systems can do the same: anything
+ * that is a pure function of the wall clock costs nothing to synchronise, and
+ * TimeManager already gives every client the same clock.
+ *
+ * mulberry32 is used rather than a hand-rolled `(seed * 41) % 100`: it is four
+ * lines, has no visible short-period artefacts, and gives well-distributed
+ * floats — which matters when the same seed drives several decisions in a row.
+ */
+
+/**
+ * FNV-1a — a small, fast, well-mixed string hash. Used to turn an entity id
+ * into a stable numeric seed that is identical on every client and every run.
+ */
+export function hashString(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    // The FNV prime, via shifts — Math.imul keeps this in 32-bit range.
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Create a seeded generator producing floats in [0, 1).
+ * The same seed always yields the same sequence.
+ */
+export function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return function next(): number {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Generator for one entity's decision at one point in time.
+ *
+ * Keying on (id, slot) rather than on accumulated local state is the whole
+ * point: two clients that have been running for different lengths of time still
+ * compute the same value for the same slot.
+ */
+export function createDecisionRandom(id: string, slot: number): () => number {
+  return createSeededRandom(hashString(id) ^ Math.imul(slot, 0x9e3779b1));
+}
+
+/**
+ * A stable per-entity phase offset within a slot, in [0, slotMs).
+ *
+ * Without this every wandering NPC would change direction on the same tick and
+ * the village would look choreographed. With it, decisions are staggered but
+ * still a pure function of the wall clock.
+ */
+export function slotPhaseOffset(id: string, slotMs: number): number {
+  return hashString(`${id}:phase`) % slotMs;
+}

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -12,6 +12,11 @@ interface ImportMetaEnv {
   readonly VITE_FIREBASE_STORAGE_BUCKET?: string;
   readonly VITE_FIREBASE_MESSAGING_SENDER_ID?: string;
   readonly VITE_FIREBASE_APP_ID?: string;
+  readonly VITE_FIREBASE_ENABLED?: string;
+
+  // Multiplayer (Realtime Database presence)
+  readonly VITE_FIREBASE_DATABASE_URL?: string;
+  readonly VITE_MULTIPLAYER_ENABLED?: string;
 
   // Firebase Emulators (development only)
   readonly VITE_USE_FIREBASE_EMULATORS?: string;

--- a/zIndex.ts
+++ b/zIndex.ts
@@ -170,6 +170,12 @@ export const Z_INVENTORY = 1000;
 /** Touch controls (mobile) */
 export const Z_TOUCH_CONTROLS = 1050;
 
+/** Multiplayer presence indicator ("2 friends here") — sits with the HUD */
+export const Z_PRESENCE_INDICATOR = 1000;
+
+/** Emote picker — above the touch controls it is opened from */
+export const Z_EMOTE_WHEEL = 1060;
+
 // =============================================================================
 // DEBUG PANELS (1100-1199)
 // =============================================================================


### PR DESCRIPTION
Players can now inhabit the same maps at once — see each other walk around Clover Village, with name tags and emotes.

Design and implementation notes: [`design_docs/planned/MULTIPLAYER.md`](design_docs/planned/MULTIPLAYER.md).

## Why this was smaller than it sounds

The game was already most of the way there. `TimeManager` derives the date from the wall clock and weather is a seeded PRNG, so every client already agreed on time, season and rain with zero network traffic. The community garden already proved the shared-state pattern (optimistic write → dirty set → batched flush → `onSnapshot`). What was missing was a presence transport, a manager for other players, and a render layer.

## Transport: Realtime Database, not Firestore

Firestore bills per document write, and a player publishing position at 5 Hz for a two-hour session is ~36,000 writes — more than the entire daily free tier, for data with a 200 ms shelf life. RTDB bills bandwidth and has `onDisconnect()`, without which every crashed tab leaves a ghost standing in the village forever. Durable shared state (community garden, world events, cloud saves) stays on Firestore.

Rooms are map IDs, so bandwidth scales with *co-located* players rather than total players. Private maps — home, personal garden, all `RANDOM_*` forests — are excluded.

## Safety

Communication is an emote wheel: eight fixed gestures, **no free text**. This game is played by children, so the vocabulary is closed by design and enforced server-side in `database.rules.json` — including `"$other": { ".validate": false }`, without which presence would become an unmoderated free-text channel by the back door.

The emote list is deliberately duplicated in `multiplayer/emotes.ts` and the security rules. `tests/emoteVocabulary.test.ts` fails if the two ever drift — that is the load-bearing test in this PR.

## Two pre-existing bugs fixed along the way

**Double-harvest on the shared farm.** The 10 s last-write-wins flush meant two players could both pick the same ripe crop. Now settled by a Firestore claim transaction, optimistic with silent rollback — blocking on a round-trip would put a visible stall on every harvest in a game whose whole appeal is unhurried. Deliberately asymmetric: a *proven* loss rolls back, a network failure keeps the crop.

**Procedural maps regenerating on every entry.** Forests used `Date.now()` as their seed, so stepping out and back in built a whole new forest. They now use a shared daily seed.

## Determinism

NPC wander and fairy spawns use a seeded PRNG keyed on `(id, time slot)` instead of `Math.random()`, so clients make the same decisions at the same instants.

Worth reading honestly: this converges *decisions*, not *positions*. Clients that started watching an NPC at different times can still drift. Full convergence needs the wander as a closed-form function of time, which would rewrite every wandering NPC's behaviour — a large, risky change for a cosmetic benefit. The caveat is documented in the design doc rather than glossed over.

## Performance note

Remote positions never touch React state — they change every frame. `usePixiRenderer`'s per-frame `updateAnimations()` polls `remotePlayerManager` directly, the way it already reads `npcManager`, and the EventBus trigger fires only on join/leave.

## Risk

**This is inert on merge.** `firebase/realtimeConfig.ts` no-ops without `VITE_FIREBASE_DATABASE_URL`, which is not set as a repo secret, so the deployed game is byte-for-byte the single-player game. Verified by running the same headless-Chrome script against a pristine worktree of `main`: pixel-identical, same two pre-existing `src=""` warnings.

Three changes *do* go live immediately and are worth a look: the seeded NPC wander, the daily forest seed, and the harvest claim transaction.

## To actually switch multiplayer on (needs Firebase Console access)

1. Create a Realtime Database instance in the `twiightgame` project (pick a region — `europe-west1` matches the UK players).
2. Add repo secret `VITE_FIREBASE_DATABASE_URL` with the instance URL.
3. Re-run the Firebase workflow — it now deploys `database.rules.json`, and **skips with a log line** rather than failing if no RTDB instance exists yet.

## Testing

`make verify`: 64 files, **662 tests** (46 new). `npm run lint`: 0 errors. Production build succeeds.

New tests and what each guards are documented in [`tests/README.md`](tests/README.md).

**Not verified:** two real browsers, two accounts, seeing each other move. That needs the RTDB instance above. Everything up to the network boundary is tested. Note PixiJS does not finish initialising under headless SwiftShader (the world renders black), so the multiplayer UI is covered by jsdom component tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJbjF9UMYAwJZzmE9bckuJ
