### PR TITLE
Fix every shared-farm harvest reading as a lost race

### DIFF
--- a/firebase/communityGardenService.ts
+++ b/firebase/communityGardenService.ts
@@ -54,6 +54,28 @@ export interface SharedPlotDoc {
   updatedAt: ReturnType<typeof serverTimestamp> | Timestamp;
 }
 
+/**
+ * Identity of the planting a harvest claim is settling, as the claiming client
+ * saw it. Compared against the stored document to tell "somebody picked this
+ * first" apart from "this crop simply ripened since its last sync".
+ */
+export interface HarvestClaim {
+  /** The crop standing on the plot when we picked it. */
+  cropType: string | null;
+  /** When that crop was sown — the identity of this particular planting. */
+  plantedAtTimestamp: number | null;
+  /** Whether the plot was present in the most recent remote snapshot. */
+  knownRemote: boolean;
+}
+
+/** States a plot can only be in once this planting has already been harvested. */
+const POST_HARVEST_STATES: ReadonlySet<number> = new Set([
+  FarmPlotState.FALLOW,
+  FarmPlotState.TILLED,
+  FarmPlotState.HERB_COOLDOWN,
+  FarmPlotState.HERB_DORMANT,
+]);
+
 // ============================================
 // SharedFarmService Class
 // ============================================
@@ -198,12 +220,19 @@ class SharedFarmService {
    * get a carrot. This is the one genuinely contended action in the game, and a
    * transaction is the only way to settle it.
    *
+   * What is compared is the *planting*, not the plot's stored state. Ripening is
+   * derived locally from `plantedAtTimestamp` on every client and is deliberately
+   * never flushed, so the stored state of a crop that matured after its last sync
+   * still reads WATERED while every player sees it standing ripe. Comparing raw
+   * states therefore called every ordinary harvest a lost race — including in
+   * single player, where there is nobody to lose to.
+   *
    * Returns true if we won the plot (or if there is nothing to lose it to).
    * Returns false ONLY when we can prove somebody else got there first — a
    * network failure counts as a win, because confiscating a crop the player
    * legitimately harvested is a far worse outcome than one duplicate carrot.
    */
-  async claimPlot(plotId: string, expectedState: number, resultPlot: FarmPlot): Promise<boolean> {
+  async claimPlot(plotId: string, expected: HarvestClaim, resultPlot: FarmPlot): Promise<boolean> {
     if (!isFirebaseInitialized() || !authService.isAuthenticated()) {
       return true; // Local-only play: nobody to race against.
     }
@@ -217,15 +246,29 @@ class SharedFarmService {
       return await runTransaction(db, async (transaction) => {
         const snapshot = await transaction.get(plotRef);
 
-        // Never synced (or already tidied away): we cannot prove a loss, so the
-        // player keeps what they picked.
-        if (!snapshot.exists()) return true;
+        if (!snapshot.exists()) {
+          // Harvesting an annual crop deletes the document, so a plot that was
+          // there in the last snapshot and is gone now was picked by somebody
+          // else. A plot we never saw remotely proves nothing — keep the crop.
+          return !expected.knownRemote;
+        }
 
         const remote = snapshot.data() as SharedPlotDoc;
-        if (remote.state !== expectedState) {
-          // Somebody moved this plot on before us — that is a real, provable loss.
+
+        // A different crop, or the same crop from a later sowing, means this
+        // planting was already harvested (and the plot replanted) before us.
+        if (remote.cropType !== expected.cropType) return false;
+        if (
+          expected.plantedAtTimestamp != null &&
+          remote.plantedAtTimestamp != null &&
+          remote.plantedAtTimestamp !== expected.plantedAtTimestamp
+        ) {
           return false;
         }
+
+        // Same planting, but already picked — herbs stay in place and drop into
+        // cooldown rather than clearing the document.
+        if (POST_HARVEST_STATES.has(remote.state)) return false;
 
         if (resultPlot.state === FarmPlotState.FALLOW) {
           // Matches the flush path, which deletes rather than storing fallow plots.

--- a/tests/firebase/sharedFarmClaim.test.ts
+++ b/tests/firebase/sharedFarmClaim.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @vitest-environment node
+ *
+ * What counts as losing a race for a ripe crop.
+ *
+ * Ripening is derived on every client from `plantedAtTimestamp` and is
+ * deliberately never flushed, so the stored document for a crop that matured
+ * since its last sync still reads WATERED while every player sees it standing
+ * ripe. An earlier version compared the stored state against the harvested
+ * state and so declared a lost race on *every* ordinary harvest — including in
+ * single player, where there is nobody to lose to. The claim settles the
+ * planting instead: same crop, same sowing, not already picked.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FarmPlotState, type FarmPlot } from '../../types';
+
+const { runTransaction, transactionSet, transactionDelete } = vi.hoisted(() => ({
+  runTransaction: vi.fn(),
+  transactionSet: vi.fn(),
+  transactionDelete: vi.fn(),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn(() => ({})),
+  setDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  collection: vi.fn(),
+  onSnapshot: vi.fn(),
+  runTransaction,
+  serverTimestamp: vi.fn(() => ({ _serverTimestamp: true })),
+  Timestamp: class {},
+}));
+
+vi.mock('../../firebase/config', () => ({
+  getFirebaseDb: vi.fn(() => ({})),
+  isFirebaseInitialized: vi.fn(() => true),
+}));
+
+vi.mock('../../firebase/authService', () => ({
+  authService: {
+    isAuthenticated: () => true,
+    getUser: () => ({ displayName: 'Someone Else', email: null }),
+    getUserId: () => 'uid-1',
+  },
+}));
+
+import { communityGardenService } from '../../firebase/communityGardenService';
+
+const PLANTED_AT = 1_700_000_000_000;
+
+/** Run the claim against a given stored document (or `null` for no document). */
+async function claimAgainst(
+  remote: Record<string, unknown> | null,
+  expected: { cropType: string | null; plantedAtTimestamp: number | null; knownRemote: boolean },
+  result: FarmPlot = harvestedPlot()
+): Promise<boolean> {
+  runTransaction.mockImplementation(async (_db: unknown, fn: (t: unknown) => Promise<boolean>) =>
+    fn({
+      get: async () => ({ exists: () => remote !== null, data: () => remote }),
+      set: transactionSet,
+      delete: transactionDelete,
+    })
+  );
+  return communityGardenService.claimPlot('village:3:4', expected, result);
+}
+
+/** The stored document for a salad that was watered and has since ripened. */
+function wateredDoc() {
+  return {
+    mapId: 'village',
+    x: 3,
+    y: 4,
+    state: FarmPlotState.WATERED,
+    cropType: 'salad',
+    plantedAtTimestamp: PLANTED_AT,
+    lastWateredTimestamp: PLANTED_AT + 1000,
+    stateChangedAtTimestamp: PLANTED_AT + 1000,
+    quality: 'normal',
+    fertiliserApplied: false,
+  };
+}
+
+/** What an annual crop's plot looks like after we picked it. */
+function harvestedPlot(): FarmPlot {
+  return {
+    mapId: 'village',
+    position: { x: 3, y: 4 },
+    state: FarmPlotState.FALLOW,
+    cropType: null,
+    plantedAtDay: null,
+    plantedAtHour: null,
+    lastWateredDay: null,
+    lastWateredHour: null,
+    stateChangedAtDay: 1,
+    stateChangedAtHour: 12,
+    plantedAtTimestamp: null,
+    lastWateredTimestamp: null,
+    stateChangedAtTimestamp: Date.now(),
+    quality: 'normal',
+    fertiliserApplied: false,
+  };
+}
+
+const ours = { cropType: 'salad', plantedAtTimestamp: PLANTED_AT, knownRemote: true };
+
+describe('shared farm — settling a harvest claim', () => {
+  beforeEach(() => {
+    runTransaction.mockReset();
+    transactionSet.mockReset();
+    transactionDelete.mockReset();
+  });
+
+  it('wins when the crop merely ripened since its last sync', async () => {
+    // The regression: stored state WATERED, harvested state FALLOW, same planting.
+    expect(await claimAgainst(wateredDoc(), ours)).toBe(true);
+    expect(transactionDelete).toHaveBeenCalled();
+  });
+
+  it('wins when the stored state already says READY', async () => {
+    expect(await claimAgainst({ ...wateredDoc(), state: FarmPlotState.READY }, ours)).toBe(true);
+  });
+
+  it('wins on a crop that ripened while wilting', async () => {
+    expect(await claimAgainst({ ...wateredDoc(), state: FarmPlotState.WILTING }, ours)).toBe(true);
+  });
+
+  it('loses when the same plant has already been picked into cooldown', async () => {
+    // Herbs stay in place after a harvest, so the document keeps the planting.
+    expect(await claimAgainst({ ...wateredDoc(), state: FarmPlotState.HERB_COOLDOWN }, ours)).toBe(
+      false
+    );
+  });
+
+  it('loses when the plot now holds a different crop', async () => {
+    expect(await claimAgainst({ ...wateredDoc(), cropType: 'carrot' }, ours)).toBe(false);
+  });
+
+  it('loses when the plot holds a later sowing of the same crop', async () => {
+    expect(
+      await claimAgainst({ ...wateredDoc(), plantedAtTimestamp: PLANTED_AT + 60_000 }, ours)
+    ).toBe(false);
+  });
+
+  it('loses when a plot we were watching has been deleted', async () => {
+    // Harvesting an annual deletes the document — somebody got there first.
+    expect(await claimAgainst(null, ours)).toBe(false);
+  });
+
+  it('wins when the plot was never synced, so a loss cannot be proven', async () => {
+    expect(await claimAgainst(null, { ...ours, knownRemote: false })).toBe(true);
+  });
+
+  it('wins when the transaction fails — an unproven loss is not a loss', async () => {
+    runTransaction.mockRejectedValue(new Error('offline'));
+    expect(await communityGardenService.claimPlot('village:3:4', ours, harvestedPlot())).toBe(true);
+  });
+
+  it('writes the harvested plot back when it is not cleared to fallow', async () => {
+    const herbCooldown: FarmPlot = {
+      ...harvestedPlot(),
+      state: FarmPlotState.HERB_COOLDOWN,
+      cropType: 'mint',
+      plantedAtTimestamp: PLANTED_AT,
+    };
+    const stored = { ...wateredDoc(), cropType: 'mint', state: FarmPlotState.READY };
+
+    expect(await claimAgainst(stored, { ...ours, cropType: 'mint' }, herbCooldown)).toBe(true);
+    expect(transactionSet).toHaveBeenCalled();
+    expect(transactionDelete).not.toHaveBeenCalled();
+  });
+});

--- a/tests/sharedFarmHarvestClaim.test.ts
+++ b/tests/sharedFarmHarvestClaim.test.ts
@@ -56,7 +56,10 @@ vi.mock('../utils/inventoryManager', () => ({
   },
 }));
 
-const { claimPlot } = vi.hoisted(() => ({ claimPlot: vi.fn() }));
+const { claimPlot, remotePlots } = vi.hoisted(() => ({
+  claimPlot: vi.fn(),
+  remotePlots: new Map<string, unknown>(),
+}));
 
 vi.mock('../firebase/safe', () => ({
   getCommunityGardenService: () => ({
@@ -67,6 +70,7 @@ vi.mock('../firebase/safe', () => ({
     stopListening: vi.fn(),
     onPlotsChanged: vi.fn(() => () => {}),
     docToFarmPlot: vi.fn(),
+    getRemotePlots: () => remotePlots,
   }),
 }));
 
@@ -115,6 +119,7 @@ describe('shared farm — contested harvest', () => {
     claimPlot.mockReset();
     addItem.mockReset();
     removeItem.mockReset();
+    remotePlots.clear();
     seedPlot(readyPlot(), key);
   });
 
@@ -193,6 +198,38 @@ describe('shared farm — contested harvest', () => {
     expect(
       (farmManager as unknown as { dirtySharedPlots: Set<string> }).dirtySharedPlots.has(key)
     ).toBe(true);
+  });
+
+  it("settles the claim on the planting, not on the plot's stored state", async () => {
+    // Ripening is derived locally and never flushed, so the stored state of a
+    // crop that matured since its last sync still reads WATERED. Sending READY
+    // as the thing to match made every ordinary harvest look like a lost race.
+    claimPlot.mockResolvedValue(true);
+    const plot = currentPlot(key)!;
+    remotePlots.set(key, {});
+
+    farmManager.harvestCrop('village', { x: 3, y: 4 });
+    await settle();
+
+    expect(claimPlot).toHaveBeenCalledWith(
+      key,
+      {
+        cropType: 'tomato',
+        plantedAtTimestamp: plot.plantedAtTimestamp,
+        knownRemote: true,
+      },
+      expect.objectContaining({ state: FarmPlotState.FALLOW })
+    );
+  });
+
+  it('tells the claim when the plot was never in a remote snapshot', async () => {
+    // Nothing to lose it to — a missing document must not be read as a loss.
+    claimPlot.mockResolvedValue(true);
+
+    farmManager.harvestCrop('village', { x: 3, y: 4 });
+    await settle();
+
+    expect(claimPlot.mock.calls[0][1]).toMatchObject({ knownRemote: false });
   });
 
   it('does not run a claim on a private map', async () => {

--- a/utils/farmManager.ts
+++ b/utils/farmManager.ts
@@ -717,9 +717,17 @@ class FarmManager {
     void (async () => {
       try {
         const { getCommunityGardenService } = await import('../firebase/safe');
-        const won = await getCommunityGardenService().claimPlot(
+        const service = getCommunityGardenService();
+        // The claim is settled on the planting, not on the stored state: a crop
+        // that ripened since its last flush still reads WATERED remotely, and
+        // comparing states made every such harvest look like a lost race.
+        const won = await service.claimPlot(
           plotId,
-          plotBefore.state,
+          {
+            cropType: plotBefore.cropType,
+            plantedAtTimestamp: plotBefore.plantedAtTimestamp,
+            knownRemote: service.getRemotePlots().has(plotId),
+          },
           plotAfter
         );
 


### PR DESCRIPTION
Reported in play: planting salad on the village farm, waiting for it to ripen, then picking it produced *"Someone else picked those Salad Greens first!"* and rolled the harvest back — with nobody else playing.

## Cause

Ripening is derived on each client from `plantedAtTimestamp` and is deliberately never flushed (that is how growth stays in sync without writes). So the stored document for a crop that matured since its last sync still reads `WATERED` while every player sees it standing ripe.

`claimPlot` settled the race by comparing that stored state against the state we harvested from (`READY`), so the mismatch was read as "somebody moved this plot on before us" — a provable loss. That fires on every ordinary harvest, single player included.

## Fix

The claim now settles the **planting**, not the stored state. A loss is only:

- a different crop, or a later sowing of the same crop (different `plantedAtTimestamp`);
- the same planting already in a post-harvest state (`HERB_COOLDOWN`/`HERB_DORMANT` — herbs stay put after picking);
- a document that is gone **and** was present in the last remote snapshot.

A stale `PLANTED`/`WATERED`/`WILTING` document is a win, which is the ordinary case.

That last rule also closes a hole the state check left open: harvesting an annual *deletes* the document, so the loser of a real race read "no document — cannot prove a loss" and kept the crop too, making the protection a no-op for exactly the crops it was written for. A plot never seen remotely still keeps the crop, so offline and unsynced play never confiscates anything.

## Tests

- `tests/firebase/sharedFarmClaim.test.ts` (new, 10 cases) — the comparison itself, including the exact regression and the deleted-document case.
- `tests/sharedFarmHarvestClaim.test.ts` — two cases asserting farmManager sends the planting identity and `knownRemote`.

`make verify` green: typecheck clean, 676 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeYFsjQCoBXRV1EXk5VHSG