### PR TITLE
Stop main's deploy cancelling verify on every open PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,18 @@ permissions:
   pages: write
   id-token: write
 
-# Allow one concurrent deployment
+# Allow one concurrent run per ref.
+#
+# The group MUST stay ref-scoped. It used to be a single global "pages" group, which meant
+# merging anything to main started main's deploy and cancelled the in-flight run on every
+# open PR — killing the `verify` job below mid-`npm ci`. GitHub reports that cancellation as
+# a failed check, indistinguishable at a glance from a real test failure, so PRs looked
+# broken when nothing was wrong with them.
+#
+# Only main deploys (build and deploy are gated on github.event_name != 'pull_request'), so
+# scoping by ref still serialises the actual Pages deployments against each other.
 concurrency:
-  group: "pages"
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## The problem

`deploy.yml` used a single global concurrency group:

```yaml
concurrency:
  group: "pages"
  cancel-in-progress: true
```

That group is not scoped by ref, and the `verify` job lives in this same workflow. So merging anything to `main` started main's deploy and cancelled the in-flight run on **every open PR**, killing `verify` partway through `npm ci` — before a single test ran.

GitHub reports that cancellation as a **failed check**. It is indistinguishable at a glance from a real test failure. The only tell is in the log: it ends with `##[error]The operation was canceled` after ~55s of install, with no test output at all.

This is not hypothetical — it happened to #60 an hour ago. Merging #59 turned #60 red; re-running the identical commit passed with no changes.

## The fix

Scope the group to the ref. `build` (line 67) and `deploy` (line 110) are both gated on `github.event_name != 'pull_request'`, so `main` remains the only ref that ever deploys, and real Pages deployments are still serialised against each other. Only the false cancellation of PR checks goes away.

`performance.yml` already did this correctly (`group: perf-${{ github.ref }}`), which is why its check survived while `verify` did not.

## Testing

CI on this PR exercises the change directly — it runs `verify` under the new group. Beyond that the change is declarative workflow config with no runtime surface, so there is nothing to unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYuoCXdvGFXa4p2AZcemuS