### PR TITLE
Stop placing an item on one map deleting every shared item on the others

### DIFF
--- a/firebase/sharedPlacedItemsService.ts
+++ b/firebase/sharedPlacedItemsService.ts
@@ -96,7 +96,6 @@ class SharedPlacedItemsService {
               sharedPlacedItemsManager.remove(change.doc.id);
               continue;
             }
-            this.publishedIds.add(change.doc.id);
             const item = decodeSharedPlacedItem(change.doc.data());
             if (!item) {
               if (DEBUG.MULTIPLAYER) {
@@ -105,6 +104,17 @@ class SharedPlacedItemsService {
               continue;
             }
             if (item.mapId !== mapId) continue;
+
+            // Only ids for the mirrored map, as getPublishedIds() promises.
+            //
+            // This add used to sit above the map check, so publishedIds accumulated every
+            // document in the collection while the mirror held only the current map. The
+            // deletion pass in useSharedPlacedItemsController treats "published but not in
+            // the mirror and not ours" as "picked up" — so placing anything on one shared
+            // map deleted every shared item on all the others. A malformed document is
+            // likewise left out: we cannot read its map, so we must not conclude it is
+            // ours to delete.
+            this.publishedIds.add(change.doc.id);
             sharedPlacedItemsManager.apply(item);
           }
           this.#emit();

--- a/tests/firebase/sharedPlacedItemsScope.test.ts
+++ b/tests/firebase/sharedPlacedItemsScope.test.ts
@@ -1,0 +1,116 @@
+/** @vitest-environment node
+ *
+ * `getPublishedIds()` must only ever report ids for the map being mirrored.
+ *
+ * The listener watches the whole collection deliberately (it is small, and a `where`
+ * clause would need an index to keep in step). The mirror filters by map — but
+ * `publishedIds` did not, so it accumulated every document in the world while the mirror
+ * held one map's worth.
+ *
+ * That is quietly destructive, because of what the caller does with it:
+ * `useSharedPlacedItemsController` reconciles deletions by treating "published, but
+ * neither ours nor in the mirror" as "somebody picked this up". An item on another shared
+ * map satisfies both halves — so putting anything down in the village deleted every
+ * shared item in the orchard, the farm, the ruins and the rest, for both players and
+ * permanently.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let snapshotHandler: ((snapshot: unknown) => void) | null = null;
+const deleted: string[] = [];
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn((_db, _path, id) => ({ id })),
+  collection: vi.fn(() => ({})),
+  setDoc: vi.fn(async () => {}),
+  deleteDoc: vi.fn(async (ref: { id: string }) => {
+    deleted.push(ref.id);
+  }),
+  onSnapshot: vi.fn((_ref, handler) => {
+    snapshotHandler = handler as (snapshot: unknown) => void;
+    return () => {};
+  }),
+}));
+vi.mock('../../firebase/config', () => ({
+  getFirebaseDb: vi.fn(() => ({})),
+  isFirebaseInitialized: vi.fn(() => true),
+}));
+vi.mock('../../firebase/authService', () => ({
+  authService: { isAuthenticated: () => true, getUserId: () => 'uid-1' },
+}));
+vi.mock('../../utils/errorReporting', () => ({ reportError: vi.fn() }));
+
+import { sharedPlacedItemsService } from '../../firebase/sharedPlacedItemsService';
+
+/** One Firestore doc as the snapshot handler sees it. */
+function change(id: string, mapId: string) {
+  return {
+    type: 'added',
+    doc: {
+      id,
+      data: () => ({
+        id,
+        itemId: 'furniture_garden_bench',
+        mapId,
+        position: { x: 3, y: 4 },
+        image: '/bench.png',
+        timestamp: 1,
+      }),
+    },
+  };
+}
+
+function emit(...changes: ReturnType<typeof change>[]) {
+  snapshotHandler?.({ docChanges: () => changes });
+}
+
+beforeEach(() => {
+  deleted.length = 0;
+  sharedPlacedItemsService.stopListening();
+  snapshotHandler = null;
+});
+
+describe('published id scope', () => {
+  it('reports ids for the mirrored map', () => {
+    sharedPlacedItemsService.startListening('village');
+    emit(change('bench-1', 'village'));
+
+    expect(sharedPlacedItemsService.getPublishedIds()).toEqual(['bench-1']);
+  });
+
+  it('does not report items belonging to another map', () => {
+    sharedPlacedItemsService.startListening('village');
+    emit(change('bench-1', 'village'), change('bench-2', 'orchard'));
+
+    // 'bench-2' is real and must stay real — it simply is not this map's business.
+    expect(sharedPlacedItemsService.getPublishedIds()).toEqual(['bench-1']);
+  });
+
+  it('does not report a document it could not decode', () => {
+    sharedPlacedItemsService.startListening('village');
+    snapshotHandler?.({
+      docChanges: () => [{ type: 'added', doc: { id: 'broken', data: () => ({ nonsense: true }) } }],
+    });
+
+    // We cannot read its map, so we must not later conclude it is ours to delete.
+    expect(sharedPlacedItemsService.getPublishedIds()).toEqual([]);
+  });
+
+  it('forgets an id once its document is removed', () => {
+    sharedPlacedItemsService.startListening('village');
+    emit(change('bench-1', 'village'));
+    snapshotHandler?.({
+      docChanges: () => [{ type: 'removed', doc: { id: 'bench-1', data: () => ({}) } }],
+    });
+
+    expect(sharedPlacedItemsService.getPublishedIds()).toEqual([]);
+  });
+
+  it('clears everything when the map changes, so ids never leak across maps', () => {
+    sharedPlacedItemsService.startListening('village');
+    emit(change('bench-1', 'village'));
+    sharedPlacedItemsService.startListening('orchard');
+
+    expect(sharedPlacedItemsService.getPublishedIds()).toEqual([]);
+  });
+});


### PR DESCRIPTION
**Live data-loss bug, shipped in #71.** Putting anything down in the village deletes every shared placed item in the orchard, the farm, the ruins and the rest — for both players, permanently.

## Cause

`publishedIds` was filled *before* the map filter, so it accumulated every document in the collection while the mirror held only the current map's worth:

```js
this.publishedIds.add(change.doc.id);   // every document, every map
const item = decodeSharedPlacedItem(change.doc.data());
if (!item) continue;
if (item.mapId !== mapId) continue;     // filter, too late
```

The deletion pass in `useSharedPlacedItemsController` treats *"published, but neither ours nor in the mirror"* as *"somebody picked this up"*. An item on another shared map satisfies both halves: it isn't in `localIds` (local is filtered to the current map) and isn't in the mirror (also current-map only). So it gets deleted.

## Fix

The `add` moves below the map check, matching what `getPublishedIds()` already documented itself as returning. A document that fails to decode is left out too — we can't read its map, so we mustn't later conclude it's ours to delete.

## The gap that let it through

The line is one thing; the test shape is the real lesson. The existing tests covered the manager and the `GameState` merge, both single-map, and never the seam where the service's snapshot handling meets the controller's deletion pass. **A bug that only exists across two maps cannot be caught by tests that only ever consider one** — and "deletes data on the map you aren't looking at" is exactly what nobody notices until the furniture is gone.

`tests/firebase/sharedPlacedItemsScope.test.ts` drives the real snapshot handler with documents from two maps. It **fails 2 of 5 without the fix**, which I verified by stashing the change rather than assuming.

866 tests pass; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh8xj7NRhaxSGEMCunnqLY