### PR TITLE
Fix Firebase never initialising when presence wins the startup race

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,7 +63,9 @@
       "mcp__chrome-devtools__emulate",
       "Read(//var/folders/kv/nxj052r50g7813x2blwc74jw0000gn/T/chrome-devtools-mcp-YW5Q8B/**)",
       "Read(//private/var/folders/kv/nxj052r50g7813x2blwc74jw0000gn/T/chrome-devtools-mcp-YW5Q8B/**)",
-      "Bash(sips -g pixelWidth -g pixelHeight /Users/mark/dev/TwilightGame/public/assets/icons/ui/mouse_32.png)"
+      "Bash(sips -g pixelWidth -g pixelHeight /Users/mark/dev/TwilightGame/public/assets/icons/ui/mouse_32.png)",
+      "Bash(.claude/skills/debug-production/scripts/:*)",
+      "Skill(debug-production)"
     ],
     "deny": [],
     "ask": [

--- a/.claude/skills/debug-production/SKILL.md
+++ b/.claude/skills/debug-production/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: debug-production
+description: Debug bugs that only happen in the deployed game — a player reports something that works fine locally, or two players see different behaviour. Use when someone says "it works on my machine", "X is broken on the live site", "we're both online but can't see each other", "check Sentry", "she can sign in and I can't", "can you see what error they got", or reports any failure you cannot reproduce with `make dev`. Also use before blaming a player's browser, network, ad blocker or account for a bug you have not actually observed.
+---
+
+# Debug Production
+
+## Quick Start
+
+```bash
+claude mcp list | grep sentry                                    # 1. real player errors
+node .claude/skills/debug-production/scripts/probe-live.mjs      # 2. what the live build logs
+.claude/skills/debug-production/scripts/fetch-bundle.sh 'apiKey' # 3. what actually shipped
+```
+
+## When to Use
+
+A player reports something you cannot reproduce with `make dev`; two players on
+the same build behave differently; someone asks you to check Sentry; or you are
+about to blame a browser, ad blocker, network or account for a bug you have not
+observed yourself.
+
+## Workflow
+
+Bugs that only appear in the deployed build are a different job from local
+debugging. You cannot add a `console.log` and reload, and the most dangerous
+ones make no noise at all — a function returns early, nothing throws, Sentry
+stays empty, and the symptom lands three subsystems away from the cause.
+
+The method below is evidence-first. Gather what the deployed build actually
+does *before* forming a theory, because the plausible-sounding theory ("their
+browser blocks IndexedDB", "the secret must be missing") is usually wrong and
+costs an hour.
+
+## Step 0 — Pin down what you are debugging
+
+Ask, or work out from the report:
+
+- **Which build?** `VITE_APP_VERSION` is set to the commit SHA by
+  `.github/workflows/deploy.yml`. Sentry tags events with it.
+- **Everyone or one person?** A bug that hits one player of two is usually a
+  race or a cached artefact, not a config difference — the config is baked into
+  a bundle they both downloaded.
+- **What exact words?** "It says Firebase not initialised" is a searchable
+  string that leads straight to the throw site. A paraphrase is not.
+
+## Step 1 — Look in Sentry first
+
+Remote error reporting is live (`utils/errorReporting.ts`). Query it through
+the **Sentry MCP server**, not the DSN — `VITE_SENTRY_DSN` is a write-only
+ingest key and cannot read issues.
+
+```bash
+claude mcp list | grep sentry     # expect "✔ Connected"
+```
+
+If it says `Needs authentication`, ask the user to run `/mcp` and authorise it;
+that OAuth flow cannot be completed for them. If the server is missing:
+`claude mcp add --transport http sentry https://mcp.sentry.dev/mcp`.
+
+MCP tools are registered when a session starts, so a server added or authorised
+mid-session shows `✔ Connected` while no `mcp__sentry__*` tool exists yet. If
+`claude mcp list` is green but the tools are absent, say so and carry on with
+steps 2 and 3 — they need a fresh session, and waiting for one is rarely worth
+it when the deployed build is right there to interrogate.
+
+Then look for issues in the relevant category tag — `auth`, `sync`,
+`shared_farm`, `presence`, `game_crash` — around the time of the report.
+
+**An empty Sentry is not an all-clear.** Nothing is reported when a function
+returns `null` instead of throwing. Treat silence as "not this kind of bug yet"
+and carry on to step 2. Stack traces are also still minified (source-map upload
+is not set up), so expect names like `g5()` — step 3 is how you decode them.
+
+## Step 2 — Watch the live site's console yourself
+
+```bash
+node .claude/skills/debug-production/scripts/probe-live.mjs
+node .claude/skills/debug-production/scripts/probe-live.mjs --filter 'Presence|Multiplayer' --wait 45
+node .claude/skills/debug-production/scripts/probe-live.mjs --url http://localhost:4000 --all
+```
+
+It loads the deployed game in headless Chrome, deduplicates the console, prints
+failed Firebase/Google/Sentry requests — and, most importantly, checks a list of
+**startup markers**.
+
+The markers are the whole point. Every one names a step that must log *something*
+on any outcome, success or failure. A `MISSING` marker means that step returned
+without logging, which is precisely the failure mode that leaves no exception and
+no Sentry event. Find the function that owes you that line and work out how it
+returned early. Extend `MARKERS` in the script whenever you add a startup step
+with mutually exclusive logged outcomes.
+
+Limits: PixiJS never initialises under headless SwiftShader, so the world renders
+black and this tells you nothing about how anything *looks*. It is for startup,
+console and network evidence only.
+
+## Step 3 — Read what actually shipped
+
+```bash
+.claude/skills/debug-production/scripts/fetch-bundle.sh 'databaseURL' 'apiKey'
+```
+
+Downloads the deployed chunks and counts matches, so you can answer questions
+the source cannot:
+
+- **Was the GitHub secret really set?** Vite inlines every `import.meta.env.VITE_*`
+  at build time. If the value is in the bundle, the secret is fine — stop
+  suspecting it.
+- **Which branch survived?** A truthy inlined string collapses
+  `!!import.meta.env.X` to a constant, so `if (!a() || !b())` in the source can
+  be `if(!a())` in production. **The log message it prints may therefore name the
+  wrong cause.** This is a live trap: `[Presence] Realtime Database not configured`
+  is printed by the *`isFirebaseInitialized()`* branch, and reads as a missing URL
+  that is in fact present.
+- **Is a module duplicated across chunks?** Count a unique string from it in every
+  chunk. Two copies means two module-level singletons, and an `init()` that sets
+  one while a getter reads the other.
+
+To read minified code around a needle:
+
+```bash
+python3 -c "s=open('<dir>/<chunk>.js').read(); i=s.index('<needle>'); print(repr(s[i-600:i+600]))"
+```
+
+## Step 4 — The silent-failure checklist
+
+When a step ran but logged nothing, it is almost always one of these:
+
+1. **A boolean guard where a promise belongs.** `if (started) return cached;`
+   hands the second concurrent caller a value that is still `null`. This is what
+   broke sign-in, cloud saves and multiplayer at once (see
+   [resources/case-firebase-init-race.md](resources/case-firebase-init-race.md)).
+   Share the in-flight promise, never a "we already started" flag.
+2. **A cache that latched a transient answer.** `if (attempted) return null;`
+   evaluated once, early, before the thing it depends on was ready — and now
+   permanent for the session. Only a real attempt may be final.
+3. **Two callers racing at startup.** Anything called from a component effect on
+   mount races `initializeGameAssets`. Effects win; async initialisation loses.
+4. **A debug flag that is dead code.** `DEBUG.X: import.meta.env.DEV && false`
+   never logs anywhere. Check whether the diagnostics you are hoping to read
+   could ever have run.
+5. **An error swallowed by design.** Grep the failure path for `catch` blocks
+   gated behind a debug flag. A publish that fails 5×/second and warns zero
+   times is invisible by construction.
+
+## Step 5 — Prove it with a test that fails first
+
+Before fixing, write the test and **watch it fail against the current code** —
+temporarily restore the old implementation if you have already changed it. A
+production race that cannot be reproduced in a test is a theory, not a diagnosis.
+
+Mock the dynamic import, drive the two callers in the same tick, and assert the
+observable that was missing (e.g. "`initializeFirebase` was called once"). See
+`tests/firebaseSafeStartup.test.ts` for the shape. Then `make verify`.
+
+## Step 6 — Leave it visible for next time
+
+The fix is half the job; the other half is making sure the next instance of this
+announces itself. Prefer, in order:
+
+1. **Log the reason out loud**, not behind a debug flag, once per distinct
+   situation so it cannot spam. A user-actionable sentence beats a code:
+   `[Multiplayer] Other players will not appear on "farm_area": you are not signed in`.
+2. **Report to Sentry** at the source (`reportError(error, category, extra)`),
+   once per session for anything in a loop.
+3. **Add a startup marker** to `probe-live.mjs` if you added a step with
+   mutually exclusive outcomes.
+4. **Make the diagnostics reachable in production** — `?debug=multiplayer` and
+   `localStorage.twilight_debug` switch `DEBUG.*` on in a deployed build
+   (`runtimeDebug()` in `constants.ts`).
+
+## Reporting back
+
+Say what you observed and where, separately from what you concluded. "The live
+site logs none of the four possible outcomes of `safeInitializeFirebase()`" is
+evidence. "Firebase never initialises" is the conclusion it supports. Keeping
+them apart is what stops a plausible theory being repeated as fact.

--- a/.claude/skills/debug-production/resources/case-firebase-init-race.md
+++ b/.claude/skills/debug-production/resources/case-firebase-init-race.md
@@ -1,0 +1,74 @@
+# Case study: sign-in, cloud saves and multiplayer all dead, nothing thrown
+
+September 2026. Two players on the same deployed build. One could sign in, the
+other got "Firebase not initialized - call initializeFirebase() first" every
+time, and neither could see the other in the shared farm.
+
+Worth reading not for the bug but for how much of the first hour went into
+theories that the evidence then killed.
+
+## Theories that were wrong
+
+Each was plausible, and each would have been reported as a diagnosis if nobody
+had checked:
+
+- *"Their browser blocks IndexedDB"* — `enableIndexedDbPersistence` is awaited
+  during init, so a hang there looked like a candidate. It is wrapped in its own
+  try/catch, and `auth` is assigned before it. Dead.
+- *"The `VITE_FIREBASE_DATABASE_URL` secret was never set"* — the deployed
+  console literally says `[Presence] Realtime Database not configured`. The
+  bundle contains the URL. That message is printed by the *other* branch of the
+  condition; Vite had collapsed the clause that would have distinguished them.
+- *"They're both signed into the same account"* — would genuinely cause
+  invisibility (own-uid filter), but did not explain the sign-in failure.
+- *"The RTDB rules were never deployed"* — permission-denied writes were indeed
+  invisible, but that was a second latent problem, not this one.
+
+## What the evidence actually said
+
+Running the live site in headless Chrome, the startup log contained **none** of
+the four possible outcomes of `safeInitializeFirebase()` — not success, not
+"not configured", not "package not installed", not "initialization failed" —
+and yet startup carried on into `[GlobalEventManager] Initialised`, which
+follows it. A function with four logged exits had taken a fifth.
+
+The fifth exit was `if (!mod) return null`.
+
+## The bug
+
+```ts
+let firebaseModule = null;
+let loadAttempted = false;
+
+async function loadFirebase() {
+  if (loadAttempted) return firebaseModule;   // <- still null while in flight
+  loadAttempted = true;
+  firebaseModule = await import('./index');
+  return firebaseModule;
+}
+```
+
+Two callers race at startup: `useMultiplayerController` calls
+`whenFirebaseSettled()` from an effect on mount, and `initializeGameAssets` then
+calls `safeInitializeFirebase()`. The controller wins, sets the flag, and starts
+a ~200 KB chunk download. The initialiser arrives, sees the flag, and is handed
+`firebaseModule` — still `null` — so it returns without initialising anything
+and without a word.
+
+`auth` therefore stayed null and every auth path threw. Whether a given player
+hit it came down to who won a race against a chunk download, which is why one
+of the two could sign in.
+
+`getRealtimeDb()` had the same shape independently: `if (initAttempted) return
+null` was evaluated the moment a shared map loaded, before Firebase was up, and
+latched "no multiplayer" for the session.
+
+## Lessons
+
+1. **Share the in-flight promise, never a "started" boolean.** The boolean is
+   correct only if nobody asks during the flight, which is exactly when they do.
+2. **Enumerate a function's exits and make every one of them log.** The bug was
+   located by an exit that logged nothing, not by anything that failed.
+3. **A log line names the branch its author expected, not the branch that ran.**
+   Check the compiled bundle before trusting a message about configuration.
+4. **Silence is a symptom.** Sentry was empty because nothing threw.

--- a/.claude/skills/debug-production/resources/reference.md
+++ b/.claude/skills/debug-production/resources/reference.md
@@ -1,0 +1,32 @@
+# Reference
+
+Longer-form material for the `debug-production` skill.
+
+- [case-firebase-init-race.md](case-firebase-init-race.md) — a worked example:
+  sign-in, cloud saves and multiplayer all dead, no exception anywhere, found by
+  reading the deployed bundle.
+
+## Where the evidence lives
+
+| Question | Where to look |
+|---|---|
+| Did a real player hit an error? | Sentry, via the MCP server (`claude mcp list`) |
+| What does the deployed build log? | `scripts/probe-live.mjs` |
+| Was a build secret set? | `scripts/fetch-bundle.sh` — Vite inlines `VITE_*` |
+| Which commit is live? | `VITE_APP_VERSION` (set to `github.sha` in `deploy.yml`) |
+| Are the Firebase rules deployed? | `.github/workflows/firebase.yml` run history |
+
+## Sentry categories
+
+`utils/errorReporting.ts` tags every event with one of:
+`auth`, `sync`, `shared_farm`, `presence`, `game_crash`.
+
+Add a category rather than overloading an existing one — the tag is what makes
+the dashboard filterable.
+
+## Not set up yet
+
+- **Source map upload.** Traces show minified names (`g5()`, `Ri()`). Needs
+  `@sentry/vite-plugin` plus a `SENTRY_AUTH_TOKEN` GitHub secret.
+- **Performance tracing and session replay.** Deliberately off — separate quota,
+  and replay records gameplay. See the Sentry section of `CLAUDE.md`.

--- a/.claude/skills/debug-production/scripts/fetch-bundle.sh
+++ b/.claude/skills/debug-production/scripts/fetch-bundle.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Download the deployed JS chunks so you can read what actually shipped.
+#
+# Vite inlines every `import.meta.env.VITE_*` at build time, so the deployed
+# bundle is the only place that tells you whether a GitHub Actions secret was
+# really set. It also shows which branch of a condition survived: a truthy
+# inlined string collapses `!!import.meta.env.X` to a constant, so a two-clause
+# `if` in the source can be a one-clause `if` in production — and the log
+# message it prints may name the wrong cause.
+#
+# Usage:
+#   fetch-bundle.sh                                   # download chunks only
+#   fetch-bundle.sh 'apiKey' 'databaseURL'            # download, then count matches
+#   fetch-bundle.sh --url https://example.com/app/ 'Firebase'
+set -euo pipefail
+
+URL="https://code.markedmondson.me/TwilightGame/"
+OUT="${TMPDIR:-/tmp}/twilight-bundle"
+
+while [[ "${1:-}" == --* ]]; do
+  case "$1" in
+    --url) URL="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+BASE="${URL%/}/"
+mkdir -p "$OUT"
+echo "→ $BASE  ->  $OUT"
+
+curl -sS "$BASE" -o "$OUT/index.html"
+
+# Entry chunks referenced by the HTML, then the lazy chunks those import.
+# (No mapfile/readarray here: macOS ships bash 3.2.)
+chunks=$(grep -oE 'assets/[A-Za-z0-9_.-]+\.js' "$OUT/index.html" | sort -u)
+for _pass in 1 2; do
+  for chunk in $chunks; do
+    name="$(basename "$chunk")"
+    [ -s "$OUT/$name" ] && continue
+    curl -sS -o "$OUT/$name" "${BASE}assets/$name" && echo "  fetched $name ($(wc -c <"$OUT/$name" | tr -d ' ') bytes)"
+  done
+  chunks=$(cat "$OUT"/*.js 2>/dev/null |
+    grep -oE '"\./[A-Za-z0-9_.-]+\.js"' |
+    sed -e 's|^"\./||' -e 's|"$||' |
+    sed 's|^|assets/|' | sort -u)
+done
+
+if [[ $# -gt 0 ]]; then
+  echo
+  for pattern in "$@"; do
+    echo "--- $pattern ---"
+    grep -c "$pattern" "$OUT"/*.js 2>/dev/null | grep -v ':0$' || echo "  (no matches in any chunk)"
+  done
+  echo
+  echo "Read the surrounding minified code with:"
+  echo "  python3 -c \"s=open('$OUT/<chunk>.js').read(); i=s.index('<needle>'); print(repr(s[i-600:i+600]))\""
+fi

--- a/.claude/skills/debug-production/scripts/probe-live.mjs
+++ b/.claude/skills/debug-production/scripts/probe-live.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Load the deployed game in headless Chrome and report what its console says.
+ *
+ * The point is not the logs it prints but the ones it *cannot* find. A startup
+ * step that returns early without logging leaves no error, no exception and no
+ * Sentry event — the only trace is a marker that never appeared. MARKERS below
+ * lists the lines a healthy startup must produce; anything reported as MISSING
+ * is a step that silently did not happen.
+ *
+ * Usage (from the repo root, so node resolves puppeteer):
+ *   node .claude/skills/debug-production/scripts/probe-live.mjs
+ *   node .claude/skills/debug-production/scripts/probe-live.mjs --url http://localhost:4000 --wait 20
+ *   node .claude/skills/debug-production/scripts/probe-live.mjs --filter 'Presence|Multiplayer'
+ *   node .claude/skills/debug-production/scripts/probe-live.mjs --all
+ *
+ * Note: PixiJS does not initialise under headless SwiftShader, so the world
+ * renders black. This probe is for startup/console/network evidence only —
+ * it cannot tell you whether anything looks right on screen.
+ */
+import puppeteer from 'puppeteer';
+
+const DEFAULT_URL = 'https://code.markedmondson.me/TwilightGame/';
+
+/** Each group must produce at least one matching line in a healthy startup. */
+const MARKERS = [
+  { name: 'firebase module + config', pattern: /\[Firebase\] (App initialized|Not configured|Package not installed)/ },
+  { name: 'firebase init outcome', pattern: /\[App\] Firebase (, auth, and sync manager initialized|not configured or disabled|initialization failed)/ },
+  { name: 'presence transport', pattern: /\[Presence\] Realtime Database/ },
+  { name: 'event chains', pattern: /\[App\] Initialised event chain system/ },
+  { name: 'audio', pattern: /\[App\] Audio system initialised/ },
+  { name: 'renderer', pattern: /\[usePixiRenderer\] Initialized/ },
+];
+
+const args = process.argv.slice(2);
+const arg = (flag, fallback) => {
+  const i = args.indexOf(flag);
+  return i === -1 ? fallback : args[i + 1];
+};
+const url = arg('--url', DEFAULT_URL);
+const waitMs = Number(arg('--wait', '35')) * 1000;
+const showAll = args.includes('--all');
+const filter = new RegExp(
+  arg('--filter', 'Firebase|Presence|Multiplayer|SharedFarm|Auth|Sentry|error|failed'),
+  'i'
+);
+
+const lines = [];
+const browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox'] });
+try {
+  const page = await browser.newPage();
+  page.on('console', (m) => lines.push({ kind: m.type(), text: m.text() }));
+  page.on('pageerror', (e) => lines.push({ kind: 'pageerror', text: e.message }));
+  page.on('requestfailed', (r) => {
+    if (/googleapis|firebase|google|sentry/i.test(r.url())) {
+      lines.push({ kind: 'reqfail', text: `${r.url().slice(0, 120)} ${r.failure()?.errorText}` });
+    }
+  });
+
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 90000 });
+  await new Promise((resolve) => setTimeout(resolve, waitMs));
+
+  // Deduplicate: a per-frame warning can repeat a thousand times and bury the
+  // one line that matters. Keep first-seen order and show a count instead.
+  const seen = new Map();
+  for (const [i, l] of lines.entries()) {
+    if (!(showAll || filter.test(l.text) || l.kind !== 'log')) continue;
+    const key = `${l.kind}:${l.text.slice(0, 220)}`;
+    const entry = seen.get(key);
+    if (entry) entry.count += 1;
+    else seen.set(key, { index: i, kind: l.kind, text: l.text.slice(0, 220), count: 1 });
+  }
+
+  console.log(`===== ${url} — ${lines.length} console lines, ${seen.size} unique shown =====`);
+  for (const e of seen.values()) {
+    const repeat = e.count > 1 ? ` (x${e.count})` : '';
+    console.log(String(e.index).padStart(4), `[${e.kind}]`, e.text + repeat);
+  }
+
+  console.log('\n===== STARTUP MARKERS =====');
+  let missing = 0;
+  for (const marker of MARKERS) {
+    const hit = lines.find((l) => marker.pattern.test(l.text));
+    if (hit) {
+      console.log(`  ok      ${marker.name}`);
+    } else {
+      missing += 1;
+      console.log(`  MISSING ${marker.name}  <- a startup step returned without logging`);
+    }
+  }
+  console.log(
+    missing === 0
+      ? '\nAll startup markers present.'
+      : `\n${missing} marker(s) missing. A missing marker is the bug, not a gap in this probe: ` +
+          'find the function that must log one of those lines and work out how it returned early.'
+  );
+} finally {
+  await browser.close();
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1411,6 +1411,7 @@ These are the bugs that keep coming back. **Read the gotchas doc before touching
 | **add-animation** | "add animation", "particle effect", "weather effect" | Add GIF animations to tiles/weather |
 | **add-pixi-component** | "PixiJS", "WebGL", "particle system", "shader" | Add PixiJS rendering components |
 | **add-minigame** | "create mini-game", "add mini-game", "new activity" | Create self-contained mini-games (2 files + 1 registry line) |
+| **debug-production** | "works locally but not deployed", "broken on the live site", "check Sentry", "can't reproduce" | Debug production-only bugs: Sentry via MCP, live console probe, deployed-bundle inspection |
 
 ### When to Use Skills
 
@@ -1426,6 +1427,7 @@ These are the bugs that keep coming back. **Read the gotchas doc before touching
 - User: "Start the game" → Use **dev-server** skill
 - User: "Add rain particles" → Use **add-animation** skill
 - User: "Add almonds as an ingredient" → Use **add-grocery-item** skill
+- User: "Sanne says she can't sign in but it works for me" → Use **debug-production** skill
 
 ### Asset Optimization Keywords
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Remote error/crash reporting, so a real player's failed login or sync is visible
 
 **Status:** Silently disabled when `VITE_SENTRY_DSN` is unset — same no-op pattern as Firebase above.
 
-**Key file:** `utils/errorReporting.ts` (uses `@sentry/react`) — `initErrorReporting()` (called once in `index.tsx`), `reportError(error, category, extra?)`, `reportMessage(message, category, extra?)`, plus `onUncaughtError`/`onRecoverableError` (React 19's `createRoot()` error hooks — wired in `index.tsx`). Categories: `'auth' | 'sync' | 'shared_farm' | 'game_crash'`.
+**Key file:** `utils/errorReporting.ts` (uses `@sentry/react`) — `initErrorReporting()` (called once in `index.tsx`), `reportError(error, category, extra?)`, `reportMessage(message, category, extra?)`, plus `onUncaughtError`/`onRecoverableError` (React 19's `createRoot()` error hooks — wired in `index.tsx`). Categories: `'auth' | 'sync' | 'shared_farm' | 'presence' | 'game_crash'`.
 
 **Wired into:** `components/ErrorBoundary.tsx` (`componentDidCatch`), `index.tsx` (`onUncaughtError`/`onRecoverableError` — NOT `onCaughtError`, which would double-report what ErrorBoundary already catches), `components/HelpBrowser.tsx` (auth actions), `firebase/syncManager.ts` (`uploadToCloud`/`downloadFromCloud`/`getCloudSyncMeta` — reported once at the source, not at every caller, since multiple call sites funnel through the same methods), `utils/farmManager.ts` (aggregate shared-farm write failures per flush, not per-plot).
 

--- a/components/HelpBrowser.tsx
+++ b/components/HelpBrowser.tsx
@@ -10,7 +10,13 @@ import {
   isAIAvailable,
 } from '../services/anthropicClient';
 import { audioManager } from '../utils/AudioManager';
-import { getAuthService, getSyncManager, type AuthState, type SyncState } from '../firebase/safe';
+import {
+  getAuthService,
+  getSyncManager,
+  safeInitializeFirebase,
+  type AuthState,
+  type SyncState,
+} from '../firebase/safe';
 import { reportError } from '../utils/errorReporting';
 
 interface HelpBrowserProps {
@@ -153,6 +159,24 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
     setSaveMessage('API key removed.');
   };
 
+  /**
+   * Firebase is initialised once during asset loading. When that attempt failed
+   * or had not finished, every button below threw "Firebase not initialized"
+   * and kept doing so for the rest of the session — there was no way back.
+   * Pressing sign-in is exactly the right moment to try again.
+   */
+  const ensureFirebaseReady = async (): Promise<boolean> => {
+    const ready = await safeInitializeFirebase();
+    if (!ready) {
+      setAuthError(
+        'Could not reach the cloud service from this browser. Check your connection ' +
+          '(and any tracking/ad blocker) and try again.'
+      );
+      return false;
+    }
+    return true;
+  };
+
   // Auth handlers
   const handleSignIn = async () => {
     if (!emailInput.trim() || !passwordInput.trim()) {
@@ -162,6 +186,7 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
     setAuthLoading(true);
     setAuthError('');
     try {
+      if (!(await ensureFirebaseReady())) return;
       await getAuthService().signIn(emailInput.trim(), passwordInput.trim());
       setEmailInput('');
       setPasswordInput('');
@@ -186,6 +211,7 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
     setAuthLoading(true);
     setAuthError('');
     try {
+      if (!(await ensureFirebaseReady())) return;
       const displayName = emailInput.split('@')[0];
       await getAuthService().signUp(emailInput.trim(), passwordInput.trim(), displayName);
       setEmailInput('');
@@ -203,6 +229,7 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
     setAuthLoading(true);
     setAuthError('');
     try {
+      if (!(await ensureFirebaseReady())) return;
       await getAuthService().signInWithGoogle();
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Google sign in failed';
@@ -217,6 +244,7 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
     setAuthLoading(true);
     setAuthError('');
     try {
+      if (!(await ensureFirebaseReady())) return;
       await getAuthService().signInAnonymously();
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Guest sign in failed';

--- a/constants.ts
+++ b/constants.ts
@@ -86,6 +86,29 @@ export const MULTIPLAYER = {
  * Toggle these to enable detailed logging for specific game systems.
  * All flags are automatically disabled in production builds.
  */
+/**
+ * Runtime debug switch, usable in a *deployed* build.
+ *
+ * Some bugs only ever happen in production on somebody else's device — the
+ * multiplayer presence path is the canonical example, since it is silent by
+ * design when it fails. Add `?debug=multiplayer` to the URL (comma-separate
+ * several, or use `all`), or run
+ * `localStorage.setItem('twilight_debug', 'multiplayer')` and reload, to turn
+ * the matching flag on without a new deploy.
+ */
+function runtimeDebug(name: string): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const fromUrl = new URLSearchParams(window.location.search).get('debug');
+    const stored = window.localStorage.getItem('twilight_debug');
+    const flags = `${fromUrl ?? ''},${stored ?? ''}`.toLowerCase().split(',');
+    return flags.some((flag) => flag.trim() === name || flag.trim() === 'all');
+  } catch {
+    // Private-browsing modes can throw on localStorage access. Never fatal.
+    return false;
+  }
+}
+
 export const DEBUG = {
   FARM: import.meta.env.DEV && false, // Farm operations (till, plant, water, harvest)
   FARM_OVERLAY: import.meta.env.DEV && false, // Visual farm debug overlay (F3) - shows crop sprite bounds and offsets
@@ -97,7 +120,9 @@ export const DEBUG = {
   QUEST: import.meta.env.DEV && false, // Quest progression and dialogue actions
   FORAGE: import.meta.env.DEV && false, // Foraging actions and loot rolls
   CLICK: import.meta.env.DEV && false, // Click targeting and interaction detection
-  MULTIPLAYER: import.meta.env.DEV && false, // Presence publish/receive and remote player lifecycle
+  // Off by default everywhere; opt in with `?debug=multiplayer` (works in
+  // production too — see runtimeDebug above).
+  MULTIPLAYER: runtimeDebug('multiplayer'), // Presence publish/receive and remote player lifecycle
 } as const;
 
 /**

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,6 +70,9 @@ export default tseslint.config(
       '*.config.js',
       '*.config.ts',
       'scripts/',
+      // Agent tooling, not game source — same reasoning as scripts/ above.
+      // These are Node scripts and would need a separate env to lint cleanly.
+      '.claude/',
       'validate-build.js',
       'public/sw.js',
     ],

--- a/firebase/presenceService.ts
+++ b/firebase/presenceService.ts
@@ -25,10 +25,13 @@ import {
   serverTimestamp,
   type DatabaseReference,
 } from 'firebase/database';
-import { getRealtimeDb } from './realtimeConfig';
+import { getRealtimeDb, isRealtimeConfigured } from './realtimeConfig';
+import { isFirebaseInitialized } from './config';
 import { authService } from './authService';
 import { DEBUG } from '../constants';
+import { reportError } from '../utils/errorReporting';
 import { encodePresence, decodePresence } from '../multiplayer/wire';
+import type { PresenceStatus } from '../multiplayer/presenceStatus';
 import type { LocalPresenceState, PresenceEvent } from '../multiplayer/types';
 
 const PRESENCE_ROOT = 'presence';
@@ -44,10 +47,32 @@ class PresenceService {
   private unsubscribers: Array<() => void> = [];
   private selfRef: DatabaseReference | null = null;
   private listeners = new Set<(event: PresenceEvent) => void>();
+  /** Publish runs at 5 Hz — report the first failure only, not 300 a minute. */
+  private reportedPublishFailure = false;
 
   /** True when presence can actually be published — Firebase up and signed in. */
   isAvailable(): boolean {
-    return getRealtimeDb() !== null && authService.isAuthenticated();
+    return this.getStatus().available;
+  }
+
+  /**
+   * The same answer as isAvailable(), plus *why*. Callers surface the reason
+   * so a silent multiplayer failure leaves a trace in the console.
+   */
+  getStatus(): PresenceStatus {
+    const uid = this.getUid();
+    const base = { uid, room: this.roomMapId };
+
+    if (!isRealtimeConfigured()) return { available: false, reason: 'no-database-url', ...base };
+    if (!isFirebaseInitialized()) {
+      return { available: false, reason: 'firebase-not-initialised', ...base };
+    }
+    if (getRealtimeDb() === null) {
+      return { available: false, reason: 'database-init-failed', ...base };
+    }
+    if (!authService.isAuthenticated()) return { available: false, reason: 'signed-out', ...base };
+
+    return { available: true, reason: null, ...base };
   }
 
   getUid(): string | null {
@@ -131,6 +156,7 @@ class PresenceService {
       return true;
     } catch (error) {
       console.warn(`[Presence] Failed to enter room "${mapId}":`, error);
+      reportError(error, 'presence', { room: mapId });
       this.roomMapId = null;
       this.selfRef = null;
       return false;
@@ -180,8 +206,17 @@ class PresenceService {
       await set(this.selfRef, wire);
       return true;
     } catch (error) {
-      // Losing a position update is harmless — the next one is 200 ms away.
-      if (DEBUG.MULTIPLAYER) console.warn('[Presence] Publish failed:', error);
+      // Losing a *single* position update is harmless — the next one is 200 ms
+      // away. Losing every one of them is invisible multiplayer, so the first
+      // failure is always reported, however quiet the debug flags are: a
+      // permission-denied here (rules not deployed) is otherwise undetectable.
+      if (!this.reportedPublishFailure) {
+        this.reportedPublishFailure = true;
+        console.warn('[Presence] Publish failed — other players will not see you:', error);
+        reportError(error, 'presence', { room: this.roomMapId });
+      } else if (DEBUG.MULTIPLAYER) {
+        console.warn('[Presence] Publish failed:', error);
+      }
       return false;
     }
   }

--- a/firebase/realtimeConfig.ts
+++ b/firebase/realtimeConfig.ts
@@ -18,6 +18,7 @@ import { getFirebaseApp, isFirebaseInitialized } from './config';
 
 let rtdb: Database | null = null;
 let initAttempted = false;
+let loggedUnconfigured = false;
 
 /**
  * True when a database URL is configured. Presence is optional: the game is
@@ -30,23 +31,36 @@ export function isRealtimeConfigured(): boolean {
 /**
  * Get the Realtime Database instance, or null when unavailable.
  * Safe to call repeatedly; initialisation happens once.
+ *
+ * The "not initialised yet" case must NOT be cached. getRealtimeDb() is first
+ * called the moment the player steps onto a shared map, which can easily be
+ * before initializeFirebase() has resolved — and latching a null then killed
+ * presence for the rest of the session, with no log to say why. Only a real
+ * getDatabase() attempt is allowed to be final.
  */
 export function getRealtimeDb(): Database | null {
   if (rtdb) return rtdb;
-  if (initAttempted) return null;
-  initAttempted = true;
 
-  if (!isFirebaseInitialized() || !isRealtimeConfigured()) {
-    console.log('[Presence] Realtime Database not configured — multiplayer disabled');
+  if (!isRealtimeConfigured()) {
+    if (!loggedUnconfigured) {
+      loggedUnconfigured = true;
+      console.log('[Presence] Realtime Database not configured - multiplayer disabled');
+    }
     return null;
   }
+
+  // Firebase itself is still starting up. Transient: try again next call.
+  if (!isFirebaseInitialized()) return null;
+
+  if (initAttempted) return null;
+  initAttempted = true;
 
   try {
     rtdb = getDatabase(getFirebaseApp(), import.meta.env.VITE_FIREBASE_DATABASE_URL);
     console.log('[Presence] Realtime Database ready');
     return rtdb;
   } catch (error) {
-    console.warn('[Presence] Realtime Database init failed — multiplayer disabled', error);
+    console.warn('[Presence] Realtime Database init failed - multiplayer disabled', error);
     return null;
   }
 }
@@ -55,4 +69,5 @@ export function getRealtimeDb(): Database | null {
 export function resetRealtimeDbForTests(): void {
   rtdb = null;
   initAttempted = false;
+  loggedUnconfigured = false;
 }

--- a/firebase/safe.ts
+++ b/firebase/safe.ts
@@ -12,6 +12,7 @@
 // Re-export types that don't need the package at runtime
 export type { AuthState } from './authService';
 import type { PresenceEvent, LocalPresenceState } from '../multiplayer/types';
+import type { PresenceStatus } from '../multiplayer/presenceStatus';
 
 /** Stub authService when Firebase is not available */
 const stubAuthService = {
@@ -113,6 +114,12 @@ const stubCommunityGardenService = {
  */
 const stubPresenceService = {
   isAvailable: () => false,
+  getStatus: (): PresenceStatus => ({
+    available: false,
+    reason: 'firebase-not-initialised',
+    uid: null,
+    room: null,
+  }),
   getUid: () => null as string | null,
   getCurrentRoom: () => null as string | null,
   onPresence: (_cb: (event: PresenceEvent) => void) => () => {},
@@ -139,19 +146,40 @@ const stubInitializeFirebase = async () => null;
 
 // Cache the loaded module
 let firebaseModule: typeof import('./index') | null = null;
-let loadAttempted = false;
+let loadPromise: Promise<typeof import('./index') | null> | null = null;
+let initPromise: Promise<Awaited<
+  ReturnType<typeof import('./index').initializeFirebase>
+> | null> | null = null;
 
-/** Try to load the real Firebase module */
+/**
+ * Try to load the real Firebase module.
+ *
+ * The in-flight *promise* is what gets shared, not a "we already started"
+ * boolean. That distinction was a production outage: a boolean made the second
+ * concurrent caller return the module variable while it was still null, so
+ * safeInitializeFirebase() saw "no Firebase" and returned without a word —
+ * initializeFirebase() was never called, and for the rest of the session
+ * signing in threw "Firebase not initialized", cloud saves were off and
+ * multiplayer was invisible. Whether it happened at all came down to which of
+ * the two startup callers won a race against a chunk download.
+ */
 async function loadFirebase(): Promise<typeof import('./index') | null> {
-  if (loadAttempted) return firebaseModule;
-  loadAttempted = true;
-  try {
-    firebaseModule = await import('./index');
-    return firebaseModule;
-  } catch {
-    console.log('[Firebase] Package not installed - cloud saves disabled');
-    return null;
+  if (firebaseModule) return firebaseModule;
+
+  if (!loadPromise) {
+    loadPromise = import('./index')
+      .then((mod) => {
+        firebaseModule = mod;
+        return mod;
+      })
+      .catch(() => {
+        console.log('[Firebase] Package not installed - cloud saves disabled');
+        loadPromise = null; // a chunk that failed to download may succeed later
+        return null;
+      });
   }
+
+  return loadPromise;
 }
 
 /**
@@ -175,23 +203,39 @@ export function getSharedDataService() {
  * Returns null if Firebase is not available or not configured.
  */
 export async function safeInitializeFirebase() {
-  const mod = await loadFirebase();
-  if (!mod) return null;
+  // Memoised so concurrent callers share one initialisation rather than racing
+  // to call authService.initialize() twice. A *failed* attempt is not cached:
+  // pressing "Sign in" after a first-load failure has to be able to retry, and
+  // before this it could not — the account screen just kept saying
+  // "Firebase not initialized" for the rest of the session.
+  if (!initPromise) {
+    initPromise = (async () => {
+      const mod = await loadFirebase();
+      if (!mod) return null;
 
-  try {
-    const result = await mod.initializeFirebase();
-    if (result) {
-      mod.authService.initialize();
-      mod.syncManager.initialize();
-      console.log('[App] Firebase, auth, and sync manager initialized');
-    } else {
-      console.log('[App] Firebase not configured or disabled - cloud saves disabled');
-    }
-    return result;
-  } catch (error) {
-    console.log('[App] Firebase initialization failed - continuing without cloud saves');
-    return null;
+      try {
+        const result = await mod.initializeFirebase();
+        if (result) {
+          mod.authService.initialize();
+          mod.syncManager.initialize();
+          console.log('[App] Firebase, auth, and sync manager initialized');
+        } else {
+          console.log('[App] Firebase not configured or disabled - cloud saves disabled');
+        }
+        return result;
+      } catch (error) {
+        console.warn(
+          '[App] Firebase initialization failed - continuing without cloud saves',
+          error
+        );
+        return null;
+      }
+    })().then((result) => {
+      if (!result) initPromise = null; // allow a retry
+      return result;
+    });
   }
+  return initPromise;
 }
 
 /**
@@ -249,6 +293,10 @@ export function isFirebaseLoaded(): boolean {
  * service. Idempotent: the underlying load runs at most once.
  */
 export async function whenFirebaseSettled(): Promise<boolean> {
-  await loadFirebase();
+  // Awaiting only the *import* was not enough: presence asks whether the
+  // Realtime Database is up the instant the player steps onto a shared map,
+  // and initializeFirebase() may still have been in flight — so multiplayer
+  // read "unavailable" and stayed that way. Wait for real initialisation.
+  await safeInitializeFirebase();
   return firebaseModule !== null;
 }

--- a/hooks/useMultiplayerController.ts
+++ b/hooks/useMultiplayerController.ts
@@ -23,6 +23,8 @@ import { remotePlayerManager } from '../multiplayer/RemotePlayerManager';
 import { shouldPublish } from '../multiplayer/publishPolicy';
 import { getLocalEmote, setLocalEmote, clearLocalEmote } from '../multiplayer/localEmote';
 import type { EmoteId } from '../multiplayer/emotes';
+import { PRESENCE_REASON_TEXT } from '../multiplayer/presenceStatus';
+import type { PresenceUnavailableReason } from '../multiplayer/presenceStatus';
 import type { LocalPresenceState } from '../multiplayer/types';
 
 export interface UseMultiplayerControllerProps {
@@ -57,6 +59,28 @@ export interface UseMultiplayerControllerReturn {
 /** Presence only runs on maps players are meant to share. */
 function isSharedMap(mapId: string): boolean {
   return MULTIPLAYER.SHARED_MAPS.has(mapId);
+}
+
+/**
+ * Say — once per distinct situation, and regardless of debug flags — why the
+ * player is alone on a map where they expected company.
+ *
+ * Deliberately not gated behind DEBUG.MULTIPLAYER. The whole failure mode is
+ * that nothing happens and nothing is logged, which leaves two people staring
+ * at empty fields with no way to tell whether the problem is their account,
+ * the deploy, or the game.
+ */
+let lastPresenceNotice = '';
+function noticePresenceState(mapId: string, reason: PresenceUnavailableReason | null): void {
+  const notice = `${mapId}:${reason ?? 'ok'}`;
+  if (notice === lastPresenceNotice) return;
+  lastPresenceNotice = notice;
+
+  if (reason) {
+    console.warn(
+      `[Multiplayer] Other players will not appear on "${mapId}": ${PRESENCE_REASON_TEXT[reason]}.`
+    );
+  }
 }
 
 /**
@@ -146,7 +170,10 @@ export function useMultiplayerController(
 
       // A private map (home, personal garden, any RANDOM_* forest) or an
       // unavailable backend both mean the same thing: nobody to see here.
-      if (!isSharedMap(currentMapId) || !presence.isAvailable()) {
+      const status = presence.getStatus();
+      if (isSharedMap(currentMapId)) noticePresenceState(currentMapId, status.reason);
+
+      if (!isSharedMap(currentMapId) || !status.available) {
         await presence.leaveRoom();
         remotePlayerManager.setMap(null);
         if (!cancelled) {
@@ -169,8 +196,12 @@ export function useMultiplayerController(
 
       activeRef.current = joined;
       setIsActive(joined);
-      if (joined && DEBUG.MULTIPLAYER) {
-        console.log(`[Multiplayer] Presence active on "${currentMapId}"`);
+      if (joined) {
+        // One line per map, always on: the counterpart to the warning above, so
+        // a bug report can show presence working as well as failing.
+        console.log(`[Multiplayer] Presence active on "${currentMapId}" as ${status.uid}`);
+      } else {
+        console.warn(`[Multiplayer] Could not join the presence room for "${currentMapId}"`);
       }
     };
 

--- a/multiplayer/presenceStatus.ts
+++ b/multiplayer/presenceStatus.ts
@@ -1,0 +1,36 @@
+/**
+ * Why presence is (or is not) running — pure, no Firebase imports.
+ *
+ * Presence failing is invisible by design: you simply never see anybody, and
+ * the game plays exactly as it does single-player. That makes "we are both
+ * online and cannot see each other" undebuggable unless every path that
+ * switches presence off can say so out loud, in words a player can act on.
+ *
+ * Kept out of firebase/presenceService.ts so the controller (and anything else
+ * that only needs to *explain* the state) can import it without pulling in the
+ * Realtime Database SDK — the same reason wire.ts lives here.
+ */
+
+export type PresenceUnavailableReason =
+  | 'firebase-not-initialised'
+  | 'no-database-url'
+  | 'database-init-failed'
+  | 'signed-out';
+
+export interface PresenceStatus {
+  available: boolean;
+  reason: PresenceUnavailableReason | null;
+  /** Our own uid, when signed in — two players sharing one account share a record */
+  uid: string | null;
+  /** The presence room currently joined, if any */
+  room: string | null;
+}
+
+/** Human-readable, actionable explanation for each reason. */
+export const PRESENCE_REASON_TEXT: Record<PresenceUnavailableReason, string> = {
+  'firebase-not-initialised':
+    'Firebase has not finished starting up (or failed to start) in this browser',
+  'no-database-url': 'no Realtime Database URL was set in this build',
+  'database-init-failed': 'the Realtime Database could not be opened',
+  'signed-out': 'you are not signed in — press F1, open Settings and sign in (or play as guest)',
+};

--- a/tests/firebaseSafeStartup.test.ts
+++ b/tests/firebaseSafeStartup.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment node
+ *
+ * Startup has two independent callers into firebase/safe: the multiplayer
+ * controller (which asks whether presence can run the moment the app mounts)
+ * and gameInitializer (which actually initialises Firebase). They race.
+ *
+ * In production the loser of that race got a null module back — loadFirebase()
+ * shared a "load already started" boolean rather than the in-flight promise —
+ * so safeInitializeFirebase() returned early and silently. initializeFirebase()
+ * was never called: signing in threw "Firebase not initialized", cloud saves
+ * were off, and multiplayer was invisible to both players.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+const calls = { initializeFirebase: 0, authInitialize: 0 };
+
+vi.mock('../firebase/index', () => ({
+  initializeFirebase: async () => {
+    calls.initializeFirebase += 1;
+    return { app: {}, auth: {}, db: {} };
+  },
+  authService: {
+    initialize: () => {
+      calls.authInitialize += 1;
+    },
+  },
+  syncManager: { initialize: () => {} },
+  presenceService: {},
+  sharedDataService: {},
+  cloudSaveService: {},
+  communityGardenService: {},
+  paintingStorageService: {},
+}));
+
+describe('firebase/safe startup', () => {
+  it('still initialises Firebase when another caller started the module load first', async () => {
+    const { whenFirebaseSettled, safeInitializeFirebase, isFirebaseLoaded } = await import(
+      '../firebase/safe'
+    );
+
+    // Presence asks first; the game initialiser follows in the same tick, while
+    // the dynamic import is still in flight.
+    const settled = whenFirebaseSettled();
+    const result = await safeInitializeFirebase();
+    await settled;
+
+    expect(
+      calls.initializeFirebase,
+      'safeInitializeFirebase() must wait for the in-flight module load rather than ' +
+        'bailing out with a null module — otherwise Firebase is never initialised and ' +
+        'sign-in, cloud saves and multiplayer are all dead for the session.'
+    ).toBe(1);
+    expect(result).not.toBeNull();
+    expect(calls.authInitialize).toBe(1);
+    expect(isFirebaseLoaded()).toBe(true);
+  });
+
+  it('shares one initialisation between concurrent callers', async () => {
+    const { safeInitializeFirebase } = await import('../firebase/safe');
+    await Promise.all([safeInitializeFirebase(), safeInitializeFirebase()]);
+    expect(calls.initializeFirebase).toBe(1);
+  });
+});

--- a/tests/presenceAvailability.test.ts
+++ b/tests/presenceAvailability.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment node
+ *
+ * Presence is silent when it fails — you simply never see anybody — so the
+ * ways it can switch itself off permanently are worth pinning down.
+ *
+ * The regression this guards: getRealtimeDb() cached "unavailable" the first
+ * time it was called, and the first call happens the moment the player steps
+ * onto a shared map — which can easily be before initializeFirebase() has
+ * resolved. One early call therefore killed multiplayer for the whole session,
+ * with no log to say why.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const firebaseState = { initialised: false };
+
+vi.mock('../firebase/config', () => ({
+  isFirebaseInitialized: () => firebaseState.initialised,
+  getFirebaseApp: () => ({ name: 'test-app' }),
+}));
+
+vi.mock('firebase/database', () => ({
+  getDatabase: () => ({ name: 'test-db' }),
+}));
+
+import {
+  getRealtimeDb,
+  isRealtimeConfigured,
+  resetRealtimeDbForTests,
+} from '../firebase/realtimeConfig';
+
+describe('realtime database availability', () => {
+  beforeEach(() => {
+    resetRealtimeDbForTests();
+    firebaseState.initialised = false;
+    vi.stubEnv(
+      'VITE_FIREBASE_DATABASE_URL',
+      'https://example-default-rtdb.europe-west1.firebasedatabase.app'
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    resetRealtimeDbForTests();
+  });
+
+  it('retries once Firebase has initialised, instead of latching on the early null', () => {
+    // Called too early (shared map reached before Firebase finished starting).
+    expect(getRealtimeDb()).toBeNull();
+
+    firebaseState.initialised = true;
+
+    expect(
+      getRealtimeDb(),
+      'getRealtimeDb() must not cache the "Firebase not ready yet" answer — ' +
+        'doing so disables multiplayer for the rest of the session.'
+    ).not.toBeNull();
+  });
+
+  it('reuses the same instance once opened', () => {
+    firebaseState.initialised = true;
+    expect(getRealtimeDb()).toBe(getRealtimeDb());
+  });
+
+  it('stays unavailable when no database URL is configured', () => {
+    vi.stubEnv('VITE_FIREBASE_DATABASE_URL', '');
+    firebaseState.initialised = true;
+    expect(isRealtimeConfigured()).toBe(false);
+    expect(getRealtimeDb()).toBeNull();
+  });
+});

--- a/utils/errorReporting.ts
+++ b/utils/errorReporting.ts
@@ -60,7 +60,7 @@ export const onUncaughtError = Sentry.reactErrorHandler();
 export const onRecoverableError = Sentry.reactErrorHandler();
 
 /** Broad categories used to filter/group errors in the Sentry dashboard. */
-export type ErrorReportCategory = 'auth' | 'sync' | 'shared_farm' | 'game_crash';
+export type ErrorReportCategory = 'auth' | 'sync' | 'shared_farm' | 'presence' | 'game_crash';
 
 /**
  * Report a caught error. Safe no-op when Sentry isn't configured or hasn't


### PR DESCRIPTION
## The bug

Signing in failed with **"Firebase not initialized - call initializeFirebase() first"**, cloud saves were off, the shared farm fell back to local-only and multiplayer was invisible — for one player at a time, seemingly at random.

`loadFirebase()` in `firebase/safe.ts` shared a *"load already started"* boolean rather than the in-flight promise. Two callers race at startup:

1. `useMultiplayerController` calls `whenFirebaseSettled()` the moment the app mounts, which starts the ~200 KB Firebase chunk download.
2. `initializeGameAssets` then calls `safeInitializeFirebase()` → `loadFirebase()` sees the flag set and returns the module variable **while it is still `null`** → `if (!mod) return null` → returns early and silently.

`initializeFirebase()` is therefore never called, `auth` stays null, and every auth path throws for the rest of the session. Whether you hit it comes down to who wins a race against a chunk download — which is why one player could sign in and the other could not.

## Verification

Confirmed against the deployed build (headless Chrome on the live site), not inferred:

- A full session logs **none** of the four possible outcomes of `safeInitializeFirebase()`, yet startup marches straight past it into `[GlobalEventManager] Initialised`.
- Followed by `[SharedFarm] Firebase not available — running in local-only mode`.
- The API key, project and RTDB URL are all correctly baked into the deployed chunks — the config was never the problem. `[Presence] Realtime Database not configured` is the `isFirebaseInitialized()` branch of that condition, not the missing-URL one.

Introduced by 9672e0e, which added the early `whenFirebaseSettled()` call that now races startup.

## Changes

- `loadFirebase()` shares the in-flight promise; a failed chunk download can be retried rather than latching.
- `getRealtimeDb()` no longer caches "unavailable" when called before Firebase has initialised. Same class of bug and independently fatal — it kept presence dead for the whole session even once Firebase came up.
- `whenFirebaseSettled()` waits for real initialisation, not just the module import. `safeInitializeFirebase()` is memoised, but a *failure* is not, so the sign-in / guest / Google buttons — which now retry it — can recover a bad startup instead of being dead for the session.
- Presence now says why it is off, once per map and regardless of debug flags (`[Multiplayer] Other players will not appear on "farm_area": …`), and logs a confirmation line when it works.
- Publish failures (e.g. a permission-denied from undeployed RTDB rules) and Firebase init failures now reach Sentry under a new `presence` category. Previously both were silent.
- `?debug=multiplayer` (or `localStorage.twilight_debug`) enables full presence logging in a deployed build. `DEBUG.MULTIPLAYER` was `import.meta.env.DEV && false` — dead code.

## Tests

- `tests/firebaseSafeStartup.test.ts` reproduces the race. Checked that it fails on the old `loadFirebase()` (`expected +0 to be 1`) before passing on the fix.
- `tests/presenceAvailability.test.ts` pins the `getRealtimeDb()` latch.

726 tests pass; typecheck and lint clean.

> Note: this branch is cut from `furniture-actions-and-item-menu`, so it carries the two commits ahead of `main` that had not been PR'd yet (furniture/item actions, and the dead-code removal). Happy to re-target if you'd rather land those separately first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh8xj7NRhaxSGEMCunnqLY

---

## Also in this PR: a `debug-production` skill

Added in a second commit, since it is the direct product of the investigation above.

`.claude/skills/debug-production/` — a project skill (so it ships to everyone in the repo, not one person's `~/.claude`) for bugs that only happen in the deployed build:

- **`scripts/probe-live.mjs`** — loads the live site in headless Chrome, deduplicates the console, and checks a list of startup markers. The *missing* marker is the find: a step that returns without logging leaves no exception and no Sentry event, so the only trace is a line that never appeared. It still reports the two Firebase markers missing today, as it should until this PR deploys.
- **`scripts/fetch-bundle.sh`** — downloads the deployed chunks. Vite inlines every `VITE_*` at build time, so the bundle is the only place that says whether a secret was really set — and an inlined truthy value collapses a two-clause condition to one, which is how `[Presence] Realtime Database not configured` ended up naming the wrong cause.
- **`resources/case-firebase-init-race.md`** — the bug written up, including the theories that were wrong (blocked IndexedDB, missing secret, shared account). Those were the expensive part.

Also adds the skill to the table in `CLAUDE.md`.
