### PR TITLE
Make production Sentry traces readable, attributable and less noisy

### DIFF
--- a/.claude/skills/debug-production/SKILL.md
+++ b/.claude/skills/debug-production/SKILL.md
@@ -64,8 +64,39 @@ mid-session shows `✔ Connected` while no `mcp__sentry__*` tool exists yet. If
 steps 2 and 3 — they need a fresh session, and waiting for one is rarely worth
 it when the deployed build is right there to interrogate.
 
+**This project's Sentry coordinates** — pass these to every `mcp__sentry__*`
+call rather than rediscovering them:
+
+| Parameter | Value |
+|---|---|
+| `organizationSlug` | `twilightgame` |
+| `projectSlug` | `javascript-react` |
+| `regionUrl` | `https://de.sentry.io` |
+
+The org is on Sentry's **EU region**. Omitting `regionUrl` can return empty
+results or fail outright, which reads exactly like "no errors reported" — do
+not mistake a missing region for an all-clear. The web dashboard is at
+`https://twilightgame.sentry.io`.
+
 Then look for issues in the relevant category tag — `auth`, `sync`,
 `shared_farm`, `presence`, `game_crash` — around the time of the report.
+
+Useful calls, in the order they usually pay off:
+
+```
+search_issues(organizationSlug='twilightgame', regionUrl='https://de.sentry.io',
+              query='is:unresolved', period='24h')       # what is broken now
+get_sentry_resource(resourceType='issue', organizationSlug='twilightgame',
+                    resourceId='JAVASCRIPT-REACT-4')     # full detail on one
+analyze_issue_with_seer(...)                             # only when stuck
+```
+
+`get_sentry_resource` is the one worth reaching for: a single call returns the
+stack trace, the `category` tag, the `details` context passed to
+`reportError()`, the player's browser/OS/locale/geo, and the **`release` tag**
+(the git SHA). Check that SHA with `git branch --contains <sha>` before
+debugging — the deployed build is often behind the fix already sitting on a
+branch, and the answer is "merge it", not "investigate it".
 
 **An empty Sentry is not an all-clear.** Nothing is reported when a function
 returns `null` instead of throwing. Treat silence as "not this kind of bug yet"

--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,18 @@ VITE_FIREBASE_DATABASE_URL=https://twiightgame-default-rtdb.europe-west1.firebas
 
 # VITE_SENTRY_DSN=your-dsn-here
 
+# Source-map upload — optional, and only affects production builds.
+# Without it Sentry stack traces are minified (`Ri()`, `wW()`) and decoding
+# them means fetching and grepping the deployed bundle by hand.
+# 1. Sentry → Settings → Auth Tokens → create one with `project:releases` scope
+# 2. Put it here for local production builds, and add the same value as a
+#    SENTRY_AUTH_TOKEN GitHub Actions secret for deploys
+# NOTE: no VITE_ prefix, deliberately. This token can write to the Sentry org,
+# and a VITE_ name would embed it in the public browser bundle. Leave unset to
+# skip upload entirely — the build works exactly as before.
+
+# SENTRY_AUTH_TOKEN=your-auth-token-here
+
 # ============================================
 # Game Testing
 # ============================================

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,6 +96,12 @@ jobs:
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           # Tags Sentry errors with the commit that shipped them.
           VITE_APP_VERSION: ${{ github.sha }}
+          # Uploads source maps so production stack traces are readable rather
+          # than minified. NOT public and deliberately un-prefixed: a VITE_ name
+          # would embed this write-capable token in the browser bundle. Unset
+          # until the SENTRY_AUTH_TOKEN secret is added — vite.config.ts leaves
+          # the plugin out entirely without it, so the build still succeeds.
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: npm run build
 
       - name: Setup Pages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,9 @@ When implementing new features:
 - `make preview` - Preview production build
 - `make optimize-assets` - Optimise images using Sharp
 - `make verify` - **Typecheck + run all tests. Run this before calling any change done.**
+  CI's `verify` job additionally runs `npm run lint`, which fails on errors (warnings are
+  fine). If you added or moved files, run `npm run lint` too — a green `make verify` is not
+  the same gate.
 - `make typecheck` - Check TypeScript only
 - `make test` - Run all tests once
 - `make clean` - Remove build artifacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,13 @@ Remote error/crash reporting, so a real player's failed login or sync is visible
 
 **Status:** Silently disabled when `VITE_SENTRY_DSN` is unset — same no-op pattern as Firebase above.
 
-**Key file:** `utils/errorReporting.ts` (uses `@sentry/react`) — `initErrorReporting()` (called once in `index.tsx`), `reportError(error, category, extra?)`, `reportMessage(message, category, extra?)`, plus `onUncaughtError`/`onRecoverableError` (React 19's `createRoot()` error hooks — wired in `index.tsx`). Categories: `'auth' | 'sync' | 'shared_farm' | 'presence' | 'game_crash'`.
+**Key file:** `utils/errorReporting.ts` (uses `@sentry/react`) — `initErrorReporting()` (called once in `index.tsx`), `reportError(error, category, extra?)`, `reportMessage(message, category, extra?)`, `setErrorReportingUser(uid)`, plus `onUncaughtError`/`onRecoverableError` (React 19's `createRoot()` error hooks — wired in `index.tsx`). Categories: `'auth' | 'sync' | 'shared_farm' | 'presence' | 'game_crash'`.
+
+**Reading errors back:** query the **Sentry MCP server** — the DSN is write-only ingest and cannot read issues. Org `twilightgame`, project `javascript-react`, and note the org is on the **EU region**, so pass `regionUrl: 'https://de.sentry.io'`; omitting it can return empty results that look exactly like "no errors reported". The `debug-production` skill covers the full workflow.
+
+**Player identity:** `setErrorReportingUser()` is called from `firebase/authService.ts`'s `notifyListeners()` — the one place every auth change funnels through — so Sentry can answer "how many distinct players hit this" rather than reporting `Users Impacted: 0` for everything. **Only the Firebase uid is sent**; never email, display name or character name, and `sendDefaultPii` stays off (it would attach IP addresses). This is a children's game — keep it that way when adding context.
+
+**Noise filtering:** `ignoreErrors: [/AbortError/]` drops fetch cancellations, which are normal on navigation and map transitions. They were 85 of the first 87 events ever reported here, across 3 issues with 0 users impacted, and buried a real auth bug underneath.
 
 **Wired into:** `components/ErrorBoundary.tsx` (`componentDidCatch`), `index.tsx` (`onUncaughtError`/`onRecoverableError` — NOT `onCaughtError`, which would double-report what ErrorBoundary already catches), `components/HelpBrowser.tsx` (auth actions), `firebase/syncManager.ts` (`uploadToCloud`/`downloadFromCloud`/`getCloudSyncMeta` — reported once at the source, not at every caller, since multiple call sites funnel through the same methods), `utils/farmManager.ts` (aggregate shared-farm write failures per flush, not per-plot).
 
@@ -56,7 +62,9 @@ Remote error/crash reporting, so a real player's failed login or sync is visible
 
 **Setup:** Sign up at sentry.io (free tier), create a React project, copy the DSN into `.env.local` as `VITE_SENTRY_DSN`. For production, add the same value as a `VITE_SENTRY_DSN` GitHub Actions secret (see `.github/workflows/deploy.yml`, which passes it through the build the same way Firebase secrets are, plus `VITE_APP_VERSION` set to `github.sha` so errors can be traced back to the deploy that shipped them).
 
-**Not set up:** source map upload (`@sentry/vite-plugin` + a Sentry auth token) — without it, stack traces in the dashboard show minified names from the production bundle rather than real source lines. Worth adding if the minified traces turn out to be too hard to debug from.
+**Source maps:** wired in `vite.config.ts` via `@sentry/vite-plugin`, so production traces show real file and line numbers instead of minified `Ri()`/`wW()`. It is **opt-in on `SENTRY_AUTH_TOKEN`** — unset, the plugin is omitted entirely and the build behaves as before (forks and contributors are unaffected). Three things to preserve, each guarded by `tests/sentryBuildConfig.test.ts` because each fails silently: the plugin `release` must match the SDK's (both `VITE_APP_VERSION`) or maps never associate with events; `url` must stay `https://de.sentry.io` (EU region — the US default uploads to the wrong place without erroring); and the token must **never** gain a `VITE_` prefix, which would inline an org-write-capable secret into the public bundle. Maps are deleted after upload (`filesToDeleteAfterUpload`) since GitHub Pages serves everything in `dist/`.
+
+**Setup for source maps:** Sentry → Settings → Auth Tokens → new token with `project:releases` scope → add as a `SENTRY_AUTH_TOKEN` GitHub Actions secret (and optionally `.env.local` for local production builds).
 
 ## Multiplayer (Shared World)
 

--- a/firebase/authService.ts
+++ b/firebase/authService.ts
@@ -25,6 +25,7 @@ import {
 import { doc, setDoc, getDoc, serverTimestamp } from 'firebase/firestore';
 import { getFirebaseAuth, getFirebaseDb, isFirebaseInitialized } from './config';
 import { UserProfile, FIRESTORE_PATHS } from './types';
+import { setErrorReportingUser } from '../utils/errorReporting';
 
 // ============================================
 // Types
@@ -94,6 +95,11 @@ class AuthService {
 
   private notifyListeners(): void {
     const state = this.getState();
+    // Keep Sentry's idea of "who" in step with auth from the one place every
+    // state change funnels through, rather than at each call site — the same
+    // report-at-the-source rule syncManager follows. uid only; see
+    // setErrorReportingUser() for why nothing else is sent.
+    setErrorReportingUser(this.currentUser?.uid ?? null);
     this.listeners.forEach((cb) => cb(state));
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
+        "@sentry/vite-plugin": "^5.4.0",
         "@tailwindcss/vite": "^4.1.18",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
@@ -2800,6 +2801,238 @@
         "node": ">=18"
       }
     },
+    "node_modules/@sentry/bundler-plugins": {
+      "version": "10.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugins/-/bundler-plugins-10.73.0.tgz",
+      "integrity": "sha512-4X5m2hoqgKO6SxHR7MF9QnvxPNk0hwTJFixDJ/pzQGVM+C34j/rSabouBqd0M+ZdxFeAt/9kA5X0TyeceNo9YQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/cli": "^2.58.6",
+        "@sentry/core": "10.73.0",
+        "dotenv": "^17.4.2",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.6",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "rollup": ">=3.2.0",
+        "webpack": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.6.tgz",
+      "integrity": "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.6",
+        "@sentry/cli-linux-arm": "2.58.6",
+        "@sentry/cli-linux-arm64": "2.58.6",
+        "@sentry/cli-linux-i686": "2.58.6",
+        "@sentry/cli-linux-x64": "2.58.6",
+        "@sentry/cli-win32-arm64": "2.58.6",
+        "@sentry/cli-win32-i686": "2.58.6",
+        "@sentry/cli-win32-x64": "2.58.6"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz",
+      "integrity": "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==",
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz",
+      "integrity": "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz",
+      "integrity": "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz",
+      "integrity": "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz",
+      "integrity": "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz",
+      "integrity": "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz",
+      "integrity": "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz",
+      "integrity": "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@sentry/conventions": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
@@ -2874,6 +3107,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.4.0.tgz",
+      "integrity": "sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugins": "^10.64.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -5171,6 +5417,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -6345,6 +6604,24 @@
         "js-binary-schema-parser": "^2.0.3"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -6356,6 +6633,45 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -8907,6 +9223,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -9003,6 +9329,52 @@
       "dev": true,
       "engines": {
         "node": ">=v0.6.5"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -9370,6 +9742,33 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@sentry/vite-plugin": "^5.4.0",
     "@tailwindcss/vite": "^4.1.18",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",

--- a/tests/errorReporting.test.ts
+++ b/tests/errorReporting.test.ts
@@ -10,13 +10,15 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const { init, captureException, captureMessage, withScope, reactErrorHandler } = vi.hoisted(() => ({
-  init: vi.fn(),
-  captureException: vi.fn(),
-  captureMessage: vi.fn(),
-  withScope: vi.fn((cb: (scope: unknown) => void) => cb({ setTag: vi.fn(), setContext: vi.fn() })),
-  reactErrorHandler: vi.fn(() => vi.fn()),
-}));
+const { init, captureException, captureMessage, withScope, reactErrorHandler, setUser } =
+  vi.hoisted(() => ({
+    init: vi.fn(),
+    captureException: vi.fn(),
+    captureMessage: vi.fn(),
+    withScope: vi.fn((cb: (scope: unknown) => void) => cb({ setTag: vi.fn(), setContext: vi.fn() })),
+    reactErrorHandler: vi.fn(() => vi.fn()),
+    setUser: vi.fn(),
+  }));
 
 vi.mock('@sentry/react', () => ({
   init,
@@ -24,6 +26,7 @@ vi.mock('@sentry/react', () => ({
   captureMessage,
   withScope,
   reactErrorHandler,
+  setUser,
 }));
 
 vi.stubEnv('VITE_SENTRY_DSN', '');
@@ -33,6 +36,7 @@ import {
   initErrorReporting,
   reportError,
   reportMessage,
+  setErrorReportingUser,
 } from '../utils/errorReporting';
 
 describe('errorReporting — safe no-op without a DSN configured', () => {
@@ -40,6 +44,7 @@ describe('errorReporting — safe no-op without a DSN configured', () => {
     init.mockClear();
     captureException.mockClear();
     captureMessage.mockClear();
+    setUser.mockClear();
   });
 
   afterEach(() => {
@@ -68,5 +73,14 @@ describe('errorReporting — safe no-op without a DSN configured', () => {
 
   it('reportError() handles a non-Error value without throwing', () => {
     expect(() => reportError('a plain string rejection', 'auth')).not.toThrow();
+  });
+
+  // authService calls this on every auth state change, including the very
+  // first one — which fires before initErrorReporting() has necessarily run,
+  // and always fires for players with no Firebase configured at all.
+  it('setErrorReportingUser() does not throw and never reaches Sentry.setUser', () => {
+    expect(() => setErrorReportingUser('abc123')).not.toThrow();
+    expect(() => setErrorReportingUser(null)).not.toThrow();
+    expect(setUser).not.toHaveBeenCalled();
   });
 });

--- a/tests/sentryBuildConfig.test.ts
+++ b/tests/sentryBuildConfig.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment node
+ *
+ * Build-time Sentry wiring. None of these mistakes are visible from playing
+ * the game — the build succeeds, the deploy succeeds, errors keep arriving.
+ * You only discover them at the exact moment you need a stack trace and find
+ * it still says `Ri()`, which is typically weeks later while debugging
+ * something real and urgent.
+ *
+ * Three things have to stay true, and each fails silently on its own:
+ *
+ *  1. The release name in vite.config.ts (stamped on the uploaded maps) must
+ *     match the one in utils/errorReporting.ts (stamped on the events). Maps
+ *     and events associate by release, so if these drift the upload works,
+ *     reports fine, and symbolicates nothing.
+ *  2. The upload must target Sentry's EU region. The org is on `de.sentry.io`;
+ *     omitting the URL uploads to the US instance instead, which does not
+ *     error — it just isn't where the events are. (Same trap the
+ *     debug-production skill documents for reading issues via MCP.)
+ *  3. The auth token must never gain a VITE_ prefix. Vite inlines every
+ *     VITE_-prefixed variable into the browser bundle, so that one rename
+ *     would publish an org-write-capable Sentry token to a public GitHub
+ *     Pages site.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = join(__dirname, '..');
+const read = (relativePath: string) => readFileSync(join(root, relativePath), 'utf-8');
+
+const viteConfig = read('vite.config.ts');
+const errorReporting = read('utils/errorReporting.ts');
+const deployWorkflow = read('.github/workflows/deploy.yml');
+const envExample = read('.env.example');
+
+describe('Sentry build configuration', () => {
+  it('stamps uploaded source maps with the same release the SDK reports', () => {
+    // Both sides must key off VITE_APP_VERSION (the deploy sets it to github.sha).
+    expect(errorReporting).toMatch(/release:\s*import\.meta\.env\.VITE_APP_VERSION/);
+    expect(viteConfig).toMatch(/release:\s*\{\s*name:\s*env\.VITE_APP_VERSION\s*\}/);
+  });
+
+  it('uploads source maps to the EU region the org actually lives on', () => {
+    expect(viteConfig).toContain('https://de.sentry.io');
+  });
+
+  it('deletes source maps after upload so they are not served publicly', () => {
+    // The game deploys to GitHub Pages; anything left in dist/ is world-readable.
+    expect(viteConfig).toContain('filesToDeleteAfterUpload');
+  });
+
+  it('never exposes the Sentry auth token to the browser bundle', () => {
+    // Vite inlines VITE_-prefixed vars into client JS. The token must stay
+    // build-only, so this name must not appear anywhere.
+    const offenders = [
+      ['vite.config.ts', viteConfig],
+      ['utils/errorReporting.ts', errorReporting],
+      ['.github/workflows/deploy.yml', deployWorkflow],
+      ['.env.example', envExample],
+    ].filter(([, contents]) => contents.includes('VITE_SENTRY_AUTH_TOKEN'));
+
+    expect(
+      offenders.map(([name]) => name),
+      'SENTRY_AUTH_TOKEN must never be VITE_-prefixed — Vite would embed this ' +
+        'org-write-capable token in the public browser bundle. Remove the VITE_ prefix.'
+    ).toEqual([]);
+  });
+
+  it('keeps source-map upload optional so a build without the token still works', () => {
+    // Contributors and forks have no SENTRY_AUTH_TOKEN; the plugin must be
+    // omitted rather than failing the build.
+    expect(viteConfig).toMatch(/uploadSourceMaps\s*\?/);
+    expect(viteConfig).toMatch(/sourcemap:\s*uploadSourceMaps/);
+  });
+
+  it('passes the auth token through the deploy workflow', () => {
+    expect(deployWorkflow).toMatch(
+      /SENTRY_AUTH_TOKEN:\s*\$\{\{\s*secrets\.SENTRY_AUTH_TOKEN\s*\}\}/
+    );
+  });
+});
+
+describe('Sentry event filtering', () => {
+  it('drops AbortError noise before it reaches the dashboard', () => {
+    // Fetch cancellation is normal during navigation and map transitions; these
+    // made up 85 of the first 87 events reported and buried a real auth bug.
+    expect(errorReporting).toMatch(/ignoreErrors:\s*\[[^\]]*AbortError/);
+  });
+});

--- a/utils/errorReporting.ts
+++ b/utils/errorReporting.ts
@@ -42,6 +42,15 @@ export function initErrorReporting(): void {
     // Unset locally (no CI to stamp it), which is fine — Sentry just omits it.
     release: import.meta.env.VITE_APP_VERSION,
     tracesSampleRate: 0, // Error tracking only — no performance/tracing overhead.
+    // Drop fetch cancellations. The browser throws AbortError whenever an
+    // in-flight request is cancelled — which happens normally every time a
+    // player navigates or a map transition supersedes an asset load. These
+    // accounted for 85 of the first 87 events ever reported here (3 separate
+    // issues, 0 users impacted, Sentry's own triage rating them "super_low"),
+    // burning quota and burying the one real bug underneath. Nothing is lost:
+    // a fetch failure that actually matters surfaces as the error thrown by
+    // the code that awaited it, with a real stack.
+    ignoreErrors: [/AbortError/],
   });
   initialised = true;
   console.log('[ErrorReporting] Sentry initialised');
@@ -58,6 +67,28 @@ export function initErrorReporting(): void {
  */
 export const onUncaughtError = Sentry.reactErrorHandler();
 export const onRecoverableError = Sentry.reactErrorHandler();
+
+/**
+ * Attach (or clear) the signed-in player's identity on reported errors.
+ *
+ * Without this every issue reads "Users Impacted: 0" even while real players
+ * are hitting it, because Sentry has no way to tell one browser from another.
+ * That makes the first triage question — "is this one player refreshing, or
+ * thirty players broken?" — unanswerable, which is exactly backwards.
+ *
+ * **Only the Firebase uid is sent.** Never email, display name or character
+ * name: this is a children's game, the uid is an opaque identifier that
+ * answers "how many distinct players" without describing any of them, and
+ * Sentry's own `sendDefaultPii` (which would attach IP addresses) is left off.
+ *
+ * Called from authService's notifyListeners() so it tracks every auth change
+ * from one place — sign-in, sign-out and anonymous upgrade alike. Safe no-op
+ * when Sentry isn't configured.
+ */
+export function setErrorReportingUser(uid: string | null): void {
+  if (!initialised) return;
+  Sentry.setUser(uid ? { id: uid } : null);
+}
 
 /** Broad categories used to filter/group errors in the Sentry dashboard. */
 export type ErrorReportCategory = 'auth' | 'sync' | 'shared_farm' | 'presence' | 'game_crash';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,21 @@ import path from 'path';
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import { sentryVitePlugin } from '@sentry/vite-plugin';
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, '.', '');
+
+  // Source-map upload is opt-in: without a token the plugin is left out
+  // entirely and the build behaves exactly as it did before. Set locally in
+  // .env.local, or in CI via the SENTRY_AUTH_TOKEN secret.
+  //
+  // Unlike VITE_SENTRY_DSN this token is NOT public — it can write to the
+  // Sentry org, so it must never be exposed with a VITE_ prefix (which would
+  // embed it in the browser bundle).
+  const sentryAuthToken = env.SENTRY_AUTH_TOKEN;
+  const uploadSourceMaps = Boolean(sentryAuthToken);
+
   return {
     base: '/TwilightGame/', // Set base path for GitHub Pages
     server: {
@@ -12,7 +24,42 @@ export default defineConfig(({ mode }) => {
       host: '0.0.0.0',
       hmr: true,
     },
-    plugins: [tailwindcss(), react()],
+    plugins: [
+      tailwindcss(),
+      react(),
+      // Uploads source maps so Sentry stack traces show real file names and
+      // line numbers instead of minified `Ri()` / `wW()`. Must come after the
+      // other plugins so it sees the final built output.
+      ...(uploadSourceMaps
+        ? [
+            sentryVitePlugin({
+              org: 'twilightgame',
+              project: 'javascript-react',
+              // The org lives on Sentry's EU region — omitting this uploads to
+              // the US instance, which silently succeeds against the wrong
+              // org and leaves traces minified with no error to explain why.
+              url: 'https://de.sentry.io',
+              authToken: sentryAuthToken,
+              // Must match the `release` passed to Sentry.init() in
+              // utils/errorReporting.ts, or uploaded maps never associate with
+              // the events they explain.
+              release: { name: env.VITE_APP_VERSION },
+              sourcemaps: {
+                // Delete the .map files once uploaded. The game deploys to
+                // GitHub Pages, so anything left in dist/ is world-readable —
+                // this keeps full source off the public site while Sentry
+                // still has what it needs to symbolicate.
+                filesToDeleteAfterUpload: ['./dist/**/*.js.map'],
+              },
+            }),
+          ]
+        : []),
+    ],
+    build: {
+      // Only generated when they will be uploaded and then deleted; a plain
+      // build stays map-free.
+      sourcemap: uploadSourceMaps,
+    },
     define: {
       'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
       'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),


### PR DESCRIPTION
Follow-ups from verifying the Sentry MCP server against real reported issues. Three gaps made the dashboard harder to act on than it should be.

## Source maps

Traces arrived minified (`Ri()`, `wW()`), so decoding one meant fetching and grepping the deployed bundle by hand — the whole of Step 3 in the `debug-production` skill.

Upload is **opt-in on `SENTRY_AUTH_TOKEN`**. Unset, the plugin is omitted entirely and the build behaves exactly as before, so forks and contributors are unaffected. Three details each fail *silently*, so `tests/sentryBuildConfig.test.ts` guards all of them:

- the plugin's `release` must match the SDK's (both `VITE_APP_VERSION`), or maps upload happily and associate with nothing
- the URL must stay `https://de.sentry.io` — the org is on the **EU region**, and the US default uploads to the wrong instance without erroring
- the token must never gain a `VITE_` prefix, which would inline an org-write-capable secret into a bundle served from public GitHub Pages

Maps are deleted after upload (`filesToDeleteAfterUpload`) for that same reason.

## Player identity

Every issue read **`Users Impacted: 0`** while real players were hitting it — Sentry had no way to tell one browser from another, making the first triage question (one player refreshing, or thirty players broken?) unanswerable.

`setErrorReportingUser()` is called from `authService.notifyListeners()`, the single point every auth change funnels through, so it can't be forgotten at a call site — the same report-at-the-source rule `syncManager` follows.

**Only the Firebase uid is sent.** No email, no display name, and `sendDefaultPii` stays off (it would attach IP addresses). This is a children's game; the uid answers "how many distinct players" without describing any of them.

## Noise

`AbortError` is what the browser throws when an in-flight request is cancelled — normal on navigation and map transitions. It was **85 of the first 87 events** ever reported here (3 issues, 0 users impacted, Sentry rating them `super_low`), burying a real auth bug underneath. A fetch failure that matters still surfaces as the error thrown by the code that awaited it.

## Verification

- `make verify` — **740 passed / 75 files**, 0 failed
- `npx eslint` — **0 errors** (278 pre-existing warnings)
- Build **without** token — succeeds, plugin omitted, `sourcemap=false`, no `.map` files in `dist/`
- Build **with** token — branch confirmed active (`sourcemap=true`, plugin loaded), checked by resolving the config rather than running a real upload

## Note

`SENTRY_AUTH_TOKEN` is already set as a repo secret, so source maps start uploading on the first deploy after this merges. Verify at https://twilightgame.sentry.io/releases/ — the release matching the merge SHA should list artifacts. If upload fails the build still succeeds (the plugin warns rather than breaking the deploy), so check the build log rather than assuming green means uploaded.

Still outstanding and not in this PR: connecting the GitHub repo under Sentry → Settings → Integrations, for suspect-commit suggestions and `Fixes SHORT-ID` auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYuoCXdvGFXa4p2AZcemuS