### PR TITLE
Fix the debug-production probe's Firebase success marker

### DIFF
--- a/.claude/skills/debug-production/scripts/probe-live.mjs
+++ b/.claude/skills/debug-production/scripts/probe-live.mjs
@@ -31,7 +31,7 @@ const DEFAULT_URL = 'https://code.markedmondson.me/TwilightGame/';
 /** Each group must produce at least one matching line in a healthy startup. */
 const MARKERS = [
   { name: 'firebase module + config', pattern: /\[Firebase\] (App initialized|Not configured|Package not installed)/ },
-  { name: 'firebase init outcome', pattern: /\[App\] Firebase (, auth, and sync manager initialized|not configured or disabled|initialization failed)/ },
+  { name: 'firebase init outcome', pattern: /\[App\] Firebase(, auth, and sync manager initialized| not configured or disabled| initialization failed)/ },
   { name: 'presence transport', pattern: /\[Presence\] Realtime Database/ },
   { name: 'event chains', pattern: /\[App\] Initialised event chain system/ },
   { name: 'audio', pattern: /\[App\] Audio system initialised/ },


### PR DESCRIPTION
Follow-up to #61, found by using the skill to verify that #61 actually fixed production.

The startup-marker alternation in `probe-live.mjs` put the space outside the group:

```js
/\[App\] Firebase (, auth, and sync manager initialized|not configured or disabled|…)/
```

so the success branch matched `Firebase , auth, …` — a comma that is not in the log line. Only the two *failure* variants could ever match, and the probe reported `MISSING firebase init outcome` against a perfectly healthy build.

That is the one failure this script must not have. Its whole premise is that a missing marker means a startup step returned without logging, so a false MISSING sends the reader hunting for a bug that isn't there.

## Verified against production

With #61 deployed, the live site now logs what it should:

```
[Firebase] App initialized for project: twiightgame
[Firebase] Initialization complete
[App] Firebase, auth, and sync manager initialized
[Presence] Realtime Database ready          <- was "not configured" before
```

and the probe reports **all six markers ok**.

`[SharedFarm] Firebase not available` still appears in a headless run, correctly: `startListening()` also requires `authService.isAuthenticated()`, and the probe is not signed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh8xj7NRhaxSGEMCunnqLY