### PR TITLE
Install gifsicle in CI so GIF optimisation reaches production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # scripts/optimize-assets.js runs as a prebuild step and pipes GIFs through
+      # gifsicle, falling back to copying them verbatim when it is absent. The
+      # runner had no gifsicle, so every deploy regenerated the GIFs uncompressed
+      # and overwrote the optimised files committed in the repo — the build warned
+      # about it in the log and shipped anyway. Without this the optimisation
+      # exists everywhere except the one place it matters.
+      - name: Install gifsicle
+        run: sudo apt-get update && sudo apt-get install -y gifsicle
+
       - name: Build
         env:
           # Firebase client config (public - embedded in browser JS)


### PR DESCRIPTION
`scripts/optimize-assets.js` runs as a prebuild step and pipes GIFs through gifsicle, falling back to copying them verbatim when it's absent. **The GitHub runner has no gifsicle**, so every deploy regenerated the GIFs uncompressed and overwrote the optimised files committed in the repo.

The build said so plainly and shipped anyway:

```
⚠️  gifsicle not found - GIFs will be copied without optimization
   ℹ️  bees.gif: 74.2KB (copied without optimization)
   ℹ️  fire/fire.gif: 200.6KB (copied without optimization)
```

## This is why #65 changed nothing

After #65 merged and deployed successfully on the correct SHA, the live assets were **still** 76,021 and 205,450 bytes — byte-for-byte what they were before. The committed files were never what got served; they're rebuilt on every deploy.

I'd claimed that PR took 187KB off the production game. It didn't. I'd checked the local files rather than the deployed bytes.

## The fix covers more than #65 did

Installing gifsicle on the runner fixes every GIF, not just the two that happened to be committed uncompressed:

| Asset | Currently shipped | Optimised |
|---|---|---|
| `bees.gif` | 74.2 KB | 30.9 KB |
| `fire/fire.gif` | 200.6 KB | 57.0 KB |
| `cherry_spring_petals.gif` | 33.9 KB | 12.7 KB |
| `dragonfly_stream.gif` | 46.0 KB | 20.9 KB |

`cherry_spring_petals` and `dragonfly_stream` were being inflated on every deploy too — they're correct in the repo, and have been re-inflated at build time all along.

## Verification

This one can't be confirmed from a green build — that's the mistake that produced #65. After merge, the check is the live bytes:

```bash
curl -s -o /dev/null -w "%{size_download}\n" \
  https://code.markedmondson.me/TwilightGame/assets-optimized/animations/bees.gif
```

Expect ~31,000, not 76,021. I'll run it and report the actual number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYuoCXdvGFXa4p2AZcemuS