### PR TITLE
Fix seedlings hidden by soil sprite; make Beast Tongue last a game day

### DIFF
--- a/components/HUD.tsx
+++ b/components/HUD.tsx
@@ -9,6 +9,7 @@ import { gameState } from '../GameState';
 import { WATER_CAN } from '../constants';
 import { resolveIcon, isImageIcon } from '../utils/iconMap';
 import AnalogClock from './AnalogClock';
+import PotionEffectIndicator from './PotionEffectIndicator';
 import SundialClock from './SundialClock';
 
 /**
@@ -159,6 +160,9 @@ const HUD: React.FC<HUDProps> = ({ selectedItemId, selectedItemQuantity }) => {
             </div>
           </div>
         )}
+
+        {/* Timed potion effects (Beast Tongue, Beastward, Revealing) */}
+        <PotionEffectIndicator />
 
         {/* Movement Effect Indicator (Floating/Flying) */}
         {movementEffect && movementTimeRemaining > 0 && (

--- a/components/PotionEffectIndicator.tsx
+++ b/components/PotionEffectIndicator.tsx
@@ -1,0 +1,105 @@
+/**
+ * PotionEffectIndicator — HUD badges for timed potion effects that are currently active.
+ *
+ * These effects (Beast Tongue, Beastward Balm, Revealing Tonic) change what the world does
+ * rather than how the player looks, so without a badge there is nothing on screen telling the
+ * player the potion is still working — or that it has quietly worn off. Beast Tongue in
+ * particular was easy to mistake for broken: you drink it, walk to the forest, and the animals
+ * are back to "*purr*" with no explanation.
+ *
+ * Data-driven: a new timed effect only needs an entry in POTION_EFFECT_DISPLAY. Effects with
+ * no entry are deliberately not shown, so internal flags never leak into the HUD. Movement
+ * effects (Floating/Flying) have their own badge in HUD.tsx — they are stored separately in
+ * GameState, not as potion effects.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { gameState } from '../GameState';
+
+interface PotionEffectDisplay {
+  /** Short name shown on the badge. */
+  label: string;
+  /** Emoji shown beside the label, matching the Floating/Flying badge style. */
+  icon: string;
+  /** Border/text colour (hex), used for the glow as well. */
+  colour: string;
+}
+
+/** Which potion effects earn a HUD badge, and how they present. */
+export const POTION_EFFECT_DISPLAY: Record<string, PotionEffectDisplay> = {
+  beast_tongue: { label: 'Beast Tongue', icon: '🐾', colour: '#a78bfa' },
+  beast_ward: { label: 'Beastward', icon: '🛡️', colour: '#facc15' },
+  reveal_gift_preference: { label: 'Revealing', icon: '🎁', colour: '#f472b6' },
+};
+
+/**
+ * Format a remaining duration for effects that can last a full game day (2 real hours).
+ * HUD's own formatTimeRemaining shows m:ss, which reads as "120:00" for a day-long potion.
+ */
+function formatDuration(ms: number): string {
+  const totalMinutes = Math.ceil(ms / 60000);
+  if (totalMinutes >= 60) {
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  if (totalMinutes >= 1) return `${totalMinutes}m`;
+  return `${Math.ceil(ms / 1000)}s`;
+}
+
+const PotionEffectIndicator: React.FC = () => {
+  const [effects, setEffects] = useState<Array<{ type: string; remainingMs: number }>>([]);
+
+  useEffect(() => {
+    const refresh = () => {
+      setEffects(
+        gameState
+          .getActivePotionEffects()
+          .filter((type) => POTION_EFFECT_DISPLAY[type])
+          .map((type) => ({ type, remainingMs: gameState.getPotionEffectRemainingMs(type) }))
+      );
+    };
+
+    refresh();
+    const interval = setInterval(refresh, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (effects.length === 0) return null;
+
+  return (
+    <>
+      {effects.map(({ type, remainingMs }) => {
+        const display = POTION_EFFECT_DISPLAY[type];
+        return (
+          <div
+            key={type}
+            className="bg-black/60 px-3 py-2 rounded-lg border self-center"
+            style={{
+              borderColor: display.colour,
+              boxShadow: `0 0 10px ${display.colour}80`,
+            }}
+          >
+            <div className="flex items-center gap-2">
+              <span className="text-lg">{display.icon}</span>
+              <div className="flex flex-col">
+                <span
+                  className="text-xs font-bold"
+                  style={{
+                    color: display.colour,
+                    textShadow: '1px 1px 2px rgba(0,0,0,0.8)',
+                  }}
+                >
+                  {display.label}
+                </span>
+                <span className="text-xs text-white">{formatDuration(remainingMs)}</span>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+};
+
+export default PotionEffectIndicator;

--- a/data/items/potions.ts
+++ b/data/items/potions.ts
@@ -189,7 +189,8 @@ export const POTION_ITEMS: Record<string, ItemDefinition> = {
     name: 'potion_beast_tongue',
     displayName: 'Beast Tongue',
     category: ItemCategory.POTION,
-    description: 'A strange potion that tastes like different animals. Lets you talk to beasts!',
+    description:
+      'A strange potion that tastes like different animals. Lets you talk to beasts for a day!',
     stackable: true,
     sellPrice: 100,
   },

--- a/data/potionRecipes.ts
+++ b/data/potionRecipes.ts
@@ -328,7 +328,7 @@ export const POTION_RECIPES: Record<string, PotionRecipeDefinition> = {
     resultItemId: 'potion_beast_tongue',
     resultQuantity: 1,
     unlockRequirement: 'beastward_balm',
-    effectDescription: 'Allows you to talk to animals',
+    effectDescription: 'Talk to animals for 1 day',
   },
 
   floatation_philtre: {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -12,7 +12,7 @@
  * tests/zIndexSafelist.test.ts fails if a Z_* constant is missing from this
  * list, so adding a new constant means adding its value below too.
  */
-@source inline("z-[{-100,-50,-10,-1,0,0.5,1,5,10,25,50,65,75,80,100,150,200,250,280,295,300,350,400,410,420,450,500,510,520,620,650,1000,1050,1060,1100,2000,2005,2010,2020,2030,2040,2045,2048,2050,2052,2055,2060,2065,2070,2080,2090,2095,3000,3100,3500,4000,4500}]");
+@source inline("z-[{-100,-50,-10,-1,0,0.5,0.75,1,5,10,25,50,65,75,80,100,150,200,250,280,295,300,350,400,410,420,450,500,510,520,620,650,1000,1050,1060,1100,2000,2005,2010,2020,2030,2040,2045,2048,2050,2052,2055,2060,2065,2070,2080,2090,2095,3000,3100,3500,4000,4500}]");
 
 /* Ensure html > body > #root chain fills the viewport exactly.
  * Uses percentage-based sizing instead of viewport units (100vw includes

--- a/tests/beastTongue.test.ts
+++ b/tests/beastTongue.test.ts
@@ -1,0 +1,94 @@
+/** @vitest-environment node */
+import { describe, it, expect, afterEach } from 'vitest';
+import { getDialogue } from '../services/dialogueService';
+import { gameState } from '../GameState';
+import { applyPotionEffect, MagicEffectCallbacks } from '../utils/MagicEffects';
+import { POTION_EFFECT_DISPLAY } from '../components/PotionEffectIndicator';
+import { TimeManager } from '../utils/TimeManager';
+import { createCatNPC } from '../utils/npcs/village/cat';
+import { createDogNPC } from '../utils/npcs/village/dog';
+import { createDuckNPC } from '../utils/npcs/village/duck';
+import { createSparrowNPC } from '../utils/npcs/forest/sparrow';
+import { createPossumNPC } from '../utils/npcs/forest/possum';
+import { createBunnyflyNPC } from '../utils/npcs/forest/bunnyfly';
+import { createUmbraWolfNPC } from '../utils/npcs/forest/umbraWolf';
+import { createCowNPC } from '../utils/npcs/farmNPCs';
+import { NPC } from '../types';
+
+/**
+ * Beast Tongue is the only potion whose whole payoff lives in other files: the potion sets
+ * an effect flag, and eight separate animal NPC modules each hand-copy
+ * `requiredPotionEffect: 'beast_tongue'` / `hiddenWithPotionEffect: 'beast_tongue'` onto
+ * their dialogue nodes. A typo in any one of those strings, or a change to the filtering in
+ * dialogueService, silently leaves that animal saying "*purr*" forever with nothing failing.
+ *
+ * This pins the round trip — drink the potion, the animal talks; let it lapse, it does not.
+ */
+
+const ORIGIN = { x: 0, y: 0 };
+
+const ANIMALS: Array<{ label: string; create: () => NPC }> = [
+  { label: 'Cat', create: () => createCatNPC('cat_test', ORIGIN) },
+  { label: 'Dog', create: () => createDogNPC('dog_test', ORIGIN, 'child_test') },
+  { label: 'Duck', create: () => createDuckNPC('duck_test', ORIGIN) },
+  { label: 'Sparrow', create: () => createSparrowNPC('sparrow_test', ORIGIN) },
+  { label: 'Possum', create: () => createPossumNPC('possum_test', ORIGIN) },
+  { label: 'Bunnyfly', create: () => createBunnyflyNPC('bunnyfly_test', ORIGIN) },
+  { label: 'Umbra Wolf', create: () => createUmbraWolfNPC('umbrawolf_test', ORIGIN) },
+  { label: 'Cow', create: () => createCowNPC('cow_test', ORIGIN) },
+];
+
+/** Nodes only readable with the potion active are the ones tagged for it. */
+const isBeastNode = (nodeId: string | undefined, npc: NPC) =>
+  npc.dialogue.find((n) => n.id === nodeId)?.requiredPotionEffect === 'beast_tongue';
+
+describe('Beast Tongue potion', () => {
+  afterEach(() => gameState.clearActivePotionEffect('beast_tongue'));
+
+  it('opens animal speech for every animal, and only while active', async () => {
+    const problems: string[] = [];
+
+    for (const { label, create } of ANIMALS) {
+      const npc = create();
+
+      gameState.clearActivePotionEffect('beast_tongue');
+      const without = await getDialogue(npc, 'greeting');
+      if (isBeastNode(without?.id, npc)) {
+        problems.push(
+          `${label}: shows beast-tongue node "${without?.id}" with no potion active — ` +
+            `its ordinary dialogue is missing a hiddenWithPotionEffect guard, or the ` +
+            `beast node is missing requiredPotionEffect: 'beast_tongue'.`
+        );
+      }
+
+      gameState.setActivePotionEffect('beast_tongue', TimeManager.MS_PER_GAME_DAY);
+      const withPotion = await getDialogue(npc, 'greeting');
+      if (!isBeastNode(withPotion?.id, npc)) {
+        problems.push(
+          `${label}: still shows "${withPotion?.id}" with Beast Tongue active — ` +
+            `check requiredPotionEffect/hiddenWithPotionEffect spelling in its dialogue nodes.`
+        );
+      }
+    }
+
+    expect(problems, `\n${problems.join('\n')}\n`).toEqual([]);
+  });
+
+  it('lasts a full game day, so it survives the walk to the forest animals', () => {
+    const set: Array<[string, number]> = [];
+    const callbacks = {
+      showToast: () => {},
+      getPlayerPosition: () => ORIGIN,
+      setActivePotionEffect: (type: string, ms: number) => set.push([type, ms]),
+    } as unknown as MagicEffectCallbacks;
+
+    const result = applyPotionEffect('potion_beast_tongue', callbacks);
+
+    expect(result.success).toBe(true);
+    expect(set).toEqual([['beast_tongue', TimeManager.MS_PER_GAME_DAY]]);
+  });
+
+  it('shows a HUD badge, so a lapsed potion never looks like a broken one', () => {
+    expect(POTION_EFFECT_DISPLAY.beast_tongue).toBeDefined();
+  });
+});

--- a/tests/cropLayering.test.ts
+++ b/tests/cropLayering.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Crop layering tests
+ *
+ * The soil underlay (tilled/tilled_wet) and the crop growing on it are separate PixiJS
+ * sprites in the same container, ordered by zIndex. PixiJS sorts with
+ * `children.sort((a, b) => a._zIndex - b._zIndex)`, and Array.prototype.sort is stable, so
+ * two sprites on the SAME zIndex fall back to insertion order.
+ *
+ * That tie is how seedlings vanished: planting happens on an already-tilled tile, so the
+ * crop sprite exists first and the soil underlay is added afterwards — landing on top of the
+ * seedling and hiding it completely. Only the seedling stage was affected, because young and
+ * adult crops are depth-sorted from Z_DEPTH_SORTED_BASE and so sit far above the soil.
+ *
+ * WHAT BREAKS IF THESE FAIL:
+ * - Soil at or above Z_TILE_SPRITES: seedlings are invisible the moment they are planted,
+ *   and reappear only after leaving and re-entering the map (which rebuilds the sprites in
+ *   the other order). Young/adult stages still show, so it reads as "planting is broken".
+ * - Soil at or below Z_TILE_BASE_SPRITE: a map's ground texture TilingSprite (the village
+ *   ground, the mine floor) paints over the soil instead, so tilled and watered plots stop
+ *   being visible at all. That was the bug fixed in ab768bf — do not reintroduce it by
+ *   simply lowering the soil.
+ */
+
+/** @vitest-environment node */
+import { describe, it, expect } from 'vitest';
+import {
+  Z_TILE_BACKGROUND,
+  Z_TILE_BASE_SPRITE,
+  Z_FARM_SOIL,
+  Z_TILE_SPRITES,
+  Z_DEPTH_SORTED_BASE,
+} from '../zIndex';
+import { CROP_SPRITE_CONFIG } from '../utils/pixi/TileLayer';
+import { CropGrowthStage } from '../types';
+
+describe('farm soil underlay layering', () => {
+  it('sits strictly between the map ground texture and the crop sprite', () => {
+    expect(Z_FARM_SOIL).toBeGreaterThan(Z_TILE_BACKGROUND);
+    expect(Z_FARM_SOIL).toBeGreaterThan(Z_TILE_BASE_SPRITE);
+    expect(Z_FARM_SOIL).toBeLessThan(Z_TILE_SPRITES);
+  });
+
+  it('never ties the seedling sprite, which would let insertion order hide it', () => {
+    const seedlingZ = CROP_SPRITE_CONFIG[CropGrowthStage.SEEDLING].zIndex;
+    expect(seedlingZ).toBeGreaterThan(Z_FARM_SOIL);
+  });
+
+  it('stays below every depth-sorted crop stage', () => {
+    expect(Z_FARM_SOIL).toBeLessThan(Z_DEPTH_SORTED_BASE);
+  });
+});

--- a/utils/MagicEffects.ts
+++ b/utils/MagicEffects.ts
@@ -301,8 +301,7 @@ const POTION_EFFECTS: Record<string, PotionEffectDefinition> = {
     potionId: 'potion_beastward',
     effectType: 'beast_ward',
     execute: (callbacks) => {
-      // 1 game day = 2 real hours = 7,200,000 ms
-      const duration = 7200000;
+      const duration = TimeManager.MS_PER_GAME_DAY;
       callbacks.setActivePotionEffect?.('beast_ward', duration);
       callbacks.showToast('Animals will ignore you for a day.', 'success');
       callbacks.triggerVFX?.('shield', callbacks.getPlayerPosition());
@@ -337,10 +336,9 @@ const POTION_EFFECTS: Record<string, PotionEffectDefinition> = {
     potionId: 'potion_revealing',
     effectType: 'reveal_gift_preference',
     execute: (callbacks) => {
-      // 1 game day = 2 real hours = 7,200,000 ms. While active, talking to an
-      // NPC reveals their favourite gift category (see onNPC in
-      // useInteractionController.ts, which checks this effect).
-      const duration = 7200000;
+      // While active, talking to an NPC reveals their favourite gift category
+      // (see onNPC in useInteractionController.ts, which checks this effect).
+      const duration = TimeManager.MS_PER_GAME_DAY;
       callbacks.setActivePotionEffect?.('reveal_gift_preference', duration);
       callbacks.showToast('Talk to a villager to learn their favourite gifts!', 'success');
       callbacks.triggerVFX?.('aura_glow', callbacks.getPlayerPosition());
@@ -477,7 +475,9 @@ const POTION_EFFECTS: Record<string, PotionEffectDefinition> = {
     potionId: 'potion_beast_tongue',
     effectType: 'beast_tongue',
     execute: (callbacks) => {
-      const duration = 300000; // 5 minutes real time
+      // A full game day, matching Beastward Balm. Five real minutes (the old value)
+      // expired before the player could walk from the cottage to the forest animals.
+      const duration = TimeManager.MS_PER_GAME_DAY;
       callbacks.setActivePotionEffect?.('beast_tongue', duration);
       callbacks.showToast('You can now understand the speech of beasts!', 'success');
       callbacks.triggerVFX?.('aura_glow', callbacks.getPlayerPosition());

--- a/utils/pixi/TileLayer.ts
+++ b/utils/pixi/TileLayer.ts
@@ -38,6 +38,7 @@ import {
   Z_TILE_BASE,
   Z_TILE_BASE_SPRITE,
   Z_TILE_BACKGROUND,
+  Z_FARM_SOIL,
   Z_TILE_SPRITES,
   Z_SPRITE_BACKGROUND,
   Z_PLAYER,
@@ -451,7 +452,7 @@ export class TileLayer extends PixiLayer {
           soilSprite.y = y * TILE_SIZE;
           soilSprite.width = TILE_SIZE;
           soilSprite.height = TILE_SIZE;
-          soilSprite.zIndex = Z_TILE_SPRITES;
+          soilSprite.zIndex = Z_FARM_SOIL;
           this.container.addChild(soilSprite);
           this.sprites.set(soilKey, soilSprite);
         } else if (soilSprite instanceof PIXI.Sprite) {

--- a/zIndex.ts
+++ b/zIndex.ts
@@ -32,6 +32,17 @@ export const Z_TILE_BACKGROUND = 0;
 /** Base tile sprite layer (e.g., mine_floor under cave rock/mushroom — above flat color, below tile sprite) */
 export const Z_TILE_BASE_SPRITE = 0.5;
 
+/**
+ * Farm soil underlay (tilled/tilled_wet) painted beneath a crop sprite.
+ *
+ * Must sit above Z_TILE_BASE_SPRITE so a map's ground texture (e.g. the village
+ * TilingSprite) does not paint over the soil, and strictly below Z_TILE_SPRITES so it
+ * never covers the crop growing on it. Sharing Z_TILE_SPRITES with the crop left the
+ * two tied, and PixiJS breaks a zIndex tie by insertion order — planting on an
+ * already-tilled tile adds the soil after the crop sprite, which hid seedlings entirely.
+ */
+export const Z_FARM_SOIL = 0.75;
+
 /** Tile sprites (stepping stones, furniture) */
 export const Z_TILE_SPRITES = 1;
 


### PR DESCRIPTION
## Seedlings were invisible when planted

The soil underlay (`tilled.png`) and the crop sprite on top of it both sat at `Z_TILE_SPRITES`. PixiJS sorts children with a stable sort on `zIndex`, so a tie falls back to insertion order — and planting always happens on an already-tilled tile, meaning the crop sprite exists first and the soil is added afterwards. The opaque soil square then painted straight over the seedling.

Only the seedling stage was affected: young and adult crops are depth-sorted from `Z_DEPTH_SORTED_BASE`, far above the soil. That is why it read as "planting is broken" rather than "crops are broken", and why the sprout reappeared after leaving and re-entering the map, which rebuilds both sprites in the other order.

Introduced by ab768bf, which raised the soil from `Z_TILE_BACKGROUND` to `Z_TILE_SPRITES` so the village ground TilingSprite (`Z_TILE_BASE_SPRITE`, 0.5) would stop painting over it. New `Z_FARM_SOIL = 0.75` satisfies both constraints at once, and `tests/cropLayering.test.ts` pins it between the two so neither bug can return by moving one number.

## Beast Tongue looked broken but wasn't

The dialogue plumbing worked — eight animal NPCs have full beast-tongue trees and `dialogueService` filters them correctly. But the potion lasted five real minutes, so it expired on the walk from the cottage to the forest animals, and nothing on screen said it was running or had lapsed. Beastward Balm, which gates it in the recipe tree, lasted a full day.

Beast Tongue now runs for a game day too, and the three timed potion effects (Beast Tongue, Beastward, Revealing) get a HUD badge alongside the existing Floating/Flying one. `PotionEffectIndicator` is data-driven, so a new timed effect needs one entry in `POTION_EFFECT_DISPLAY` and nothing else.

## Tests

- `tests/cropLayering.test.ts` — pins the soil underlay strictly between the ground texture and the crop sprite.
- `tests/beastTongue.test.ts` — walks all eight animals through `getDialogue()` with and without the effect. The `requiredPotionEffect` string is hand-copied across eight NPC modules, so a typo in any one of them was previously invisible.

`make verify` green: typecheck clean, 691 tests across 69 files.

## Note

The seedling art is small — `seedling.png` draws its sprout in a 107x122 region of a 768x768 canvas, so it renders about 9x10 px on a 64 px tile. Visible, but modest. Not changed here; worth a follow-up if it still reads as too subtle in play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYuoCXdvGFXa4p2AZcemuS