### PR TITLE
Gate CI performance on scene cost instead of fps

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -18,12 +18,11 @@ permissions:
 jobs:
   performance:
     runs-on: ubuntu-latest
-    # 35, not 20: these tests used to sit on the "Enter Game" overlay for their
-    # whole run, so isInWorld was false and none of the HUD/NPC/weather overlays
-    # rendered — the numbers described a stripped-down scene. Now the harness
-    # enters the world properly, every CDP round-trip queues behind real frames,
-    # and the six sub-tests need roughly half again as long.
-    timeout-minutes: 35  # multi-map + device-throttled tests, measured in-world
+    # 35 covered six sub-tests; the three device-throttled ones are gone (see
+    # below), leaving three. 25 keeps headroom for the slow case: the harness
+    # enters the world properly, so every CDP round-trip queues behind real
+    # frames, and on a bad runner those frames take seconds.
+    timeout-minutes: 25  # three in-world map runs
 
     steps:
       - name: Checkout code
@@ -77,16 +76,17 @@ jobs:
           echo "## Testing witch_hut map..."
           node scripts/perf-test.js --map witch_hut --scenario explore --duration 10000 --github --save perf-witch.json || true
 
-      - name: Run device-throttled tests (simulated old iPad)
-        run: |
-          echo "## Testing village on simulated iPad Air 2 (4x CPU throttle)..."
-          node scripts/perf-test.js --device ipad --map village --scenario movement --duration 10000 --github --save perf-ipad-village.json || true
-
-          echo "## Testing bear_cave on simulated iPad 4th Gen (6x CPU throttle)..."
-          node scripts/perf-test.js --device ipad-old --map bear_cave --scenario explore --duration 10000 --github --save perf-ipad-bear.json || true
-
-          echo "## Testing witch_hut on simulated iPad 4th Gen (6x CPU throttle)..."
-          node scripts/perf-test.js --device ipad-old --map witch_hut --scenario explore --duration 10000 --github --save perf-ipad-witch.json || true
+      # The simulated-iPad runs (4x and 6x CPU throttle) were removed here on
+      # 2026-09-03. They applied a CPU throttle on top of a software rasteriser,
+      # which is not a slow tablet — it is two unrelated slowdowns multiplied,
+      # and the resulting fps described neither device. What CI can compare is
+      # scene cost, and scene cost does not change with CPU speed: those runs
+      # produced the same counts as the unthrottled runs of the same maps, at
+      # roughly five minutes of runner time each.
+      #
+      # Device emulation is still genuinely useful on a real machine, where a
+      # throttle models a slow CPU against a real GPU. It lives on as
+      # `npm run perf:ipad` / `perf:ipad-old` / `perf:android`.
 
       - name: Generate performance report
         id: report
@@ -136,7 +136,6 @@ jobs:
             perf-results.json
             perf-bear.json
             perf-witch.json
-            perf-ipad-*.json
             perf-screenshot.png
           retention-days: 30
 
@@ -148,9 +147,15 @@ jobs:
           path: perf-results.json
           retention-days: 90
 
+      # What this gates on, since 2026-09-03: scene cost — the number of sprites,
+      # nodes and textures the map asks the renderer to draw. Frame rate is
+      # recorded but never gates, because CI has no GPU and this game is GPU
+      # render-bound; four main-branch runs of identical code spanned 1.4 to
+      # 49.6 fps, so the old fps gate fired on the runner's mood. Full reasoning
+      # in the header of scripts/perf-report.js.
       - name: Check for regressions
         run: |
           if [ -f regression-detected ]; then
-            echo "::error::Performance regression detected! Check the PR comment for details."
+            echo "::error::Scene-cost regression detected — the maps got more expensive to draw. Check the PR comment."
             exit 1
           fi

--- a/hooks/usePixiRenderer.ts
+++ b/hooks/usePixiRenderer.ts
@@ -18,6 +18,7 @@ import { USE_SPRITE_SHADOWS, TILE_LEGEND } from '../constants';
 import { Z_DEPTH_SORTED_BASE } from '../zIndex';
 import { VisibleRange } from '../utils/viewportUtils';
 import { textureManager } from '../utils/TextureManager';
+import { performanceMonitor, SceneNode } from '../utils/PerformanceMonitor';
 import { ColorResolver } from '../utils/ColorResolver';
 import { TileLayer } from '../utils/pixi/TileLayer';
 import { PlayerSprite } from '../utils/pixi/PlayerSprite';
@@ -326,6 +327,11 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
         // Enable z-index sorting on stage
         app.stage.sortableChildren = true;
 
+        // Hand the stage to the performance monitor. This is what makes CI able
+        // to say anything true about performance: a GPU-less runner cannot
+        // measure fps, but it can count exactly what the stage asks to draw.
+        performanceMonitor.attachStage(app.stage as unknown as SceneNode);
+
         // Preload the core set plus this map's textures — NOT the whole game.
         // Loading every texture up front cost ~1.2GB of GPU memory, which iOS
         // answers by killing the tab before the first frame. Everything else
@@ -538,6 +544,7 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
       // Force full re-initialization by destroying and re-creating
       setIsPixiInitialized(false);
       if (pixiAppRef.current) {
+        performanceMonitor.attachStage(null);
         pixiAppRef.current.destroy(true);
         pixiAppRef.current = null;
       }
@@ -568,6 +575,9 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
       canvas?.removeEventListener('webglcontextrestored', handleContextRestored);
       if (pixiAppRef.current) {
         console.log('[usePixiRenderer] Destroying PixiJS application');
+        // Drop the stage reference BEFORE destroy, so nothing can walk a tree
+        // that is being torn down.
+        performanceMonitor.attachStage(null);
         pixiAppRef.current.destroy(true);
         pixiAppRef.current = null;
       }

--- a/scripts/perf-report.js
+++ b/scripts/perf-report.js
@@ -6,6 +6,31 @@
  * Generates a markdown report from performance test results.
  * Used by GitHub Actions to post PR comments.
  *
+ * WHY THE FPS GRADE NO LONGER GATES
+ * ---------------------------------
+ * This report used to award a letter grade from average FPS and fail the build
+ * when FPS fell 10% below a stored baseline. Both were measuring the CI runner.
+ *
+ * The evidence: four consecutive main-branch runs, on effectively identical
+ * code, reported 49.6, 7.5, 1.5 and 1.4 fps -- a 35x spread -- with worst-frame
+ * times between 1.9s and 3.7s. That is structural, not flaky. CI launches Chrome
+ * with `--use-angle=swiftshader` on a GPU-less shared runner, and this game is
+ * GPU render-bound, so the suite measured in software the one axis it cannot
+ * represent, then graded the answer against a scale where 58 fps is an A. The
+ * grade was F on every run that mattered: arithmetic, not a finding.
+ *
+ * A gate whose verdict is uncorrelated with the diff is worse than no gate. It
+ * teaches everyone to scroll past a red X, and takes the real failures with it.
+ *
+ * So on a software renderer, frame timings are recorded and shown but never
+ * graded and never gating. The gate moves to SCENE COST -- how many sprites,
+ * nodes and textures the map asks the renderer to draw. Those are counts, equal
+ * on a Mac, an iPad and SwiftShader, and per the forest-perf investigation they
+ * are the real lever on device frame rate.
+ *
+ * On a GPU runner the timing grade returns by itself: the switch is the actual
+ * WEBGL_debug_renderer_info string, not a CI environment variable.
+ *
  * Usage:
  *   node scripts/perf-report.js
  *
@@ -38,6 +63,22 @@ const THRESHOLDS = {
     regressionPct: 25,  // 25% more memory growth is regression
     warningPct: 15,     // 15% increase triggers warning
   },
+};
+
+/**
+ * Scene-cost budgets -- the metrics that actually gate.
+ *
+ * `minAbs` is there because a percentage on a small count is noise: 3 textures
+ * to 4 is +33% and means nothing. A field must clear BOTH the percentage and the
+ * absolute delta, so the gate stays quiet about rounding and speaks up about a
+ * map that grew a thousand sprites.
+ */
+const SCENE_BUDGETS = {
+  sprites: { label: 'Sprites (drawn)', regressionPct: 20, warningPct: 10, minAbs: 25 },
+  nodes: { label: 'Scene nodes', regressionPct: 20, warningPct: 10, minAbs: 40 },
+  textures: { label: 'Textures', regressionPct: 20, warningPct: 10, minAbs: 4 },
+  textureMB: { label: 'Texture memory', regressionPct: 20, warningPct: 10, minAbs: 8, unit: ' MB' },
+  maxDepth: { label: 'Tree depth', regressionPct: 25, warningPct: 15, minAbs: 2 },
 };
 
 function loadJson(filename) {
@@ -89,31 +130,122 @@ function getStatusEmoji(status) {
   }
 }
 
+/**
+ * Scene-cost status, with the absolute-delta floor applied.
+ */
+function getSceneStatus(current, baseline, budget) {
+  if (baseline === undefined || baseline === null || baseline === 0) return 'neutral';
+  if (Math.abs(current - baseline) < budget.minAbs) return 'neutral';
+  return getRegressionStatus(current, baseline, budget, false);
+}
+
+/**
+ * Frame timings only compare between two runs on the same class of renderer --
+ * and at the same CPU throttle, since a throttled run is a different machine.
+ */
+function timingsAreComparable(results, baseline) {
+  if (!baseline) return false;
+  if (results.renderer?.software || baseline.renderer?.software) return false;
+  return (results.cpuThrottle || 1) === (baseline.cpuThrottle || 1);
+}
+
+/**
+ * Prefer the at-rest snapshot: it does not depend on how far the scripted
+ * movement travelled, which itself depends on the frame rate we do not trust.
+ */
+function sceneOf(run) {
+  if (run?.sceneAtRest) return run.sceneAtRest;
+  if (run?.scene) {
+    return Object.fromEntries(Object.entries(run.scene).map(([k, v]) => [k, v.peak]));
+  }
+  return null;
+}
+
+/**
+ * The scene-cost table. Counts, so they mean the same thing on every machine.
+ */
+function sceneTable(rows, hasBaseline, results) {
+  if (rows.length === 0) {
+    return '\n> :warning: No scene-cost data in this result. The stage was never registered\n' +
+      '> with the performance monitor, so this run graded nothing. Check that\n' +
+      '> usePixiRenderer still calls `performanceMonitor.attachStage`.\n';
+  }
+
+  const where = results.sceneAtRest ? 'at rest, after map load' : 'peak during scenario';
+  let out = `
+### Scene Cost (${where})
+
+What the map asks the renderer to draw. These are counts, so they read the same
+on a laptop, an iPad and a CI software rasteriser — which is why they, and not
+frame rate, decide whether this check passes.
+
+| Metric | Current | ${hasBaseline ? 'Baseline | Change | ' : ''}Status |
+|--------|---------|${hasBaseline ? '---------|--------|' : ''}--------|
+`;
+  for (const row of rows) {
+    const unit = row.budget.unit || '';
+    const baseCell = hasBaseline
+      ? `${row.base ?? 'n/a'}${row.base != null ? unit : ''} | ${row.base != null ? formatChange(row.current, row.base) : ''} | `
+      : '';
+    out += `| **${row.budget.label}** | ${row.current}${unit} | ${baseCell}${getStatusEmoji(row.status)} |\n`;
+  }
+  return out;
+}
+
+function softwareCaveat(results) {
+  return `
+> Measured on \`${results.renderer.name}\`, a **software rasteriser** on a shared
+> CI runner with no GPU. This game is GPU render-bound, so the numbers below
+> describe the runner, not the code in this PR — across four main-branch runs of
+> effectively identical code they ranged from 1.4 to 49.6 fps. Kept for the
+> record, **never graded, never gating**.
+>
+> For a real frame rate, profile on hardware: \`npm run perf:headed\`.
+`;
+}
+
 function generateReport(results, baseline) {
   const hasBaseline = !!baseline;
+  const software = !!results.renderer?.software;
+  const gradeTimings = timingsAreComparable(results, baseline);
   let hasRegression = false;
   let hasWarning = false;
 
-  // Calculate regression statuses
-  const fpsStatus = hasBaseline
+  // Scene cost -- the part that gates, because it is the part CI can measure.
+  const scene = sceneOf(results);
+  const baseScene = hasBaseline ? sceneOf(baseline) : null;
+  const sceneRows = [];
+  if (scene) {
+    for (const [key, budget] of Object.entries(SCENE_BUDGETS)) {
+      const current = scene[key] ?? 0;
+      const base = baseScene ? baseScene[key] : null;
+      const status = getSceneStatus(current, base, budget);
+      if (status === 'regression') hasRegression = true;
+      if (status === 'warning') hasWarning = true;
+      sceneRows.push({ budget, current, base, status });
+    }
+  }
+
+  // Frame timings -- graded only when both runs came off a real GPU.
+  const fpsStatus = gradeTimings
     ? getRegressionStatus(results.fps.avg, baseline.fps.avg, THRESHOLDS.fps, true)
     : 'neutral';
-  const frameTimeStatus = hasBaseline
+  const frameTimeStatus = gradeTimings
     ? getRegressionStatus(results.frameTime.avg, baseline.frameTime.avg, THRESHOLDS.frameTime)
     : 'neutral';
-  const jankStatus = hasBaseline
+  const jankStatus = gradeTimings
     ? getRegressionStatus(results.jank.maxFrameTime, baseline.jank.maxFrameTime, THRESHOLDS.jank)
     : 'neutral';
+
+  if ([fpsStatus, frameTimeStatus, jankStatus].includes('regression')) hasRegression = true;
+  if ([fpsStatus, frameTimeStatus, jankStatus].includes('warning')) hasWarning = true;
+
+  // Heap is CPU-side and so survives the software renderer, but a shared runner
+  // makes it noisy enough to warn rather than gate.
   const memoryStatus = hasBaseline && results.memory && baseline.memory
     ? getRegressionStatus(results.memory.growthMB, baseline.memory.growthMB, THRESHOLDS.memory)
     : 'neutral';
-
-  if ([fpsStatus, frameTimeStatus, jankStatus, memoryStatus].includes('regression')) {
-    hasRegression = true;
-  }
-  if ([fpsStatus, frameTimeStatus, jankStatus, memoryStatus].includes('warning')) {
-    hasWarning = true;
-  }
+  if (memoryStatus === 'regression' || memoryStatus === 'warning') hasWarning = true;
 
   // Overall status
   let overallStatus = ':white_check_mark: **PASSED**';
@@ -128,32 +260,55 @@ function generateReport(results, baseline) {
 ${overallStatus}
 
 **Scenario:** ${results.scenario} | **Duration:** ${results.duration / 1000}s | **Samples:** ${results.sampleCount}
+**Renderer:** \`${results.renderer?.name || 'unknown'}\`${software ? ' — **software rasteriser, no GPU**' : ''}${(results.cpuThrottle || 1) > 1 ? ` | **CPU throttle:** ${results.cpuThrottle}x` : ''}
+${sceneTable(sceneRows, hasBaseline, results)}
+### Frame Timings${software ? ' — advisory only' : ''}
+${software ? softwareCaveat(results) : ''}
 
-### Metrics
-
-| Metric | Current | ${hasBaseline ? 'Baseline | Change |' : ''} Status |
-|--------|---------|${hasBaseline ? '---------|--------|' : ''} ------ |
-| **FPS (avg)** | ${results.fps.avg} fps | ${hasBaseline ? `${baseline.fps.avg} fps | ${formatChange(results.fps.avg, baseline.fps.avg, true)} |` : ''} ${getStatusEmoji(fpsStatus)} |
-| **FPS (min)** | ${results.fps.min} fps | ${hasBaseline ? `${baseline.fps.min} fps | ${formatChange(results.fps.min, baseline.fps.min, true)} |` : ''} |
-| **Frame Time (avg)** | ${results.frameTime.avg} ms | ${hasBaseline ? `${baseline.frameTime.avg} ms | ${formatChange(results.frameTime.avg, baseline.frameTime.avg)} |` : ''} ${getStatusEmoji(frameTimeStatus)} |
-| **Frame Time (P95)** | ${results.frameTime.p95} ms | ${hasBaseline ? `${baseline.frameTime.p95} ms | ${formatChange(results.frameTime.p95, baseline.frameTime.p95)} |` : ''} |
-| **Jank (worst)** | ${results.jank.maxFrameTime} ms | ${hasBaseline ? `${baseline.jank.maxFrameTime} ms | ${formatChange(results.jank.maxFrameTime, baseline.jank.maxFrameTime)} |` : ''} ${getStatusEmoji(jankStatus)} |
+| Metric | Current | ${gradeTimings ? 'Baseline | Change |' : ''} Status |
+|--------|---------|${gradeTimings ? '---------|--------|' : ''} ------ |
+| **FPS (avg)** | ${results.fps.avg} fps | ${gradeTimings ? `${baseline.fps.avg} fps | ${formatChange(results.fps.avg, baseline.fps.avg, true)} |` : ''} ${getStatusEmoji(fpsStatus)} |
+| **FPS (min)** | ${results.fps.min} fps | ${gradeTimings ? `${baseline.fps.min} fps | ${formatChange(results.fps.min, baseline.fps.min, true)} |` : ''} |
+| **Frame Time (avg)** | ${results.frameTime.avg} ms | ${gradeTimings ? `${baseline.frameTime.avg} ms | ${formatChange(results.frameTime.avg, baseline.frameTime.avg)} |` : ''} ${getStatusEmoji(frameTimeStatus)} |
+| **Frame Time (P95)** | ${results.frameTime.p95} ms | ${gradeTimings ? `${baseline.frameTime.p95} ms | ${formatChange(results.frameTime.p95, baseline.frameTime.p95)} |` : ''} |
+| **Jank (worst)** | ${results.jank.maxFrameTime} ms | ${gradeTimings ? `${baseline.jank.maxFrameTime} ms | ${formatChange(results.jank.maxFrameTime, baseline.jank.maxFrameTime)} |` : ''} ${getStatusEmoji(jankStatus)} |
 `;
 
+  // Heap gets its own table: it is CPU-side, so it stays comparable across
+  // renderers even when the timings above are not, and it must not inherit the
+  // timing table's column count.
   if (results.memory) {
-    report += `| **Memory Growth** | ${results.memory.growthMB} MB | ${hasBaseline && baseline.memory ? `${baseline.memory.growthMB} MB | ${formatChange(results.memory.growthMB, baseline.memory.growthMB)} |` : ''} ${getStatusEmoji(memoryStatus)} |
-| **Heap (max)** | ${results.memory.maxMB} MB | ${hasBaseline && baseline.memory ? `${baseline.memory.maxMB} MB | ${formatChange(results.memory.maxMB, baseline.memory.maxMB)} |` : ''} |
+    const memBase = hasBaseline && baseline.memory;
+    report += `
+### Memory
+
+| Metric | Current | ${memBase ? 'Baseline | Change |' : ''} Status |
+|--------|---------|${memBase ? '---------|--------|' : ''} ------ |
+| **Growth** | ${results.memory.growthMB} MB | ${memBase ? `${baseline.memory.growthMB} MB | ${formatChange(results.memory.growthMB, baseline.memory.growthMB)} |` : ''} ${getStatusEmoji(memoryStatus)} |
+| **Heap (max)** | ${results.memory.maxMB} MB | ${memBase ? `${baseline.memory.maxMB} MB | ${formatChange(results.memory.maxMB, baseline.memory.maxMB)} |` : ''} |
 `;
   }
 
-  // Performance grade
-  let grade = 'A';
-  if (results.fps.avg < 30) grade = 'F';
-  else if (results.fps.avg < 45) grade = 'D';
-  else if (results.fps.avg < 55) grade = 'C';
-  else if (results.fps.avg < 58) grade = 'B';
+  // Performance grade.
+  //
+  // A letter grade derived from FPS needs a GPU to grade. On a software
+  // rasteriser it only ever restated the runner's speed, so it is withheld
+  // rather than guessed -- an honest "n/a" beats a confident F.
+  if (software) {
+    report += `
+### Performance Grade: **n/a — no GPU on this runner**
 
-  report += `
+The scene-cost budget above is what gated this run. To grade the frame rate,
+measure it on hardware: \`npm run perf:headed\`.
+`;
+  } else {
+    let grade = 'A';
+    if (results.fps.avg < 30) grade = 'F';
+    else if (results.fps.avg < 45) grade = 'D';
+    else if (results.fps.avg < 55) grade = 'C';
+    else if (results.fps.avg < 58) grade = 'B';
+
+    report += `
 ### Performance Grade: **${grade}**
 
 | Grade | FPS Range | Description |
@@ -164,7 +319,10 @@ ${overallStatus}
 | D | 30-45 fps | Poor |
 | F | <30 fps | Unplayable |
 
+<sub>Measured on \`${results.renderer?.name || 'unknown'}\`.</sub>
+
 `;
+  }
 
   if (hasRegression) {
     report += `
@@ -173,6 +331,11 @@ ${overallStatus}
 Performance has degraded compared to baseline. Please investigate the following:
 
 `;
+    for (const row of sceneRows.filter((r) => r.status === 'regression')) {
+      const pct = (((row.current - row.base) / row.base) * 100).toFixed(1);
+      report += `- **${row.budget.label}** grew ${pct}% (${row.base} → ${row.current}${row.budget.unit || ''}) — ` +
+        `more work per frame on every device, which is the thing that actually shows up as lag.\n`;
+    }
     if (fpsStatus === 'regression') {
       report += `- **FPS dropped** by ${(((baseline.fps.avg - results.fps.avg) / baseline.fps.avg) * 100).toFixed(1)}%\n`;
     }
@@ -190,6 +353,13 @@ Performance has degraded compared to baseline. Please investigate the following:
   if (!hasBaseline) {
     report += `
 > :information_source: No baseline available for comparison. This run will become the baseline on merge to main.
+`;
+  } else if (!gradeTimings && !software) {
+    report += `
+> :information_source: Frame timings not compared: the baseline was recorded on a
+> different machine class (\`${baseline.renderer?.name || 'unknown'}\`, throttle
+> ${baseline.cpuThrottle || 1}x). Scene-cost counters are machine-independent and
+> were compared.
 `;
   }
 
@@ -221,7 +391,15 @@ if (hasRegression) {
 }
 
 // Print summary to console
+const summaryScene = sceneOf(results);
 console.log('\n--- Performance Summary ---');
+console.log(`Renderer: ${results.renderer?.name || 'unknown'}${results.renderer?.software ? ' (software — timings advisory)' : ''}`);
+if (summaryScene) {
+  console.log(
+    `Scene: ${summaryScene.sprites} sprites, ${summaryScene.nodes} nodes, ` +
+    `${summaryScene.textures} textures (${summaryScene.textureMB}MB), depth ${summaryScene.maxDepth}`
+  );
+}
 console.log(`FPS: ${results.fps.avg} (min: ${results.fps.min})`);
 console.log(`Frame Time: ${results.frameTime.avg}ms (P95: ${results.frameTime.p95}ms)`);
 console.log(`Jank: ${results.jank.maxFrameTime}ms worst frame`);

--- a/scripts/perf-test.js
+++ b/scripts/perf-test.js
@@ -105,6 +105,13 @@ const DEVICE_PROFILES = {
   },
 };
 
+// The GPU we ended up on, filled in once the page is open. Read by
+// analyseResults so every saved result records what measured it.
+let RENDERER = { available: false, name: 'unknown', software: false };
+
+// Scene cost sampled once after warmup, before the scenario moves anything.
+let AT_REST = null;
+
 // Check if running in GitHub Actions
 const isGitHubActions = process.env.GITHUB_ACTIONS === 'true' || CONFIG.github;
 
@@ -135,6 +142,43 @@ function logMetric(name, value, unit = '', threshold = null) {
     }
   }
   console.log(`  ${name.padEnd(20)} ${colours[colour]}${value}${unit}${colours.reset}`);
+}
+
+/**
+ * Ask the GPU what it actually is.
+ *
+ * `gl.RENDERER` is masked to "WebKit WebGL" for fingerprinting reasons, so it
+ * tells you nothing; WEBGL_debug_renderer_info gives the real string. This
+ * matters because every fps number this script produces is only meaningful on
+ * hardware. On SwiftShader (CI) the frame time is the software rasteriser's,
+ * not the game's, and reporting it as a grade invents a finding.
+ *
+ * Detecting it here rather than keying off `GITHUB_ACTIONS` means the gate
+ * re-arms itself automatically the day these tests move to a GPU runner.
+ */
+const SOFTWARE_RENDERER_MARKERS = ['swiftshader', 'llvmpipe', 'software', 'lavapipe', 'mesa offscreen'];
+
+async function detectRenderer(page) {
+  const info = await page.evaluate(() => {
+    try {
+      const canvas = document.createElement('canvas');
+      const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+      if (!gl) return { available: false, name: 'none' };
+      const ext = gl.getExtension('WEBGL_debug_renderer_info');
+      return {
+        available: true,
+        name: ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER),
+        vendor: ext ? gl.getParameter(ext.UNMASKED_VENDOR_WEBGL) : '',
+      };
+    } catch (e) {
+      return { available: false, name: 'error', error: e.message };
+    }
+  });
+
+  const name = String(info.name || 'unknown');
+  const software = SOFTWARE_RENDERER_MARKERS.some((m) => name.toLowerCase().includes(m));
+
+  return { ...info, name, software };
 }
 
 async function waitForGame(page) {
@@ -657,6 +701,13 @@ function analyseResults(samples) {
     scenario: CONFIG.scenario,
     sampleCount: samples.length,
 
+    // Provenance. A result carries the renderer that produced it so a consumer
+    // can refuse to compare a SwiftShader run against a GPU run — the single
+    // mistake that made this whole suite report noise as regressions.
+    renderer: RENDERER,
+    device: CONFIG.device || null,
+    cpuThrottle: (CONFIG.device ? DEVICE_PROFILES[CONFIG.device]?.cpuThrottle : CONFIG.cpuThrottle) || 1,
+
     fps: {
       avg: Math.round(avg(fpsSamples) * 10) / 10,
       min: Math.round(min(fpsSamples) * 10) / 10,
@@ -681,9 +732,46 @@ function analyseResults(samples) {
       growthMB: Math.round(((heapSamples[heapSamples.length - 1] - heapSamples[0]) / 1024 / 1024) * 10) / 10,
     } : null,
 
+    // Scene cost — the hardware-independent half of the results, and the only
+    // half CI can compare run to run. `peak` rather than `avg` because a budget
+    // is about the worst moment: the frame that drops on an old iPad is the one
+    // with the most sprites resident, not the average one.
+    scene: sceneSummary(samples),
+
+    // The reproducible one — see where AT_REST is captured.
+    sceneAtRest: AT_REST,
+
     // Final snapshot values
     finalMetrics: samples[samples.length - 1],
   };
+}
+
+/**
+ * Reduce the per-sample scene counts to a peak + median per field.
+ *
+ * Counts move as the player walks (sprites cull in and out), so a single sample
+ * is noisy in a way a total is not. Median describes the steady state, peak
+ * describes what the device actually has to survive.
+ */
+function sceneSummary(samples) {
+  const scenes = samples.map((s) => s.scene).filter(Boolean);
+  if (scenes.length === 0) return null;
+
+  const median = (arr) => {
+    const sorted = [...arr].sort((a, b) => a - b);
+    return sorted[Math.floor(sorted.length / 2)];
+  };
+
+  const fields = ['nodes', 'sprites', 'visibleSprites', 'containers', 'maxDepth', 'textures', 'textureMB'];
+  const out = {};
+  for (const field of fields) {
+    const values = scenes.map((s) => s[field] ?? 0);
+    out[field] = {
+      median: Math.round(median(values) * 10) / 10,
+      peak: Math.round(Math.max(...values) * 10) / 10,
+    };
+  }
+  return out;
 }
 
 function printResults(results) {
@@ -715,6 +803,17 @@ function printResults(results) {
     logMetric('Growth', results.memory.growthMB, ' MB', 10);
   }
 
+  if (results.scene) {
+    log('\nScene Cost (hardware-independent):', 'yellow');
+    logMetric('Sprites (peak)', results.scene.sprites.peak);
+    logMetric('  ...drawn', results.scene.visibleSprites.peak);
+    logMetric('Containers (peak)', results.scene.containers.peak);
+    logMetric('Nodes (peak)', results.scene.nodes.peak);
+    logMetric('Tree depth', results.scene.maxDepth.peak);
+    logMetric('Textures (peak)', results.scene.textures.peak);
+    logMetric('Texture memory', results.scene.textureMB.peak, ' MB');
+  }
+
   log('\n========================================\n', 'cyan');
 
   // GitHub Actions output
@@ -735,6 +834,10 @@ function printGitHubSummary(results) {
 | **Frame Time (avg)** | ${results.frameTime.avg} ms | ${results.frameTime.avg <= 20 ? ':white_check_mark:' : results.frameTime.avg <= 33 ? ':warning:' : ':x:'} |
 | **Jank (worst)** | ${results.jank.maxFrameTime} ms | ${results.jank.maxFrameTime <= 50 ? ':white_check_mark:' : ':warning:'} |
 ${results.memory ? `| **Memory Growth** | ${results.memory.growthMB} MB | ${results.memory.growthMB <= 10 ? ':white_check_mark:' : ':warning:'} |` : ''}
+${results.scene ? `| **Sprites (peak)** | ${results.scene.sprites.peak} | :heavy_minus_sign: |
+| **Textures (peak)** | ${results.scene.textures.peak} (${results.scene.textureMB.peak} MB) | :heavy_minus_sign: |` : ''}
+
+${results.renderer?.software ? `> Renderer: \`${results.renderer.name}\` — **software**. Frame timings above describe the CI rasteriser, not the game.` : `> Renderer: \`${results.renderer?.name || 'unknown'}\``}
 `;
 
   // Write to GitHub step summary if available
@@ -743,15 +846,26 @@ ${results.memory ? `| **Memory Growth** | ${results.memory.growthMB} MB | ${resu
     console.log('Wrote summary to GITHUB_STEP_SUMMARY');
   }
 
-  // Output annotations for warnings/errors
-  if (results.fps.avg < 30) {
-    console.log(`::error::Critical: Average FPS (${results.fps.avg}) is below 30 fps`);
-  } else if (results.fps.avg < 45) {
-    console.log(`::warning::Average FPS (${results.fps.avg}) is below target (45 fps)`);
-  }
+  // Output annotations for warnings/errors.
+  //
+  // Frame-timing annotations are suppressed on a software renderer. They used to
+  // fire on every CI run — "Critical: Average FPS (1.4) is below 30" — which is
+  // true of SwiftShader and says nothing about the game. An annotation that is
+  // always red is an annotation nobody reads, so it took the real ones with it.
+  if (results.renderer?.software) {
+    console.log(
+      `::notice::Frame timings measured on a software renderer (${results.renderer.name}) — recorded, but not graded. Scene-cost counters are the comparable metrics.`
+    );
+  } else {
+    if (results.fps.avg < 30) {
+      console.log(`::error::Critical: Average FPS (${results.fps.avg}) is below 30 fps`);
+    } else if (results.fps.avg < 45) {
+      console.log(`::warning::Average FPS (${results.fps.avg}) is below target (45 fps)`);
+    }
 
-  if (results.jank.maxFrameTime > 100) {
-    console.log(`::warning::High jank detected: ${results.jank.maxFrameTime}ms worst frame`);
+    if (results.jank.maxFrameTime > 100) {
+      console.log(`::warning::High jank detected: ${results.jank.maxFrameTime}ms worst frame`);
+    }
   }
 
   if (results.memory && results.memory.growthMB > 20) {
@@ -799,7 +913,18 @@ function compareResults(current, baseline) {
 
   log('\n========================================\n', 'cyan');
 
-  // Return pass/fail status
+  // Return pass/fail status.
+  //
+  // Frame timings only compare within the same renderer class. Comparing a GPU
+  // baseline to a SwiftShader run (or two SwiftShader runs to each other, where
+  // the spread across identical code was 1.4 to 49.6 fps) produces a verdict
+  // with no relationship to the code under test.
+  if (current.renderer?.software || baseline.renderer?.software) {
+    log('Frame timings not compared: software renderer involved.', 'yellow');
+    log('RESULT: PERFORMANCE OK (timings advisory)', 'green');
+    return true;
+  }
+
   const fpsRegression = current.fps.avg < baseline.fps.avg * 0.9;
   const frameTimeRegression = current.frameTime.avg > baseline.frameTime.avg * 1.1;
   const jankRegression = current.jank.maxFrameTime > baseline.jank.maxFrameTime * 1.5;
@@ -950,6 +1075,10 @@ async function main() {
     // Wait for game to initialise
     await waitForGame(page);
 
+    RENDERER = await detectRenderer(page);
+    log(`  Renderer: ${RENDERER.name}${RENDERER.software ? ' (SOFTWARE — frame timings are not comparable to real hardware)' : ''}`,
+        RENDERER.software ? 'yellow' : 'dim');
+
     // Log current game state
     await logCurrentGameState(page);
 
@@ -963,6 +1092,18 @@ async function main() {
     // Warmup period
     log(`Warming up for ${CONFIG.warmupMs / 1000}s...`, 'dim');
     await new Promise((r) => setTimeout(r, CONFIG.warmupMs));
+
+    // Scene cost at rest: map loaded, textures settled, player still on the spawn
+    // tile. This is the one measurement in the whole run that is genuinely
+    // reproducible, because it does not depend on how far the scripted movement
+    // got — and on a 1.4 fps software renderer, "hold W for one second" covers a
+    // very different distance than it does at 60 fps. Everything measured during
+    // the scenario inherits that variance; this does not.
+    AT_REST = await page.evaluate(() => window.__PERF_MONITOR__?.getMetrics()?.scene ?? null);
+    if (AT_REST) {
+      log(`  Scene at rest: ${AT_REST.visibleSprites}/${AT_REST.sprites} sprites drawn, ` +
+          `${AT_REST.textures} textures (${AT_REST.textureMB} MB), depth ${AT_REST.maxDepth}`, 'dim');
+    }
 
     // Run scenario
     await runScenario(page, CONFIG.scenario);

--- a/tests/sceneCost.test.ts
+++ b/tests/sceneCost.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { measureSceneCost, SceneNode } from '../utils/PerformanceMonitor';
+
+/**
+ * Scene cost is what the CI performance gate now grades, in place of frame rate.
+ *
+ * The reason is in scripts/perf-report.js: CI renders through SwiftShader on a
+ * GPU-less runner, so fps there measured the runner, not the game — four
+ * main-branch runs of identical code spanned 1.4 to 49.6 fps. These counts do
+ * not, which is the whole point of moving the gate onto them. So they need to be
+ * right, and they need to keep counting the same things.
+ */
+
+const sprite = (uid: number, w = 64, h = 64, extra: Partial<SceneNode> = {}): SceneNode => ({
+  texture: { source: { uid, width: w, height: h } },
+  ...extra,
+});
+
+describe('measureSceneCost', () => {
+  it('returns zeros rather than throwing when no stage is attached', () => {
+    // The harness reads metrics before the renderer exists, and on teardown
+    // after it is gone. Neither may throw inside a getMetrics() call.
+    expect(measureSceneCost(null)).toMatchObject({ nodes: 0, sprites: 0, textureMB: 0 });
+    expect(measureSceneCost(undefined)).toMatchObject({ nodes: 0 });
+  });
+
+  it('separates sprites from the containers that group them', () => {
+    const stage: SceneNode = { children: [{ children: [sprite(1), sprite(2)] }, sprite(3)] };
+    const cost = measureSceneCost(stage);
+
+    expect(cost.sprites).toBe(3);
+    expect(cost.containers).toBe(2); // the stage is itself a container
+    expect(cost.nodes).toBe(5); // stage + container + 3 sprites
+  });
+
+  it('counts a hidden subtree as built but not as drawn', () => {
+    // The gap between the two is the signal: a layer left mounted-but-hidden
+    // still costs transform and sort work, and is a common accidental regression.
+    const stage: SceneNode = {
+      children: [sprite(1), { visible: false, children: [sprite(2), sprite(3)] }],
+    };
+    const cost = measureSceneCost(stage);
+
+    expect(cost.sprites).toBe(3);
+    expect(cost.visibleSprites).toBe(1);
+  });
+
+  it('treats alpha 0 and renderable false as not drawn', () => {
+    const stage: SceneNode = {
+      children: [sprite(1, 64, 64, { alpha: 0 }), sprite(2, 64, 64, { renderable: false }), sprite(3)],
+    };
+    expect(measureSceneCost(stage).visibleSprites).toBe(1);
+  });
+
+  it('deduplicates texture sources, so an atlas reused 100 times costs once', () => {
+    const stage: SceneNode = { children: [sprite(7), sprite(7), sprite(7), sprite(9)] };
+    const cost = measureSceneCost(stage);
+
+    expect(cost.sprites).toBe(4);
+    expect(cost.textures).toBe(2);
+  });
+
+  it('estimates texture residency as RGBA bytes', () => {
+    // 1024x1024x4 = 4 MB.
+    const stage: SceneNode = { children: [sprite(1, 1024, 1024)] };
+    expect(measureSceneCost(stage).textureMB).toBe(4);
+  });
+
+  it('reports the deepest nesting, not the average', () => {
+    const stage: SceneNode = { children: [{ children: [{ children: [sprite(1)] }] }, sprite(2)] };
+    expect(measureSceneCost(stage).maxDepth).toBe(3);
+  });
+
+  it('ignores a hidden sprite when totalling texture memory', () => {
+    // Residency is about what the frame actually needs resident.
+    const stage: SceneNode = {
+      children: [sprite(1, 1024, 1024), sprite(2, 1024, 1024, { visible: false })],
+    };
+    expect(measureSceneCost(stage).textureMB).toBe(4);
+  });
+});

--- a/utils/PerformanceMonitor.ts
+++ b/utils/PerformanceMonitor.ts
@@ -19,6 +19,26 @@
  *   (window as any).__PERF_MONITOR__ = performanceMonitor;
  */
 
+/**
+ * What the renderer is being *asked* to draw, counted from the live scene graph.
+ *
+ * Every field here is a count or a byte total, not a duration. That is the whole
+ * point: fps on a GPU-less CI runner is a measurement of the runner, but "this
+ * map now puts 4,000 sprites on the stage" is the same number on a Mac, on an
+ * iPad and on a SwiftShader software rasteriser. The forest-perf investigation
+ * found the real lever is sprite density and texture residency, so these are
+ * the quantities a regression would actually move.
+ */
+export interface SceneCost {
+  nodes: number;          // every node in the stage tree
+  sprites: number;        // renderable leaves (Sprite/AnimatedSprite/Text/Graphics)
+  visibleSprites: number; // ...of those, the ones actually drawn this frame
+  containers: number;     // grouping nodes
+  maxDepth: number;       // deepest nesting — proxy for transform/sort work
+  textures: number;       // distinct texture sources referenced by visible sprites
+  textureMB: number;      // estimated GPU residency of those sources (RGBA)
+}
+
 export interface PerformanceMetrics {
   // Frame timing
   fps: number;
@@ -35,6 +55,10 @@ export interface PerformanceMetrics {
   spriteCount: number;       // PixiJS sprite count
   domNodeCount: number;      // DOM node count
 
+  // Scene cost — see SceneCost. Hardware-independent, so unlike fps these
+  // survive being measured on a software renderer.
+  scene: SceneCost;
+
   // Timing
   timestamp: number;
   uptime: number;            // Seconds since monitoring started
@@ -45,6 +69,86 @@ export interface PerformanceSnapshot {
   timestamp: number;
   metrics: PerformanceMetrics;
   label?: string;
+}
+
+/**
+ * The slice of a PixiJS display object this module needs. Structural, so the
+ * monitor never imports pixi.js and can be unit-tested against plain objects.
+ */
+export interface SceneNode {
+  children?: SceneNode[];
+  visible?: boolean;
+  renderable?: boolean;
+  alpha?: number;
+  texture?: { source?: { uid?: number | string; width?: number; height?: number } } | null;
+}
+
+export const EMPTY_SCENE_COST: SceneCost = {
+  nodes: 0,
+  sprites: 0,
+  visibleSprites: 0,
+  containers: 0,
+  maxDepth: 0,
+  textures: 0,
+  textureMB: 0,
+};
+
+/**
+ * Count what the stage is asking the renderer to draw.
+ *
+ * A node counts as a sprite when it carries a texture; anything with children
+ * and no texture is a container. `visible` is inherited, so a hidden subtree
+ * contributes to `sprites` (it is still built, still transformed on a resort)
+ * but not to `visibleSprites` — the gap between the two is itself a useful
+ * signal, because a layer left mounted-but-hidden is a common accidental cost.
+ *
+ * Texture memory is an estimate: width * height * 4 bytes, deduplicated by
+ * source, ignoring mipmaps and compression. It tracks *residency*, which is the
+ * number that decides whether an old iPad evicts textures mid-frame.
+ */
+export function measureSceneCost(stage: SceneNode | null | undefined): SceneCost {
+  if (!stage) return { ...EMPTY_SCENE_COST };
+
+  const cost: SceneCost = { ...EMPTY_SCENE_COST };
+  const seenSources = new Set<number | string>();
+  let textureBytes = 0;
+
+  const walk = (node: SceneNode, depth: number, parentVisible: boolean): void => {
+    cost.nodes++;
+    if (depth > cost.maxDepth) cost.maxDepth = depth;
+
+    const drawn =
+      parentVisible &&
+      node.visible !== false &&
+      node.renderable !== false &&
+      (node.alpha === undefined || node.alpha > 0);
+
+    const source = node.texture?.source;
+    if (source) {
+      cost.sprites++;
+      if (drawn) {
+        cost.visibleSprites++;
+        const uid = source.uid;
+        const key = uid === undefined ? `${source.width}x${source.height}` : uid;
+        if (!seenSources.has(key)) {
+          seenSources.add(key);
+          textureBytes += (source.width || 0) * (source.height || 0) * 4;
+        }
+      }
+    } else if (node.children && node.children.length > 0) {
+      cost.containers++;
+    }
+
+    if (node.children) {
+      for (const child of node.children) walk(child, depth + 1, drawn);
+    }
+  };
+
+  walk(stage, 0, true);
+
+  cost.textures = seenSources.size;
+  cost.textureMB = Math.round((textureBytes / 1024 / 1024) * 10) / 10;
+  return cost;
 }
 
 const SAMPLE_SIZE = 60; // Track last 60 frames for averages
@@ -59,6 +163,10 @@ class PerformanceMonitor {
   // External counts (set by renderers)
   private _spriteCount: number = 0;
   private _domNodeCount: number = 0;
+
+  // The live PixiJS stage, registered by usePixiRenderer. Held as a plain
+  // reference and cleared on teardown; never walked on the frame path.
+  private _stage: SceneNode | null = null;
 
   constructor() {
     this.startTime = performance.now();
@@ -91,6 +199,17 @@ class PerformanceMonitor {
    */
   setSpriteCount(count: number): void {
     this._spriteCount = count;
+  }
+
+  /**
+   * Register the PixiJS stage so scene cost can be counted.
+   *
+   * Duck-typed rather than typed as `PIXI.Container` so this module stays free
+   * of a pixi.js import — it is loaded by the headless harness and by tests that
+   * have no renderer at all.
+   */
+  attachStage(stage: SceneNode | null): void {
+    this._stage = stage;
   }
 
   /**
@@ -139,6 +258,10 @@ class PerformanceMonitor {
     // DOM node count
     const domNodeCount = this._domNodeCount || document.querySelectorAll('*').length;
 
+    // Walk the stage. Only ever called on demand (debug HUD, headless harness),
+    // never from the frame loop, so an O(nodes) walk is not on any hot path.
+    const scene = measureSceneCost(this._stage);
+
     return {
       fps: Math.round(fps * 10) / 10,
       avgFrameTime: Math.round(avgFrameTime * 100) / 100,
@@ -147,8 +270,9 @@ class PerformanceMonitor {
       frameTimeVariance: Math.round(variance * 100) / 100,
       heapUsed,
       heapTotal,
-      spriteCount: this._spriteCount,
+      spriteCount: this._spriteCount || scene.sprites,
       domNodeCount,
+      scene,
       timestamp: now,
       uptime: (now - this.startTime) / 1000,
       frameCount: this.frameCount,
@@ -199,7 +323,7 @@ class PerformanceMonitor {
   getSummary(): string {
     const m = this.getMetrics();
     const heapMB = m.heapUsed ? `${(m.heapUsed / 1024 / 1024).toFixed(1)}MB` : 'N/A';
-    return `FPS: ${m.fps} | Frame: ${m.avgFrameTime}ms (${m.minFrameTime}-${m.maxFrameTime}ms) | Jank: ${m.frameTimeVariance}ms | Heap: ${heapMB} | Sprites: ${m.spriteCount} | DOM: ${m.domNodeCount}`;
+    return `FPS: ${m.fps} | Frame: ${m.avgFrameTime}ms (${m.minFrameTime}-${m.maxFrameTime}ms) | Jank: ${m.frameTimeVariance}ms | Heap: ${heapMB} | Sprites: ${m.scene.visibleSprites}/${m.scene.sprites} | Tex: ${m.scene.textures} (${m.scene.textureMB}MB) | DOM: ${m.domNodeCount}`;
   }
 
   /**


### PR DESCRIPTION
## What

Moves the CI performance gate from frame rate to **scene cost** — the counts of sprites, nodes, textures and tree depth the map asks the renderer to draw.

## Why

CI runs Chrome under SwiftShader on GPU-less runners, and this game is GPU render-bound. Four consecutive main-branch runs of identical code reported **1.4 to 49.6 fps** — a 35× spread — so the old fps gate fired on the runner's mood, not the diff. A gate whose verdict is uncorrelated with the change teaches everyone to scroll past a red X.

Scene-cost counts are identical on a Mac, an iPad and a software rasteriser, and per the forest-perf investigation sprite density and texture residency are the real levers on device frame rate.

## Changes

- `PerformanceMonitor`: new `measureSceneCost()` walks the live scene graph (`SceneNode` interface)
- `usePixiRenderer`: registers the stage on init, tears it down before `destroy()` (both the re-init and unmount paths)
- `perf-report.js`: scene-cost table with regression budgets (percentage **and** absolute-delta floors so small-count noise stays quiet); frame timings recorded but only gate when both runs used a real GPU
- `performance.yml`: drops the simulated-iPad sub-runs (CPU throttle × software rasteriser = two unrelated slowdowns multiplied); timeout 35→25 min
- Device emulation stays available locally: `npm run perf:ipad` / `perf:ipad-old` / `perf:android`
- New `tests/sceneCost.test.ts` locks the counting behaviour, including the null/teardown cases the harness hits

## Verification

- `npm run verify`: tsc clean, 874 tests pass (incl. the new sceneCost suite)
- The perf workflow runs on this PR, exercising the new gate before merge