### PR TITLE
Make interiors fill the screen and follow the player (#26)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,7 +7,7 @@ import {
   TIMING,
   SHARED_FARM_MAP_IDS,
 } from './constants';
-import { Position, Direction, ImageRoomLayer, NPC, TileType } from './types';
+import { Position, Direction, NPC, TileType } from './types';
 import { usePixiRenderer } from './hooks/usePixiRenderer';
 import HUD from './components/HUD';
 import DebugOverlay from './components/DebugOverlay';
@@ -44,6 +44,11 @@ import { useUIState } from './hooks/useUIState';
 import { useGameEvents } from './hooks/useGameEvents';
 import { eventBus, GameEvent } from './utils/EventBus';
 import { calculateViewportScale, DEFAULT_REFERENCE_VIEWPORT } from './hooks/useViewportScale';
+import {
+  getRoomArtworkSize,
+  getRoomCoverScale,
+  getRoomPan,
+} from './utils/backgroundRoomLayout';
 import { DEFAULT_CHARACTER } from './utils/characterSprites';
 import { getPortraitSprite } from './utils/portraitSprites';
 import { handleDialogueAction } from './utils/dialogueHandlers';
@@ -1237,35 +1242,43 @@ const App: React.FC = () => {
       return 1.0; // No scaling for tiled maps
     }
 
-    // Get reference viewport from map definition, or use defaults
-    const refViewport = currentMap.referenceViewport ?? DEFAULT_REFERENCE_VIEWPORT;
-
     // Divide the browser-zoom factor back out of the viewport dimensions before
     // fitting. Browser zoom shrinks innerWidth/innerHeight (CSS px), which would
     // otherwise drag viewportScale toward its 1.0 floor and cancel the zoom on
     // large monitors — leaving the room image and character the only things that
     // don't magnify. Normalising here lets interiors zoom WITH the browser, like
     // tiled rooms do. See useBrowserZoom / docs/ARCHITECTURE_GOTCHAS.md.
-    //
-    // 'cover' (not the default 'contain'): at a viewport aspect ratio that
-    // doesn't match the reference, 'contain' fits the room fully on screen but
-    // leaves a letterboxed gap on one axis, showing the game's own background
-    // colour through it (issue #26). 'cover' scales to fill both axes instead,
-    // cropping whichever axis has the excess.
-    const rawScale = calculateViewportScale(
-      viewportSize.width * browserZoom,
-      viewportSize.height * browserZoom,
-      refViewport.width,
-      refViewport.height,
-      0.5, // minScale (absolute floor)
-      2.5, // maxScale - allow larger scaling for big monitors
-      'cover'
-    );
+    const fitWidth = viewportSize.width * browserZoom;
+    const fitHeight = viewportSize.height * browserZoom;
 
-    // Only scale UP on larger viewports, never scale down
-    // This ensures small screens still see the original design
+    // Scale so the ROOM ARTWORK covers the viewport, measured from the artwork
+    // itself rather than the map's declared `referenceViewport` (issue #26).
+    // The reference is an authoring hint and drifts from the real artwork —
+    // Mum's Kitchen is 960x540 at scale 1.3 = 1248x702 against a declared
+    // 1280x720 — and every bit of that 2.6% drift showed up on screen as the
+    // game's background colour around the room, at every window size.
+    // The `referenceViewport` path below survives only for a background-image
+    // room with no centred artwork to measure; no current map is one.
+    const artwork = getRoomArtworkSize(currentMap);
+    const refViewport = currentMap.referenceViewport ?? DEFAULT_REFERENCE_VIEWPORT;
+    const rawScale = artwork
+      ? getRoomCoverScale(artwork.width, artwork.height, fitWidth, fitHeight)
+      : calculateViewportScale(
+          fitWidth,
+          fitHeight,
+          refViewport.width,
+          refViewport.height,
+          0.5, // minScale (absolute floor)
+          2.5, // maxScale - allow larger scaling for big monitors
+          'cover'
+        );
+
+    // Only scale UP on larger viewports, never scale down, so small screens
+    // still see the room at its authored size (cropped, and panned to follow the
+    // player). Deliberately no upper clamp: capping the scale would reopen #26
+    // as a visible gap on a large monitor.
     return Math.max(1.0, rawScale);
-  }, [currentMap?.renderMode, currentMap?.referenceViewport, viewportSize, browserZoom]);
+  }, [currentMap, viewportSize, browserZoom]);
 
   // Memoize compact mode for touch controls to avoid synchronous DOM reads on every render
   const isCompactMode = useMemo(() => {
@@ -1273,77 +1286,64 @@ const App: React.FC = () => {
   }, [viewportSize.height]);
 
   // Calculate effective grid offset for centered background-image rooms
-  // This aligns the collision grid/player/NPCs with the centered background image
-  // Now incorporates viewport scaling for responsive rendering
+  // This aligns the collision grid/player/NPCs with the room artwork, and is the
+  // single value every consumer (PixiJS player/NPC/highlight layers, DOM
+  // overlays, click-to-tile) uses to place things in these rooms.
+  //
+  // How far the room artwork slides from dead centre to follow the player
+  // through whatever `cover` scaling cropped off (issue #26). Zero when the
+  // artwork's aspect ratio matches the window, so a 16:9 room in a 16:9 window
+  // doesn't move at all. Shared by effectiveGridOffset below (which positions
+  // everything drawn on top of the room) and BackgroundImageLayer (which
+  // positions the artwork itself) — they must use the same number or the room
+  // slides out from under its own collision grid.
+  const backgroundRoomPan = useMemo((): Position => {
+    const artwork = currentMap?.gridOffset ? null : getRoomArtworkSize(currentMap);
+    if (!artwork) return { x: 0, y: 0 };
+
+    return getRoomPan({
+      playerPos,
+      tileSize: TILE_SIZE * viewportScale * artwork.layerScale * zoom,
+      artworkWidth: artwork.width * viewportScale * zoom,
+      artworkHeight: artwork.height * viewportScale * zoom,
+      viewportWidth: viewportSize.width,
+      viewportHeight: viewportSize.height,
+    });
+  }, [currentMap, viewportScale, viewportSize, zoom, playerPos]);
+
   const effectiveGridOffset = useMemo((): Position | undefined => {
     if (!currentMap) return undefined;
 
     // Use explicit gridOffset if provided (not scaled - assume it's pre-calculated)
     if (currentMap.gridOffset) return currentMap.gridOffset;
 
-    // For background-image rooms, find centered image layer
-    if (currentMap.renderMode === 'background-image' && currentMap.layers) {
-      const centeredLayer = currentMap.layers.find(
-        (layer) => layer.type === 'image' && (layer as ImageRoomLayer).centered
-      ) as ImageRoomLayer | undefined;
+    const artwork = getRoomArtworkSize(currentMap);
+    if (!artwork) return undefined;
 
-      if (centeredLayer) {
-        // Get base image dimensions (use explicit or calculate from grid)
-        let imageWidth: number;
-        let imageHeight: number;
+    // Final on-screen artwork size: authored size x responsive scale x zoom.
+    // The PixiJS stage is scaled by zoom, so the artwork occupies this many
+    // screen pixels and screenToTile must invert the same number.
+    const artworkWidth = artwork.width * viewportScale * zoom;
+    const artworkHeight = artwork.height * viewportScale * zoom;
 
-        if (centeredLayer.width && centeredLayer.height) {
-          imageWidth = centeredLayer.width;
-          imageHeight = centeredLayer.height;
-        } else if (centeredLayer.useNativeSize) {
-          // For native size, we need to know the actual image dimensions
-          // For now, use map grid dimensions as fallback
-          imageWidth = currentMap.width * TILE_SIZE;
-          imageHeight = currentMap.height * TILE_SIZE;
-        } else {
-          imageWidth = currentMap.width * TILE_SIZE;
-          imageHeight = currentMap.height * TILE_SIZE;
-        }
-
-        // Apply layer scale if present
-        const layerScale = centeredLayer.scale ?? 1.0;
-        imageWidth *= layerScale;
-        imageHeight *= layerScale;
-
-        // Apply viewport scaling for responsive rendering
-        imageWidth *= viewportScale;
-        imageHeight *= viewportScale;
-
-        // Apply zoom — the PixiJS stage is scaled by zoom, so the centered
-        // image occupies (imageWidth * zoom) screen pixels.  The grid offset
-        // must reflect this so screenToTile can invert correctly.
-        imageWidth *= zoom;
-        imageHeight *= zoom;
-
-        // Use tracked viewport dimensions for centering (responds to resize/zoom)
-        const offsetX = (viewportSize.width - imageWidth) / 2;
-        const offsetY = (viewportSize.height - imageHeight) / 2;
-
-        return { x: offsetX, y: offsetY };
-      }
-    }
-
-    return undefined;
-  }, [currentMap, currentMapId, viewportScale, viewportSize, zoom]); // Recalculate when map, scale, or viewport changes
+    // Centre the artwork, then apply the pan. Without it the room stays pinned
+    // to the viewport centre and the player walks off the edge of the screen
+    // into artwork that is never drawn there.
+    return {
+      x: (viewportSize.width - artworkWidth) / 2 + backgroundRoomPan.x,
+      y: (viewportSize.height - artworkHeight) / 2 + backgroundRoomPan.y,
+    };
+  }, [currentMap, currentMapId, viewportScale, viewportSize, zoom, backgroundRoomPan]);
 
   // Calculate effective tile size for background-image rooms (scaled)
-  // Must include both viewport scale AND layer scale to match the background image
+  // Must include both viewport scale AND layer scale to match the room artwork
   const effectiveTileSize = useMemo((): number => {
-    if (currentMap?.renderMode === 'background-image' && currentMap.layers) {
-      // Find the centered image layer to get its scale
-      const centeredLayer = currentMap.layers.find(
-        (layer) => layer.type === 'image' && (layer as ImageRoomLayer).centered
-      ) as ImageRoomLayer | undefined;
-      const layerScale = centeredLayer?.scale ?? 1.0;
-      return TILE_SIZE * viewportScale * layerScale;
+    const artwork = getRoomArtworkSize(currentMap);
+    if (artwork) {
+      return TILE_SIZE * viewportScale * artwork.layerScale;
     }
     return TILE_SIZE;
-  }, [currentMap?.renderMode, currentMap?.layers, viewportScale]);
+  }, [currentMap, viewportScale]);
 
   // Use camera hook for positioning
   const { cameraX, cameraY } = useCamera({
@@ -1650,6 +1650,7 @@ const App: React.FC = () => {
       viewportSize,
       effectiveGridOffset: effectiveGridOffset ?? { x: 0, y: 0 },
       effectiveTileSize,
+      backgroundRoomPan,
       zoom,
     },
     player: {

--- a/docs/ARCHITECTURE_GOTCHAS.md
+++ b/docs/ARCHITECTURE_GOTCHAS.md
@@ -36,7 +36,7 @@ The game has **two fundamentally different** rendering pipelines:
 | | Standard tiled rooms | Background-image rooms |
 |---|---|---|
 | **Examples** | Village, forest, caves | Shop, cottage interior, Mum's kitchen |
-| **How it works** | PixiJS renders each tile, camera scrolls | Pre-drawn image centered in viewport |
+| **How it works** | PixiJS renders each tile, camera scrolls | Pre-drawn image scaled to cover the viewport, panned to follow the player |
 | **Coordinate conversion** | Uses `cameraX/Y` and `TILE_SIZE` | Uses `gridOffset` and `effectiveTileSize` |
 | **Map property** | `renderMode: undefined` or `'tiled'` | `renderMode: 'background-image'` |
 | **Zoom handling** | PixiJS stage.scale handles it | Must manually factor zoom into gridOffset |
@@ -47,8 +47,11 @@ The game has **two fundamentally different** rendering pipelines:
 
 ```
 imageWidth = baseWidth × layerScale × viewportScale × zoom
-offsetX = (viewportSize.width - imageWidth) / 2
+offsetX = (viewportSize.width - imageWidth) / 2 + pan.x
 ```
+
+(`pan` comes from `getRoomPan` — see "Maps not filling the screen" below. It is zero
+whenever the artwork's aspect ratio matches the window, which is the common case.)
 
 **Why zoom matters**: PixiJS `stage.scale.set(zoom)` scales the rendered image. At zoom=2, the image occupies twice the screen pixels. If `gridOffset` doesn't account for this, `screenToTile` produces coordinates that are offset by a factor of zoom — clicks land on the wrong tile.
 
@@ -64,6 +67,7 @@ The `effectiveGridOffset` useMemo must recalculate when ANY of these change:
 - `viewportScale` — responsive scaling
 - `viewportSize` — window resize
 - `zoom` — user zoom level
+- `playerPos` (via `backgroundRoomPan`) — the artwork pans to follow the player
 
 Missing `zoom` from the dependency array was part of the original bug — the offset was stale after zoom changes.
 
@@ -334,14 +338,33 @@ that didn't match the map/reference, the game's own background colour showed thr
   view with the player instead of it sitting static. The axis that determined `coverZoom` is an
   exact tie (zero pan room, by definition of "just barely covers") — only the other axis has
   slack to pan on; see [`tests/cameraCoverage.test.ts`](../tests/cameraCoverage.test.ts).
-- **Background-image rooms**: `calculateViewportScale` (`hooks/useViewportScale.ts`) now takes a
-  `fitMode: 'contain' | 'cover'` param (default stays `'contain'` — only `App.tsx`'s
-  `viewportScale` memo passes `'cover'`). These rooms still don't pan with the player — that's a
-  deliberate, larger follow-up left out of the initial fix (see `docs/ARCHITECTURE_GOTCHAS.md`
-  Common mistake #4 below; introducing panning here would touch the click-coordinate pipeline
-  this whole section is about, and needs live-browser verification).
+- **Background-image rooms**: two separate faults, both now in
+  [`utils/backgroundRoomLayout.ts`](../utils/backgroundRoomLayout.ts).
 
-Guarded by [`tests/mapFillsScreen.test.ts`](../tests/mapFillsScreen.test.ts) and
+  1. *The gap.* `calculateViewportScale` gained a `fitMode: 'cover'`, but was still fed the map's
+     declared `referenceViewport` — an authoring hint that drifts from the artwork it claims to
+     describe. Mum's Kitchen is 960×540 at `scale: 1.3` = **1248×702**, 2.6% short of its declared
+     **1280×720**, so `cover` filled a box 2.6% larger than the room at *every* window size and the
+     background colour showed through the difference on all four sides. `getRoomCoverScale` now
+     measures the artwork itself, so `referenceViewport` can no longer be wrong — it is no longer
+     consulted. (This is also why it looked fine on a small laptop and broken on a bigger screen:
+     below 1280×720 the `Math.max(1.0, …)` floor takes over and the artwork already exceeds the
+     window.) There is deliberately **no upper clamp** on the cover scale; the old `2.5` cap would
+     reopen the gap as a ~700px band on a 4K display, and upscaling a sprite costs sharpness, not
+     GPU memory.
+  2. *Walking off-screen.* Covering means cropping, and the crop used to be a static centre crop
+     with no camera — so the cropped strip was simply unreachable, and walking toward it took the
+     character off the screen. `getRoomPan` slides the artwork to follow the player, clamped at the
+     artwork's edges so it can never reopen the gap. It returns an **offset from centre**, not an
+     absolute origin, because a room can pair a background and foreground layer of different sizes:
+     each stays centred by its own size, and they all pan together. `App.tsx` folds it into
+     `effectiveGridOffset` (so player, NPCs, placed items, highlights, DOM overlays and
+     `screenToTile` all move as one) and passes it to `BackgroundImageLayer.setCenteredPan` (so the
+     artwork moves with them). **Those two must use the same number** — a mismatch slides the room
+     out from under its own collision grid.
+
+Guarded by [`tests/backgroundRoomLayout.test.ts`](../tests/backgroundRoomLayout.test.ts),
+[`tests/mapFillsScreen.test.ts`](../tests/mapFillsScreen.test.ts) and
 [`tests/cameraCoverage.test.ts`](../tests/cameraCoverage.test.ts).
 
 ### Common mistakes
@@ -349,12 +372,18 @@ Guarded by [`tests/mapFillsScreen.test.ts`](../tests/mapFillsScreen.test.ts) and
 1. **Forgetting zoom in gridOffset** — see Section 1
 2. **Placing NPCs using pixel coordinates** — NPCs use tile coordinates, not pixels
 3. **Testing only at zoom=1** — offset bugs only manifest when zoomed
-4. **Assuming camera works the same** — background-image rooms don't scroll or pan with the
-   player (unlike tiled rooms — see "Maps not filling the screen" above); camera is effectively fixed
+4. **Assuming camera works the same** — background-image rooms have no `cameraX/cameraY`; they
+   follow the player through `effectiveGridOffset` instead (see "Maps not filling the screen"
+   above). This used to say the camera was fixed for these rooms. It was, and that was the bug:
+   once the artwork is scaled to *cover* the window, a fixed camera lets the player walk into the
+   cropped strip and off the screen
 5. **Deriving interior sizes from raw `innerWidth`** — factor out browser zoom (see above) or interiors won't match tiled rooms
 6. **Using `calculateViewportScale`'s default (contain) when you actually need cover** — contain
    leaves a gap on the axis with room to spare; pass `fitMode: 'cover'` explicitly when the goal
    is to fill the viewport with no gaps, cropping overflow instead
+7. **Trusting `referenceViewport` to describe a room's artwork** — it is an authoring hint that
+   nothing validates, and most maps' copy of it is wrong by a couple of percent. Size from the
+   centred layer's own `width × height × scale` (`getRoomArtworkSize`)
 
 ---
 

--- a/hooks/usePixiRenderer.ts
+++ b/hooks/usePixiRenderer.ts
@@ -82,6 +82,13 @@ export interface UsePixiRendererProps {
     /** User zoom level (default 1.0) */
     zoom?: number;
     effectiveTileSize: number;
+    /**
+     * Background-image rooms only: how far the room artwork is offset from dead
+     * centre so the `cover` crop follows the player (issue #26). Already folded
+     * into effectiveGridOffset; passed separately because BackgroundImageLayer
+     * centres each layer by its own size and needs the offset, not the result.
+     */
+    backgroundRoomPan?: { x: number; y: number };
   };
 
   /** Player state */
@@ -203,6 +210,7 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
     viewportSize,
     effectiveGridOffset,
     effectiveTileSize,
+    backgroundRoomPan,
     zoom = 1.0,
   } = viewport;
   const {
@@ -879,6 +887,12 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
 
     // Update camera positions
     if (backgroundImageLayerRef.current) {
+      // Keep the room artwork on the same pan as everything drawn over it
+      // before moving anything (issue #26).
+      backgroundImageLayerRef.current.setCenteredPan(
+        backgroundRoomPan?.x ?? 0,
+        backgroundRoomPan?.y ?? 0
+      );
       backgroundImageLayerRef.current.updateCamera(cameraX, cameraY);
     }
 
@@ -936,6 +950,7 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
     canvasRef,
     effectiveGridOffset,
     effectiveTileSize,
+    backgroundRoomPan,
   ]);
 
   // =========================================================================

--- a/tests/README.md
+++ b/tests/README.md
@@ -89,6 +89,7 @@ box, an out-of-bounds transition dumps the player somewhere arbitrary. Nothing t
 | `mapTextureBudget.test.ts` | A texture reference that 404s (renders as *nothing*, with no error), a filename whose case only matches on macOS, or a map whose resident textures exceed what a phone can hold — which kills the tab with no catchable error | Adding a map, NPC, or tile; changing `scripts/optimize-assets.js` |
 | `textureManager.test.ts` | Unbounded texture fan-out at startup (mobile WebKit answers that by terminating requests as `TypeError: Load failed`), a render-loop miss retrying forever, or eviction destroying a texture still in use | Touching `utils/TextureManager.ts` or the loading policy |
 | `characterSpriteScale.test.ts` | The player rendering at a third of its size. Custom art scales 3x and placeholders 1x, chosen by pattern-matching the sprite URL — move the artwork and the match breaks silently, with nothing thrown and no 404 | Moving character art, or touching `isCustomCharacterSprite()` |
+| `backgroundRoomLayout.test.ts` | An interior that doesn't fill the window (a band of background colour down one side, at some window sizes but not others), or one whose artwork stops following the player so they walk off the edge of the screen | Touching interior scaling/panning, or a map's centred image layer `width`/`height`/`scale` |
 
 ## Writing a new test
 

--- a/tests/backgroundRoomLayout.test.ts
+++ b/tests/backgroundRoomLayout.test.ts
@@ -1,0 +1,271 @@
+/** @vitest-environment node */
+/**
+ * Regression for issue #26, reopened: background-image rooms (interiors) still
+ * didn't fill the screen, and after the first fix made them fill it, the player
+ * could walk off the edge of the screen.
+ *
+ * Two root causes, both in this file's helpers:
+ *
+ * 1. **The gap.** The cover scale was computed from the map's declared
+ *    `referenceViewport` rather than from the artwork it was supposed to
+ *    describe. Mum's Kitchen is 960x540 at `scale: 1.3` = 1248x702, 2.6% short
+ *    of its declared 1280x720 — so `cover` dutifully filled 1280x720 worth of
+ *    space with 1248x702 worth of room, at every window size, and the game's
+ *    background colour showed through the 2.6%. `getRoomCoverScale` measures
+ *    the artwork instead, which removes the class of bug rather than the one
+ *    bad number: `referenceViewport` can no longer be wrong because it is no
+ *    longer consulted. (It also explains why this looked fine on one laptop and
+ *    broken on a bigger screen — below 1280x720 the 1.0 floor kicks in and the
+ *    artwork is already larger than the window.)
+ *
+ * 2. **Walking off-screen.** Covering means cropping, and the crop was a static
+ *    centre crop with no camera, so the cropped strip was simply never
+ *    reachable — walk toward it and the character left the screen. `getRoomPan`
+ *    slides the artwork to follow the player, clamped at the artwork's edges so
+ *    the crop can never reopen the gap from (1).
+ *
+ * WHAT BREAKS IF THESE FAIL: the room stops filling the window (a coloured band
+ * down one side), or the player walks out of view in an interior. Neither
+ * throws; both are only visible by looking at the game at the right window size.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import { mapManager } from '../maps/MapManager';
+import { getRoomArtworkSize, getRoomCoverScale, getRoomPan } from '../utils/backgroundRoomLayout';
+import { TILE_SIZE, TILE_LEGEND, PLAYER_SIZE } from '../constants';
+import { CollisionType, MapDefinition, TileData } from '../types';
+
+/**
+ * Real window sizes, chosen to span the aspect ratios that actually break this:
+ * 16:9 (where cover and contain agree and nothing crops), 16:10 and 3:2 (common
+ * on Windows laptops and Surfaces — this is what the bug was reported on), 4:3,
+ * and a 4K screen well past any scale clamp.
+ */
+const VIEWPORTS: Array<[number, number]> = [
+  [1280, 720], // 16:9, exactly the declared reference
+  [1366, 768], // 16:9
+  [1440, 900], // 16:10
+  [1680, 1050], // 16:10
+  [1536, 864], // 16:9
+  [1920, 1080], // 16:9
+  [2256, 1504], // 3:2 (Surface)
+  [1024, 768], // 4:3
+  [2560, 1440], // 16:9
+  [3840, 2160], // 4K
+  [900, 1400], // portrait — a narrow window, or a tablet stood up
+];
+
+/** Everything App.tsx derives for one room at one window size. */
+function layoutFor(map: MapDefinition, viewportWidth: number, viewportHeight: number) {
+  const artwork = getRoomArtworkSize(map)!;
+  // App.tsx floors the scale at 1.0 — a small window shows the room at its
+  // authored size (cropped and panned), rather than shrinking it.
+  const viewportScale = Math.max(
+    1.0,
+    getRoomCoverScale(artwork.width, artwork.height, viewportWidth, viewportHeight)
+  );
+  return {
+    artwork,
+    viewportScale,
+    artworkWidth: artwork.width * viewportScale,
+    artworkHeight: artwork.height * viewportScale,
+    tileSize: TILE_SIZE * viewportScale * artwork.layerScale,
+  };
+}
+
+/** Screen position of a point given in tile units, matching effectiveGridOffset. */
+function screenPos(
+  map: MapDefinition,
+  tilePos: { x: number; y: number },
+  viewportWidth: number,
+  viewportHeight: number
+) {
+  const { artworkWidth, artworkHeight, tileSize } = layoutFor(map, viewportWidth, viewportHeight);
+  const pan = getRoomPan({
+    playerPos: tilePos,
+    tileSize,
+    artworkWidth,
+    artworkHeight,
+    viewportWidth,
+    viewportHeight,
+  });
+  return {
+    x: (viewportWidth - artworkWidth) / 2 + pan.x + tilePos.x * tileSize,
+    y: (viewportHeight - artworkHeight) / 2 + pan.y + tilePos.y * tileSize,
+  };
+}
+
+let backgroundImageMaps: Array<{ id: string; map: MapDefinition }> = [];
+
+beforeAll(async () => {
+  const { initializeMaps } = await import('../maps/index');
+  initializeMaps();
+
+  backgroundImageMaps = mapManager
+    .getAllMapIds()
+    .map((id) => ({ id, map: mapManager.getMap(id) as MapDefinition }))
+    .filter(({ map }) => map && map.renderMode === 'background-image' && getRoomArtworkSize(map));
+});
+
+describe('getRoomCoverScale', () => {
+  it('fills both axes, taking whichever needs more', () => {
+    // 16:9 artwork in a 16:10 window: height is the binding constraint.
+    const scale = getRoomCoverScale(1248, 702, 1440, 900);
+    expect(scale).toBeCloseTo(900 / 702, 6);
+    expect(1248 * scale).toBeGreaterThanOrEqual(1440 - 1e-6);
+    expect(702 * scale).toBeGreaterThanOrEqual(900 - 1e-6);
+  });
+
+  it('is exactly 1 when the artwork already matches the window', () => {
+    expect(getRoomCoverScale(1248, 702, 1248, 702)).toBeCloseTo(1, 9);
+  });
+
+  it("measures the artwork, not the map's declared reference viewport", () => {
+    // The reopened half of #26, with Mum's Kitchen's real numbers. Scaling from
+    // the declared 1280x720 reference leaves the 1248x702 artwork 2.6% short of
+    // a 1920x1080 window on BOTH axes — a band of background colour all round,
+    // at every window size, which is exactly what was reported.
+    const fromReference = Math.max(1920 / 1280, 1080 / 720);
+    expect(1248 * fromReference).toBeLessThan(1920);
+    expect(702 * fromReference).toBeLessThan(1080);
+
+    const fromArtwork = getRoomCoverScale(1248, 702, 1920, 1080);
+    expect(1248 * fromArtwork).toBeGreaterThanOrEqual(1920 - 1e-6);
+    expect(702 * fromArtwork).toBeGreaterThanOrEqual(1080 - 1e-6);
+  });
+
+  it('is not capped, so a big monitor cannot reopen the gap', () => {
+    // A 4K window needs >3x. The old code clamped at 2.5, which would leave a
+    // 700px band down the side.
+    const scale = getRoomCoverScale(1248, 702, 3840, 2160);
+    expect(scale).toBeGreaterThan(2.5);
+    expect(1248 * scale).toBeGreaterThanOrEqual(3840 - 1e-6);
+  });
+});
+
+describe('getRoomPan', () => {
+  const base = {
+    tileSize: 100,
+    artworkWidth: 1600,
+    artworkHeight: 900,
+    viewportWidth: 1440,
+    viewportHeight: 900,
+  };
+
+  it('does not move an axis that has nothing cropped', () => {
+    // Height matches exactly here — a 16:9 room in a 16:9 window must sit still.
+    const pan = getRoomPan({ ...base, playerPos: { x: 2, y: 8 } });
+    expect(pan.y).toBe(0);
+  });
+
+  it('follows the player across the cropped axis', () => {
+    const left = getRoomPan({ ...base, playerPos: { x: 1, y: 4 } }).x;
+    const right = getRoomPan({ ...base, playerPos: { x: 14, y: 4 } }).x;
+    // Player moving right means the artwork slides left.
+    expect(right).toBeLessThan(left);
+  });
+
+  it('sits dead centre when the player is at the middle of the artwork', () => {
+    // Artwork centre is 800px in, i.e. tile 8 at tileSize 100.
+    expect(getRoomPan({ ...base, playerPos: { x: 8, y: 4 } }).x).toBeCloseTo(0, 9);
+  });
+
+  it('clamps at the artwork edges rather than exposing a gap', () => {
+    const crop = base.artworkWidth - base.viewportWidth; // 160
+    // Well beyond either end of the room, including outside it entirely.
+    for (const x of [-50, -1, 0, 8, 15, 16, 99]) {
+      const pan = getRoomPan({ ...base, playerPos: { x, y: 4 } }).x;
+      expect(Math.abs(pan)).toBeLessThanOrEqual(crop / 2 + 1e-9);
+
+      const origin = (base.viewportWidth - base.artworkWidth) / 2 + pan;
+      expect(origin).toBeLessThanOrEqual(1e-9); // no gap on the left
+      expect(origin + base.artworkWidth).toBeGreaterThanOrEqual(base.viewportWidth - 1e-9);
+    }
+  });
+
+  it('keeps any point inside the artwork on screen', () => {
+    // The property that stops the player walking off the edge: if they are
+    // within the room's artwork at all, the pan puts them within the window.
+    for (let offset = 0; offset <= base.artworkWidth; offset += 25) {
+      const pan = getRoomPan({
+        ...base,
+        playerPos: { x: offset / base.tileSize, y: 4 },
+      }).x;
+      const screenX = (base.viewportWidth - base.artworkWidth) / 2 + pan + offset;
+      expect(screenX).toBeGreaterThanOrEqual(-1e-9);
+      expect(screenX).toBeLessThanOrEqual(base.viewportWidth + 1e-9);
+    }
+  });
+});
+
+describe('every background-image room, at real window sizes', () => {
+  it('has artwork to measure (otherwise it silently falls back to the reference)', () => {
+    expect(backgroundImageMaps.length).toBeGreaterThan(0);
+    for (const { id, map } of backgroundImageMaps) {
+      expect(getRoomArtworkSize(map), `${id} has no centred image layer`).not.toBeNull();
+    }
+  });
+
+  it('fills the window with no gap', () => {
+    const gaps: string[] = [];
+    for (const { id, map } of backgroundImageMaps) {
+      for (const [vw, vh] of VIEWPORTS) {
+        const { artworkWidth, artworkHeight } = layoutFor(map, vw, vh);
+        if (artworkWidth < vw - 1e-6 || artworkHeight < vh - 1e-6) {
+          gaps.push(
+            `${id} at ${vw}x${vh}: artwork covers only ${artworkWidth.toFixed(0)}x${artworkHeight.toFixed(0)}`
+          );
+        }
+      }
+    }
+    expect(
+      gaps,
+      `Background colour shows through around these rooms. Check the centred image layer's ` +
+        `width/height/scale in the map definition — getRoomCoverScale sizes from those.\n${gaps.join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('keeps the player visible on every walkable tile', () => {
+    const offScreen: string[] = [];
+
+    for (const { id, map } of backgroundImageMaps) {
+      const characterScale = map.characterScale ?? 1.0;
+
+      for (const [vw, vh] of VIEWPORTS) {
+        const { tileSize } = layoutFor(map, vw, vh);
+        // "Visible" means the sprite is on screen, not that its centre point is.
+        // A few of these rooms have a walkable bottom row whose centre sits a
+        // pixel or two below the artwork (the walkmesh is 15x10 tiles over 16:9
+        // art), and the character there is still plainly in view.
+        const margin = (PLAYER_SIZE * characterScale * tileSize) / 2;
+
+        for (let y = 0; y < map.grid.length; y++) {
+          for (let x = 0; x < map.grid[y].length; x++) {
+            const tile = TILE_LEGEND[map.grid[y][x]] as TileData | undefined;
+            if (tile?.collisionType !== CollisionType.WALKABLE) continue;
+
+            const centre = { x: x + 0.5, y: y + 0.5 };
+            const pos = screenPos(map, centre, vw, vh);
+            if (
+              pos.x < -margin ||
+              pos.x > vw + margin ||
+              pos.y < -margin ||
+              pos.y > vh + margin
+            ) {
+              offScreen.push(
+                `${id} at ${vw}x${vh}: tile (${x},${y}) renders at (${pos.x.toFixed(0)},${pos.y.toFixed(0)})`
+              );
+            }
+          }
+        }
+      }
+    }
+
+    expect(
+      offScreen,
+      `A player standing on these tiles would be off the edge of the screen. Either the ` +
+        `room's walkmesh reaches outside its artwork, or the pan stopped following the ` +
+        `player (getRoomPan / effectiveGridOffset in App.tsx).\n${offScreen.slice(0, 20).join('\n')}`
+    ).toEqual([]);
+  });
+});

--- a/tests/mapFillsScreen.test.ts
+++ b/tests/mapFillsScreen.test.ts
@@ -19,6 +19,14 @@
  *   screen but leaves a letterboxed gap on whichever axis has room to spare
  *   at a mismatched aspect ratio. 'cover' mode (new) picks the LARGER scale
  *   instead, filling both axes and cropping the overflow.
+ *
+ * NOTE: 'cover' fixed the fit but not the *input* — App.tsx was feeding it the
+ * map's declared `referenceViewport`, which drifts from the artwork it claims
+ * to describe, so interiors were still short by a couple of percent at every
+ * window size. Interiors now size and pan from the artwork itself; see
+ * tests/backgroundRoomLayout.test.ts. What is left here for that half is the
+ * contract of calculateViewportScale's fitMode param, which other callers
+ * still rely on.
  */
 import { describe, it, expect } from 'vitest';
 import {

--- a/utils/backgroundRoomLayout.ts
+++ b/utils/backgroundRoomLayout.ts
@@ -1,0 +1,143 @@
+/**
+ * backgroundRoomLayout - Where a background-image room's artwork sits on screen
+ *
+ * Background-image rooms (interiors) don't scroll a tile grid; they draw one
+ * piece of hand-painted artwork and lay an invisible collision grid over it.
+ * Two numbers decide how that looks at an arbitrary window size:
+ *
+ * 1. **Cover scale** — how much to enlarge the artwork so it fills the window
+ *    with no gap. Issue #26: this used to be derived from the map's declared
+ *    `referenceViewport` rather than from the artwork itself, on the assumption
+ *    that the artwork at its authored `scale` exactly filled that reference.
+ *    It usually didn't. Mum's Kitchen is 960x540 at `scale: 1.3` = 1248x702,
+ *    2.6% short of its declared 1280x720 reference — so however the window was
+ *    resized, the room came out 2.6% too small and the game's own background
+ *    colour showed through around it. Measuring the real artwork removes the
+ *    class of bug: `referenceViewport` can no longer be wrong, because it is no
+ *    longer consulted.
+ *
+ * 2. **Pan** — covering means cropping whichever axis has the excess, and a
+ *    static centre crop lets the player walk into the cropped region and off
+ *    the screen entirely. The pan follows the player within the crop, clamped
+ *    so the artwork's edge never leaves the window (which would reopen the gap
+ *    the cover scale just closed). This is the same follow-and-clamp rule
+ *    `useCamera` applies to tiled rooms, expressed in screen pixels.
+ *
+ * Both are pure functions of sizes, so `tests/backgroundRoomLayout.test.ts` can
+ * check them against the real map definitions without a renderer.
+ */
+
+import { TILE_SIZE } from '../constants';
+import { ImageRoomLayer, MapDefinition, Position } from '../types';
+
+/** On-screen size of a room's artwork before viewport scaling is applied. */
+export interface RoomArtworkSize {
+  /** Artwork width in px at the layer's authored `scale`, before viewport scaling */
+  width: number;
+  /** Artwork height in px at the layer's authored `scale`, before viewport scaling */
+  height: number;
+  /** The layer's authored `scale` (also the multiplier on TILE_SIZE for this room) */
+  layerScale: number;
+}
+
+/**
+ * Measure the centred artwork of a background-image room.
+ *
+ * Mirrors what BackgroundImageLayer.createImageLayerSprite does when sizing the
+ * sprite, so the two cannot drift: explicit width/height wins, then the map's
+ * grid dimensions as the fallback (`useNativeSize` has no dimensions available
+ * outside the renderer and falls back the same way it always has).
+ *
+ * Returns null for maps that aren't background-image rooms or have no centred
+ * image layer — those keep viewportScale 1.0 and no pan.
+ */
+export function getRoomArtworkSize(map: MapDefinition | null | undefined): RoomArtworkSize | null {
+  if (!map || map.renderMode !== 'background-image' || !map.layers) return null;
+
+  const centredLayer = map.layers.find(
+    (layer) => layer.type === 'image' && (layer as ImageRoomLayer).centered
+  ) as ImageRoomLayer | undefined;
+
+  if (!centredLayer) return null;
+
+  const hasExplicitSize = centredLayer.width !== undefined && centredLayer.height !== undefined;
+  const baseWidth = hasExplicitSize ? centredLayer.width! : map.width * TILE_SIZE;
+  const baseHeight = hasExplicitSize ? centredLayer.height! : map.height * TILE_SIZE;
+  const layerScale = centredLayer.scale ?? 1.0;
+
+  return {
+    width: baseWidth * layerScale,
+    height: baseHeight * layerScale,
+    layerScale,
+  };
+}
+
+/**
+ * Scale needed for artwork of the given size to cover the viewport completely.
+ *
+ * Takes the LARGER of the two axis ratios, so both axes are filled and the
+ * excess on the other axis is cropped (and then panned — see getRoomPan).
+ * Deliberately unclamped at the top: a clamp here reopens issue #26 as a gap on
+ * a large monitor, and upscaling a sprite costs no extra GPU memory, only
+ * sharpness. Callers apply their own floor (the game never scales a room DOWN
+ * below its authored size).
+ */
+export function getRoomCoverScale(
+  artworkWidth: number,
+  artworkHeight: number,
+  viewportWidth: number,
+  viewportHeight: number
+): number {
+  if (artworkWidth <= 0 || artworkHeight <= 0) return 1;
+  return Math.max(viewportWidth / artworkWidth, viewportHeight / artworkHeight);
+}
+
+/**
+ * How far to slide the (already cover-scaled) artwork from dead centre so the
+ * player stays on screen, on one axis.
+ *
+ * Positive pan moves the artwork right/down, revealing more of its left/top.
+ * Zero when there's nothing cropped on this axis — so a 16:9 room in a 16:9
+ * window doesn't move at all.
+ */
+function panAxis(playerOffset: number, artworkSize: number, viewportSize: number): number {
+  const crop = artworkSize - viewportSize;
+  if (crop <= 0) return 0;
+
+  // Camera measured from the artwork's leading edge, as useCamera does.
+  const wanted = playerOffset - viewportSize / 2;
+  const camera = Math.max(0, Math.min(crop, wanted));
+
+  // Convert to an offset from the centred position (camera === crop / 2).
+  return crop / 2 - camera;
+}
+
+export interface RoomPanConfig {
+  /** Player position in tile units */
+  playerPos: Position;
+  /** On-screen size of one tile (TILE_SIZE * viewportScale * layerScale * zoom) */
+  tileSize: number;
+  /** Final on-screen artwork size, after viewport scaling and zoom */
+  artworkWidth: number;
+  artworkHeight: number;
+  viewportWidth: number;
+  viewportHeight: number;
+}
+
+/**
+ * Offset from centre for a background-image room's artwork, following the
+ * player through whatever the cover scale cropped.
+ *
+ * Returned as an offset from centre rather than an absolute origin so each
+ * centred layer keeps being centred by its own size (rooms pair a background
+ * and foreground layer, and nothing guarantees they're the same size) while all
+ * of them pan together.
+ */
+export function getRoomPan(config: RoomPanConfig): Position {
+  const { playerPos, tileSize, artworkWidth, artworkHeight, viewportWidth, viewportHeight } = config;
+
+  return {
+    x: panAxis(playerPos.x * tileSize, artworkWidth, viewportWidth),
+    y: panAxis(playerPos.y * tileSize, artworkHeight, viewportHeight),
+  };
+}

--- a/utils/pixi/BackgroundImageLayer.ts
+++ b/utils/pixi/BackgroundImageLayer.ts
@@ -68,6 +68,10 @@ export class BackgroundImageLayer {
   private layerNPCs: NPC[] = [];
   // Viewport scaling configuration
   private scalingConfig: ScalingConfig | null = null;
+  // Offset from dead centre for centered layers, so the crop that `cover`
+  // scaling introduces follows the player instead of sitting static (issue #26).
+  // Owned by App.tsx (getRoomPan) and pushed in every frame via setCenteredPan.
+  private centeredPan: { x: number; y: number } = { x: 0, y: 0 };
   // Individual cobweb sprites tracked for dynamic show/hide on clean
   private cobwebLayerEntries: Array<{ sprite: PIXI.Sprite; cobwebId: number }> = [];
   // Individual mess pile sprites tracked for dynamic show/hide on clean
@@ -157,6 +161,37 @@ export class BackgroundImageLayer {
   }
 
   /**
+   * Set how far centered layers are offset from dead centre.
+   *
+   * `cover` scaling makes the artwork larger than the viewport on one axis; this
+   * pan slides the crop so it follows the player, exactly as the camera does in
+   * a tiled room. Pass the value App.tsx already folds into effectiveGridOffset,
+   * so the artwork and everything positioned on top of it move together — a
+   * mismatch here would slide the room out from under the collision grid.
+   */
+  setCenteredPan(x: number, y: number): void {
+    if (this.centeredPan.x === x && this.centeredPan.y === y) return;
+    this.centeredPan = { x, y };
+    this.updateSpritesForScale();
+  }
+
+  /**
+   * Screen position of a centered layer of the given scaled size: centred in the
+   * viewport, then panned. One place, so every caller agrees.
+   */
+  private centeredPosition(
+    scaledWidth: number,
+    scaledHeight: number
+  ): { x: number; y: number } {
+    const viewportWidth = this.scalingConfig?.viewportWidth ?? window.innerWidth;
+    const viewportHeight = this.scalingConfig?.viewportHeight ?? window.innerHeight;
+    return {
+      x: (viewportWidth - scaledWidth) / 2 + this.centeredPan.x,
+      y: (viewportHeight - scaledHeight) / 2 + this.centeredPan.y,
+    };
+  }
+
+  /**
    * Set scaling configuration for viewport-relative rendering
    * When set, images scale to fill the viewport while maintaining aspect ratio
    */
@@ -174,7 +209,7 @@ export class BackgroundImageLayer {
   private updateSpritesForScale(): void {
     if (!this.scalingConfig) return;
 
-    const { viewportScale, viewportWidth, viewportHeight } = this.scalingConfig;
+    const { viewportScale } = this.scalingConfig;
 
     // Update all sprites
     const allSprites = [...this.backgroundSprites, ...this.foregroundSprites];
@@ -187,8 +222,9 @@ export class BackgroundImageLayer {
 
       // Recalculate position for centered sprites
       if (layerSprite.centered) {
-        layerSprite.sprite.x = (viewportWidth - scaledWidth) / 2;
-        layerSprite.sprite.y = (viewportHeight - scaledHeight) / 2;
+        const { x, y } = this.centeredPosition(scaledWidth, scaledHeight);
+        layerSprite.sprite.x = x;
+        layerSprite.sprite.y = y;
       } else {
         // Scale offset position too
         layerSprite.sprite.x = layerSprite.baseX * viewportScale;
@@ -481,10 +517,9 @@ export class BackgroundImageLayer {
 
     if (layer.centered) {
       // Use scaling config viewport dimensions for consistent centering
-      const vw = this.scalingConfig?.viewportWidth ?? window.innerWidth;
-      const vh = this.scalingConfig?.viewportHeight ?? window.innerHeight;
-      baseX = (vw - finalWidth) / 2;
-      baseY = (vh - finalHeight) / 2;
+      const centred = this.centeredPosition(finalWidth, finalHeight);
+      baseX = centred.x;
+      baseY = centred.y;
     } else {
       // Scale offset positions too
       baseX *= viewportScale;
@@ -517,8 +552,6 @@ export class BackgroundImageLayer {
    */
   updateCamera(cameraX: number, cameraY: number): void {
     // Use scaling config viewport dimensions for consistent positioning
-    const viewportWidth = this.scalingConfig?.viewportWidth ?? window.innerWidth;
-    const viewportHeight = this.scalingConfig?.viewportHeight ?? window.innerHeight;
     const viewportScale = this.scalingConfig?.viewportScale ?? 1.0;
 
     // Update background sprites
@@ -528,9 +561,11 @@ export class BackgroundImageLayer {
       const scaledHeight = layerSprite.height * viewportScale;
 
       if (layerSprite.centered) {
-        // Centered layers stay fixed in viewport - recalculate center position
-        layerSprite.sprite.x = (viewportWidth - scaledWidth) / 2;
-        layerSprite.sprite.y = (viewportHeight - scaledHeight) / 2;
+        // Centered layers ignore the tiled-room camera; they sit in the viewport
+        // centre, offset by the pan that follows the player through the crop.
+        const { x, y } = this.centeredPosition(scaledWidth, scaledHeight);
+        layerSprite.sprite.x = x;
+        layerSprite.sprite.y = y;
       } else {
         // Normal parallax scrolling (with scaled positions)
         const offsetX = cameraX * (1 - layerSprite.parallaxFactor);
@@ -551,9 +586,11 @@ export class BackgroundImageLayer {
       const scaledHeight = layerSprite.height * viewportScale;
 
       if (layerSprite.centered) {
-        // Centered layers stay fixed in viewport
-        layerSprite.sprite.x = (viewportWidth - scaledWidth) / 2;
-        layerSprite.sprite.y = (viewportHeight - scaledHeight) / 2;
+        // Centered layers ignore the tiled-room camera; they sit in the viewport
+        // centre, offset by the pan that follows the player through the crop.
+        const { x, y } = this.centeredPosition(scaledWidth, scaledHeight);
+        layerSprite.sprite.x = x;
+        layerSprite.sprite.y = y;
       } else {
         // Normal parallax scrolling (with scaled positions)
         const offsetX = cameraX * (1 - layerSprite.parallaxFactor);
@@ -607,6 +644,10 @@ export class BackgroundImageLayer {
 
     // Clear layer NPCs
     this.layerNPCs = [];
+
+    // Reset the pan so the next room starts centred rather than inheriting the
+    // previous room's crop offset for a frame.
+    this.centeredPan = { x: 0, y: 0 };
 
     // Clear cobweb sprite tracking (sprites already destroyed above)
     this.cobwebLayerEntries = [];


### PR DESCRIPTION
Closes #26.

Two faults, both in background-image rooms (interiors). Sanne's follow-up comment on the issue diagnosed both correctly.

## 1. The gap

The `cover` scale was computed from each map's declared `referenceViewport` rather than from the artwork it was supposed to describe. Mum's Kitchen is 960×540 at `scale: 1.3` = **1248×702**, 2.6% short of its declared **1280×720** — so `cover` faithfully filled a box 2.6% larger than the room, at *every* window size, on all four sides. Every background-image map has some version of this drift, because nothing validates the two against each other.

`getRoomCoverScale` now measures the artwork itself. That removes the class of bug rather than the one bad number: `referenceViewport` can no longer be wrong here because it is no longer consulted.

This also explains "it looks fine on my laptop" — below 1280×720 the `Math.max(1.0, …)` floor takes over and the artwork already exceeds the window. The old `2.5` cap on the scale is gone too: it would have reopened the gap as a ~700px band on a 4K display, and upscaling a sprite costs sharpness, not GPU memory.

## 2. Walking off-screen

Covering means cropping, and the crop was a static centre crop with no camera — so the cropped strip was simply unreachable, and walking toward it took the character off the screen. This is the regression the first fix introduced, and the half of the original ask ("the crop should shift/pan as the player walks around") that was left out for interiors.

`getRoomPan` slides the artwork to follow the player, clamped at its edges so it can never reopen the gap. It returns an offset **from centre** rather than an absolute origin, so a room pairing background and foreground layers of different sizes keeps each centred by its own size while both pan together.

`App.tsx` folds the pan into `effectiveGridOffset` — the one value that already positions the player, NPCs, placed items, highlights, DOM overlays and `screenToTile` — and passes it to `BackgroundImageLayer.setCenteredPan` so the artwork moves with them. Those two must use the same number, or the room slides out from under its own collision grid.

## Verified

Headless browser, `main` vs this branch, at 1440×900 (16:10), 1920×1080 and 1024×768:

- `main` at 1440×900 shows the dark band top and bottom. This branch fills the screen.
- At 1024×768 the room pans as the player crosses it, with Mum and the "To Village" prompt staying aligned.
- Tiled rooms untouched — village screenshot diff before/after: mean absolute difference **0.014/255**.

`make verify` green (764 tests), `npm run lint` 0 errors.

## Guarded by

`tests/backgroundRoomLayout.test.ts` — every background-image map at eleven real window sizes (16:9, 16:10, 3:2, 4:3, 4K, portrait), checked for both a gap and a player who would render off-screen, plus unit coverage of the clamp and the reference-vs-artwork drift with Mum's Kitchen's real numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYuoCXdvGFXa4p2AZcemuS