### PR TITLE
Explain why Sentry ignores the configured region URL

### DIFF
--- a/tests/sentryBuildConfig.test.ts
+++ b/tests/sentryBuildConfig.test.ts
@@ -16,7 +16,10 @@
  *  2. The upload must target Sentry's EU region. The org is on `de.sentry.io`;
  *     omitting the URL uploads to the US instance instead, which does not
  *     error — it just isn't where the events are. (Same trap the
- *     debug-production skill documents for reading issues via MCP.)
+ *     debug-production skill documents for reading issues via MCP.) An
+ *     organisation auth token embeds its own region and overrides this — the
+ *     build log says so — so it is a fallback for tokens that do not, not the
+ *     primary defence.
  *  3. The auth token must never gain a VITE_ prefix. Vite inlines every
  *     VITE_-prefixed variable into the browser bundle, so that one rename
  *     would publish an org-write-capable Sentry token to a public GitHub

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,9 +35,17 @@ export default defineConfig(({ mode }) => {
             sentryVitePlugin({
               org: 'twilightgame',
               project: 'javascript-react',
-              // The org lives on Sentry's EU region — omitting this uploads to
-              // the US instance, which silently succeeds against the wrong
-              // org and leaves traces minified with no error to explain why.
+              // The org lives on Sentry's EU region. Kept as a fallback for
+              // tokens that do not carry a region: without it such a token
+              // uploads to the US instance, which succeeds against the wrong
+              // org and leaves traces minified with nothing to explain why.
+              //
+              // Expect a WARN in the build log saying this value was ignored
+              // in favour of "https://sentry.io (embedded in token)". That is
+              // correct and not a misconfiguration: an organisation auth token
+              // (`sntrys_…`) embeds its own region and takes precedence, and
+              // routes to the EU org anyway. The warning only means the
+              // fallback was not needed.
               url: 'https://de.sentry.io',
               authToken: sentryAuthToken,
               // Must match the `release` passed to Sentry.init() in


### PR DESCRIPTION
The first deploy with source-map upload logged this:

```
WARN  Using https://sentry.io (embedded in token) rather than
      manually-configured URL https://de.sentry.io.
```

It reads like a misconfiguration and isn't one. An organisation auth token (`sntrys_…`) carries its own region and takes precedence over the plugin's `url` option, then routes to the EU org anyway — the release and its 10 uploaded artifacts landed in the right place.

The problem was the comment, which claimed that option is what stops uploads going to the wrong region. With a region-bearing token it does nothing, so it promised a guarantee the code wasn't providing — the kind of thing that costs someone an hour six months from now, either chasing the warning or trusting a safeguard that isn't there.

It's still worth keeping as a fallback for tokens that carry no region, which is what it now says it is. The test rationale in `tests/sentryBuildConfig.test.ts` is corrected to match.

**Comment and test-rationale only — no behaviour change.** 7 tests pass, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYuoCXdvGFXa4p2AZcemuS