### PR TITLE
Fix RTDB rules deploy guard skipping on output instead of exit status

### DIFF
--- a/.github/workflows/firebase.yml
+++ b/.github/workflows/firebase.yml
@@ -59,7 +59,12 @@ jobs:
           echo "$GOOGLE_APPLICATION_CREDENTIALS_JSON" > /tmp/sa.json
           export GOOGLE_APPLICATION_CREDENTIALS=/tmp/sa.json
 
-          if firebase database:instances:list --project twiightgame 2>/dev/null | grep -qE '[a-z0-9]'; then
+          # Key the skip on the CLI's exit status, not on its output. When no
+          # instance exists, `database:instances:list` prints its error to STDOUT
+          # and exits non-zero — so grepping the output for text matches the error
+          # message itself and takes the deploy branch, which is how this step
+          # failed the first time it ran.
+          if firebase database:instances:list --project twiightgame >/dev/null 2>&1; then
             firebase deploy --only database --project twiightgame
             echo "RTDB_DEPLOYED=true" >> $GITHUB_ENV
           else


### PR DESCRIPTION
The guard added in #54 was meant to skip the Realtime Database rules deploy when the project has no RTDB instance, so an optional, currently switched-off feature could not turn `main` red. It did the exact opposite — [the run it was written to prevent](https://github.com/MarkEdmondson1234/TwilightGame/actions/runs/33472566781).

`firebase database:instances:list` prints its "you haven't created a Realtime Database instance" error to **stdout** (not stderr) and exits non-zero. The guard grepped that output for `[a-z0-9]`, which matched the error message itself, so it took the deploy branch and failed.

Keyed on the command's exit status instead.

Nothing else in that workflow was affected: Firestore rules deployed successfully in the same run, and the GitHub Pages deploy of #54 succeeded independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJbjF9UMYAwJZzmE9bckuJ
