### PR TITLE
Remove all unused imports, locals and arguments (eslint sweep to zero)

### DIFF
--- a/GameState.ts
+++ b/GameState.ts
@@ -17,7 +17,7 @@ import { STAMINA, WATERING_CAN } from './constants';
 import { eventBus, GameEvent } from './utils/EventBus';
 import { sharedPlacedItemsManager } from './multiplayer/sharedPlacedItems';
 import { eventChainManager } from './utils/EventChainManager';
-import { loadPersistedState, runSaveMigrations, SAVE_VERSION } from './GameStatePersistence';
+import { loadPersistedState, SAVE_VERSION } from './GameStatePersistence';
 export { runSaveMigrations, SAVE_VERSION } from './GameStatePersistence';
 
 export interface CharacterCustomization {

--- a/NPCManager.ts
+++ b/NPCManager.ts
@@ -1,4 +1,4 @@
-import { NPC, Position, Direction, NPCBehavior, isTileSolid, SeasonalLocation } from './types';
+import { NPC, Position, Direction, NPCBehavior, isTileSolid } from './types';
 import { getTileData } from './utils/mapUtils';
 import { PLAYER_SIZE } from './constants';
 import { metadataCache } from './utils/MetadataCache';
@@ -1176,7 +1176,6 @@ class NPCManagerClass {
    * Initialize seasonal locations (call this after all maps are registered)
    */
   initializeSeasonalLocations(): void {
-    const currentTime = TimeManager.getCurrentTime();
     // Set currentSeason to null first to force the initial placement
     this.currentSeason = null;
     // Now update to the actual current season (this will trigger placement)

--- a/components/AnimationOverlay.tsx
+++ b/components/AnimationOverlay.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MapDefinition, TileAnimation, Position } from '../types';
+import { MapDefinition, Position } from '../types';
 import { getTileData } from '../utils/mapUtils';
 import { TILE_SIZE, TILE_ANIMATIONS } from '../constants';
 

--- a/components/Bookshelf.tsx
+++ b/components/Bookshelf.tsx
@@ -24,9 +24,6 @@ interface BookshelfProps {
  */
 const Bookshelf: React.FC<BookshelfProps> = ({
   isTouchDevice,
-  playerPosition,
-  currentMapId,
-  nearbyNPCs,
   onRecipeBookOpen,
   onMagicBookOpen,
   onJournalOpen,

--- a/components/CookingInterface.tsx
+++ b/components/CookingInterface.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { RecipeDefinition, RecipeCategory, RECIPES, getRecipe } from '../data/recipes';
+import { RecipeCategory, getRecipe } from '../data/recipes';
 import { getItem } from '../data/items';
 import { cookingManager, CookingResult } from '../utils/CookingManager';
 import { audioManager } from '../utils/AudioManager';
@@ -23,14 +23,7 @@ interface CookingInterfaceProps {
  * Shows recipes, ingredients, and allows player to cook
  * Cooked items appear on the stove/campfire instead of in inventory
  */
-const CookingInterface: React.FC<CookingInterfaceProps> = ({
-  isOpen,
-  onClose,
-  locationType,
-  cookingPosition,
-  currentMapId,
-  onItemPlaced,
-}) => {
+const CookingInterface: React.FC<CookingInterfaceProps> = ({ isOpen, onClose, locationType }) => {
   const isTouchDevice = useTouchDevice();
   const [selectedRecipe, setSelectedRecipe] = useState<string | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<RecipeCategory | 'all'>('all');
@@ -48,12 +41,6 @@ const CookingInterface: React.FC<CookingInterfaceProps> = ({
 
   // Get selected recipe details
   const recipe = selectedRecipe ? getRecipe(selectedRecipe) : null;
-
-  // Check if we can cook
-  const canCook = recipe ? cookingManager.hasIngredients(recipe.id) : false;
-
-  // Get missing ingredients
-  const missingIngredients = recipe ? cookingManager.getMissingIngredients(recipe.id) : [];
 
   // Get ingredient display info
   const getIngredientInfo = (itemId: string, needed: number) => {
@@ -288,8 +275,8 @@ const CookingInterface: React.FC<CookingInterfaceProps> = ({
         {/* Footer */}
         <div className="bg-amber-900/50 px-4 py-2 border-t border-amber-700 text-center">
           <p className="text-amber-400 text-xs">
-            {isTouchDevice ? 'Tap ✕ to close' : 'Press ESC or E to close'} • Cook recipes 3 times
-            to master them
+            {isTouchDevice ? 'Tap ✕ to close' : 'Press ESC or E to close'} • Cook recipes 3 times to
+            master them
           </p>
         </div>
 

--- a/components/CutscenePlayer.tsx
+++ b/components/CutscenePlayer.tsx
@@ -15,7 +15,6 @@ import {
   CutsceneBackgroundLayer,
   CutsceneCharacter,
   CutsceneDialogue,
-  CutsceneLayerAnimation,
   CutsceneWeatherEffect,
   CutscenePanDirection,
 } from '../types';
@@ -58,7 +57,11 @@ const CutscenePlayer: React.FC<CutscenePlayerProps> = ({ onComplete }) => {
     const cutscene = state.currentCutscene;
     if (cutscene) {
       // Capture completion action now — it will be cleared when endCutscene() fires
-      const onComplete = cutscene.onComplete as { action: string; mapId?: string; position?: { x: number; y: number } };
+      const onComplete = cutscene.onComplete as {
+        action: string;
+        mapId?: string;
+        position?: { x: number; y: number };
+      };
       completionActionRef.current = { ...onComplete, cutsceneId: cutscene.id };
     }
 
@@ -95,7 +98,9 @@ const CutscenePlayer: React.FC<CutscenePlayerProps> = ({ onComplete }) => {
       console.log(`[CutscenePlayer] Audio already started for ${cutscene.id}, skipping replay`);
       previousMusicRef.current = cutsceneManager.getPreviousMusicBeforeCutscene();
     } else {
-      console.log(`[CutscenePlayer] Starting audio for ${cutscene.id}: music=${cutscene.audio.music}`);
+      console.log(
+        `[CutscenePlayer] Starting audio for ${cutscene.id}: music=${cutscene.audio.music}`
+      );
       previousMusicRef.current = audioManager.getCurrentMusic();
       cutsceneManager.markAudioStarted(cutscene.id, previousMusicRef.current);
 
@@ -154,7 +159,10 @@ const CutscenePlayer: React.FC<CutscenePlayerProps> = ({ onComplete }) => {
         // before notifying, so we can't read it from state here)
         if (!onCompleteCalledRef.current) {
           onCompleteCalledRef.current = true;
-          const action = completionActionRef.current ?? { action: 'return', cutsceneId: cutsceneIdRef.current };
+          const action = completionActionRef.current ?? {
+            action: 'return',
+            cutsceneId: cutsceneIdRef.current,
+          };
           onComplete(action);
         }
         return;
@@ -363,8 +371,12 @@ const LetterboxBars: React.FC<LetterboxBarsProps> = ({ mode, onClosed }) => {
 
   const height =
     mode === 'close'
-      ? active ? '50%' : '0%'  // close: 0% → 50%
-      : active ? '0%' : '50%'; // open:  50% → 0%
+      ? active
+        ? '50%'
+        : '0%' // close: 0% → 50%
+      : active
+        ? '0%'
+        : '50%'; // open:  50% → 0%
 
   const barStyle: React.CSSProperties = {
     position: 'absolute',

--- a/components/DebugOverlay.tsx
+++ b/components/DebugOverlay.tsx
@@ -1,14 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { TILE_SIZE, MAP_WIDTH, MAP_HEIGHT, DEBUG } from '../constants';
 import { getTileData } from '../utils/mapUtils';
-import {
-  Position,
-  Transition,
-  isTileSolid,
-  CollisionType,
-  FarmPlotState,
-  CropGrowthStage,
-} from '../types';
+import { Position, Transition, CollisionType, FarmPlotState, CropGrowthStage } from '../types';
 import DebugInfoPanel from './DebugInfoPanel';
 import { Z_DEBUG_TILES, Z_DEBUG_TRANSITIONS, Z_DEBUG_CLICK, zClass } from '../zIndex';
 import { mapManager } from '../maps';
@@ -54,8 +47,6 @@ const DebugOverlay: React.FC<DebugOverlayProps> = ({
         Array.from({ length: MAP_WIDTH }).map((_, x) => {
           const tileData = getTileData(x, y);
           if (!tileData) return null;
-
-          const isClicked = clickedTile?.x === x && clickedTile?.y === y;
 
           return (
             <div

--- a/components/FarmActionAnimation.tsx
+++ b/components/FarmActionAnimation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { Z_FARM_ACTIONS } from '../zIndex';
 import GameIcon from './GameIcon';
 import { iconAssets } from '../iconAssets';

--- a/components/ForegroundParallax.tsx
+++ b/components/ForegroundParallax.tsx
@@ -182,7 +182,6 @@ const FULL_FADE_DISTANCE = 250; // Fully faded when player is this close
 const ForegroundParallax: React.FC<ForegroundParallaxProps> = ({
   cameraX,
   cameraY,
-  mapWidth,
   mapHeight,
   enabled = true,
 }) => {

--- a/components/HelpBrowser.tsx
+++ b/components/HelpBrowser.tsx
@@ -953,52 +953,52 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
                   remarkPlugins={[remarkGfm]}
                   components={{
                     // Custom cottagecore styling for markdown elements
-                    h1: ({ node, ...props }) => (
+                    h1: ({ ...props }) => (
                       <h1
                         className="text-4xl font-serif font-bold mb-4 pb-2"
                         style={{ color: colours.brass, borderBottom: `2px solid ${colours.wood}` }}
                         {...props}
                       />
                     ),
-                    h2: ({ node, ...props }) => (
+                    h2: ({ ...props }) => (
                       <h2
                         className="text-3xl font-serif font-bold mt-8 mb-3"
                         style={{ color: colours.brassDark }}
                         {...props}
                       />
                     ),
-                    h3: ({ node, ...props }) => (
+                    h3: ({ ...props }) => (
                       <h3
                         className="text-2xl font-serif font-bold mt-6 mb-2"
                         style={{ color: colours.wood }}
                         {...props}
                       />
                     ),
-                    p: ({ node, ...props }) => (
+                    p: ({ ...props }) => (
                       <p
                         className="mb-4 leading-relaxed"
                         style={{ color: colours.text }}
                         {...props}
                       />
                     ),
-                    ul: ({ node, ...props }) => (
+                    ul: ({ ...props }) => (
                       <ul
                         className="list-disc list-inside mb-4 space-y-1"
                         style={{ color: colours.text }}
                         {...props}
                       />
                     ),
-                    ol: ({ node, ...props }) => (
+                    ol: ({ ...props }) => (
                       <ol
                         className="list-decimal list-inside mb-4 space-y-1"
                         style={{ color: colours.text }}
                         {...props}
                       />
                     ),
-                    li: ({ node, ...props }) => (
+                    li: ({ ...props }) => (
                       <li className="ml-4" style={{ color: colours.text }} {...props} />
                     ),
-                    code: ({ node, inline, ...props }: any) =>
+                    code: ({ inline, ...props }: any) =>
                       inline ? (
                         <code
                           className="px-2 py-1 rounded font-mono text-sm"
@@ -1012,31 +1012,31 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
                           {...props}
                         />
                       ),
-                    pre: ({ node, ...props }) => (
+                    pre: ({ ...props }) => (
                       <pre
                         className="p-4 rounded overflow-x-auto mb-4"
                         style={{ background: colours.parchmentDark }}
                         {...props}
                       />
                     ),
-                    strong: ({ node, ...props }) => (
+                    strong: ({ ...props }) => (
                       <strong
                         className="font-bold"
                         style={{ color: colours.woodDarker }}
                         {...props}
                       />
                     ),
-                    em: ({ node, ...props }) => (
+                    em: ({ ...props }) => (
                       <em className="italic" style={{ color: colours.wood }} {...props} />
                     ),
-                    a: ({ node, ...props }) => (
+                    a: ({ ...props }) => (
                       <a
                         className="underline hover:brightness-125"
                         style={{ color: colours.brass }}
                         {...props}
                       />
                     ),
-                    blockquote: ({ node, ...props }) => (
+                    blockquote: ({ ...props }) => (
                       <blockquote
                         className="pl-4 italic mb-4"
                         style={{
@@ -1046,10 +1046,10 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
                         {...props}
                       />
                     ),
-                    table: ({ node, ...props }) => (
+                    table: ({ ...props }) => (
                       <table className="w-full border-collapse mb-4" {...props} />
                     ),
-                    th: ({ node, ...props }) => (
+                    th: ({ ...props }) => (
                       <th
                         className="px-4 py-2 text-left font-serif font-bold"
                         style={{
@@ -1060,7 +1060,7 @@ const HelpBrowser: React.FC<HelpBrowserProps> = ({ onClose, onOpenCharacterSelec
                         {...props}
                       />
                     ),
-                    td: ({ node, ...props }) => (
+                    td: ({ ...props }) => (
                       <td
                         className="px-4 py-2"
                         style={{ border: `1px solid ${colours.wood}`, color: colours.text }}

--- a/components/Inventory.tsx
+++ b/components/Inventory.tsx
@@ -63,7 +63,14 @@ const Inventory: React.FC<InventoryProps> = ({
   isMagicUnlocked = false,
   photoCount = 0,
 }) => {
-  type InventoryFilter = 'all' | 'ingredients' | 'farming' | 'seeds' | 'materials' | 'magical' | 'photos';
+  type InventoryFilter =
+    | 'all'
+    | 'ingredients'
+    | 'farming'
+    | 'seeds'
+    | 'materials'
+    | 'magical'
+    | 'photos';
   const [activeFilter, setActiveFilter] = useState<InventoryFilter>('all');
 
   // Drag-drop state for desktop
@@ -95,48 +102,39 @@ const Inventory: React.FC<InventoryProps> = ({
 
   if (!isOpen) return null;
 
-  // Calculate dynamic slot count for unlimited inventory
+  // Dynamic slot count for unlimited inventory
   const COLS = 9;
   const MIN_ROWS = 4; // Always show at least 4 rows (36 slots) for quick slots + buffer
   const BUFFER_ROWS = 1; // Show one extra empty row after last item
 
-  // Keep total count for footer display (unfiltered)
-  let displaySlots: number;
-  if (maxSlots !== undefined) {
-    displaySlots = maxSlots;
-  } else {
-    const usedSlots = items.length;
-    const requiredRows = Math.ceil(usedSlots / COLS) + BUFFER_ROWS;
-    displaySlots = Math.max(MIN_ROWS, requiredRows) * COLS;
-  }
-
   const FILTER_CATEGORIES: Record<InventoryFilter, ItemCategory[]> = {
-    all:         [],
+    all: [],
     ingredients: [ItemCategory.INGREDIENT, ItemCategory.FOOD, ItemCategory.CROP],
-    farming:     [ItemCategory.CROP, ItemCategory.SEED, ItemCategory.TOOL],
-    seeds:       [ItemCategory.SEED],
-    materials:   [ItemCategory.MATERIAL, ItemCategory.MISC, ItemCategory.DECORATION],
-    magical:     [ItemCategory.MAGICAL_INGREDIENT, ItemCategory.POTION],
-    photos:      [ItemCategory.KEEPSAKE],
+    farming: [ItemCategory.CROP, ItemCategory.SEED, ItemCategory.TOOL],
+    seeds: [ItemCategory.SEED],
+    materials: [ItemCategory.MATERIAL, ItemCategory.MISC, ItemCategory.DECORATION],
+    magical: [ItemCategory.MAGICAL_INGREDIENT, ItemCategory.POTION],
+    photos: [ItemCategory.KEEPSAKE],
   };
 
   const filterTabs: { id: InventoryFilter; label: string }[] = [
-    { id: 'all',         label: 'All' },
+    { id: 'all', label: 'All' },
     { id: 'ingredients', label: 'Ingredients' },
-    { id: 'farming',     label: 'Farming' },
-    { id: 'seeds',       label: 'Seeds' },
-    { id: 'materials',   label: 'Materials' },
+    { id: 'farming', label: 'Farming' },
+    { id: 'seeds', label: 'Seeds' },
+    { id: 'materials', label: 'Materials' },
     ...(isMagicUnlocked ? [{ id: 'magical' as InventoryFilter, label: 'Magical' }] : []),
     { id: 'photos', label: `Photos${photoCount > 0 ? ` (${photoCount})` : ''}` },
   ];
 
   // Apply category filter
-  const filteredItems = activeFilter === 'all'
-    ? items
-    : items.filter((item) => {
-        const cat = getItem(item.id)?.category;
-        return cat !== undefined && FILTER_CATEGORIES[activeFilter].includes(cat);
-      });
+  const filteredItems =
+    activeFilter === 'all'
+      ? items
+      : items.filter((item) => {
+          const cat = getItem(item.id)?.category;
+          return cat !== undefined && FILTER_CATEGORIES[activeFilter].includes(cat);
+        });
 
   // Recalculate slot count for filtered view
   let filteredDisplaySlots: number;
@@ -162,11 +160,7 @@ const Inventory: React.FC<InventoryProps> = ({
     longPress.handlers.onTouchStart(e);
   };
 
-  const handleContextMenu = (
-    item: InventoryItem | null,
-    index: number,
-    e: React.MouseEvent
-  ) => {
+  const handleContextMenu = (item: InventoryItem | null, index: number, e: React.MouseEvent) => {
     e.preventDefault(); // suppress the browser's own menu whether or not we show ours
     if (!item || !onItemContextMenu) return;
     onItemContextMenu(item, index, { clientX: e.clientX, clientY: e.clientY });
@@ -296,7 +290,11 @@ const Inventory: React.FC<InventoryProps> = ({
           {activeFilter === 'photos' && filteredItems.length === 0 && (
             <div className="flex flex-col items-center justify-center py-10 text-amber-500 text-sm gap-2">
               <span className="text-4xl">📷</span>
-              <p className="text-center">No photos yet.<br />Equip your camera and take some!</p>
+              <p className="text-center">
+                No photos yet.
+                <br />
+                Equip your camera and take some!
+              </p>
             </div>
           )}
           <div className={`grid ${gridCols} ${slotGap}`}>
@@ -381,7 +379,9 @@ const Inventory: React.FC<InventoryProps> = ({
 
                       {/* Exposure counter badge on camera */}
                       {item.id === 'camera' && (
-                        <div className={`absolute bottom-0 right-0 text-white text-xs font-bold px-1 py-0.5 rounded-tl-lg rounded-br-lg min-w-[28px] text-center ${photoCount >= CAMERA.MAX_EXPOSURES ? 'bg-red-700/90' : 'bg-teal-700/90'}`}>
+                        <div
+                          className={`absolute bottom-0 right-0 text-white text-xs font-bold px-1 py-0.5 rounded-tl-lg rounded-br-lg min-w-[28px] text-center ${photoCount >= CAMERA.MAX_EXPOSURES ? 'bg-red-700/90' : 'bg-teal-700/90'}`}
+                        >
                           {photoCount}/{CAMERA.MAX_EXPOSURES}
                         </div>
                       )}

--- a/components/NPCInteractionIndicators.tsx
+++ b/components/NPCInteractionIndicators.tsx
@@ -18,7 +18,6 @@ const NPCS_WITH_INDICATORS = ['shop_counter_fox'];
 
 // Distance thresholds
 const ICON_VISIBLE_DISTANCE = 3.0; // Icon visible from further away
-const TOOLTIP_DISTANCE = 1.5; // Tooltip only when very close
 
 /**
  * Floating icon that bobs gently above an NPC

--- a/components/NPCRenderer.tsx
+++ b/components/NPCRenderer.tsx
@@ -24,7 +24,6 @@ interface NPCRendererProps {
  */
 const NPCRenderer: React.FC<NPCRendererProps> = ({
   playerPos,
-  npcUpdateTrigger,
   characterScale = 1.0,
   gridOffset,
 }) => {
@@ -103,8 +102,14 @@ const NPCRenderer: React.FC<NPCRendererProps> = ({
               className="absolute pointer-events-none"
               style={{
                 left: (npc.position.x - (PLAYER_SIZE * npcScale) / 2) * TILE_SIZE + offsetX,
-                top: (npc.position.y - (PLAYER_SIZE * npcScale) / 2) * TILE_SIZE + offsetY +
-                  (npc.hover ? Math.sin((Date.now() / npc.hover.frequency) * Math.PI * 2) * npc.hover.amplitude * TILE_SIZE : 0),
+                top:
+                  (npc.position.y - (PLAYER_SIZE * npcScale) / 2) * TILE_SIZE +
+                  offsetY +
+                  (npc.hover
+                    ? Math.sin((Date.now() / npc.hover.frequency) * Math.PI * 2) *
+                      npc.hover.amplitude *
+                      TILE_SIZE
+                    : 0),
                 width: PLAYER_SIZE * npcScale * TILE_SIZE,
                 height: PLAYER_SIZE * npcScale * TILE_SIZE,
                 transform: shouldFlip ? 'scaleX(-1)' : undefined,

--- a/components/PlacedItems.tsx
+++ b/components/PlacedItems.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { PlacedItem } from '../types';
 import { TILE_SIZE } from '../constants';
-import { shouldShowDecayWarning, getDecayProgress } from '../utils/itemDecayManager';
+import { shouldShowDecayWarning } from '../utils/itemDecayManager';
 import { getItem } from '../data/items';
 import { Z_PLAYER, Z_SPRITE_BACKGROUND } from '../zIndex';
 
@@ -50,7 +50,6 @@ const PlacedItems: React.FC<PlacedItemsProps> = ({
           ? Z_SPRITE_BACKGROUND
           : Z_PLAYER + Math.floor(feetY);
         const showWarning = shouldShowDecayWarning(item);
-        const decayProgress = getDecayProgress(item);
         const imageSrc = item.customImage || item.image;
         const hasFrame = !!item.frameStyle;
         const emojiIcon = !imageSrc && itemDef?.icon ? itemDef.icon : null;

--- a/components/ShopUI.tsx
+++ b/components/ShopUI.tsx
@@ -49,14 +49,10 @@ interface ShopUIProps {
   onClose: () => void;
   playerGold: number;
   playerInventory: { itemId: string; quantity: number; uses?: number; masteryLevel?: number }[];
-  onTransaction: (newGold: number, newInventory: { itemId: string; quantity: number; uses?: number; masteryLevel?: number }[]) => void;
-}
-
-interface DragState {
-  itemId: string;
-  quantity: number;
-  fromShop: boolean; // true = dragging from shop, false = dragging from player
-  maxQuantity: number;
+  onTransaction: (
+    newGold: number,
+    newInventory: { itemId: string; quantity: number; uses?: number; masteryLevel?: number }[]
+  ) => void;
 }
 
 const ShopUI: React.FC<ShopUIProps> = ({
@@ -93,24 +89,25 @@ const ShopUI: React.FC<ShopUIProps> = ({
         filterInactive: 'bg-rose-900/50 text-rose-300 border border-rose-700 hover:bg-rose-800/60',
       }
     : isShellaShop
-    ? {
-        title: "Shella's Food Truck",
-        container: 'bg-gradient-to-b from-teal-900 to-teal-950 border-4 border-orange-500',
-        titleColor: 'text-orange-200',
-        stockHeader: 'text-teal-300',
-        filterActive: 'bg-orange-500 text-orange-950',
-        filterInactive: 'bg-teal-900/50 text-teal-300 border border-teal-700 hover:bg-teal-800/60',
-      }
-    : {
-        title: 'General Store',
-        container: 'bg-gradient-to-b from-slate-800 to-slate-900 border-4 border-slate-600',
-        titleColor: 'text-amber-200',
-        stockHeader: 'text-emerald-300',
-        filterActive: 'bg-emerald-500 text-emerald-950',
-        filterInactive: 'bg-emerald-900/50 text-emerald-300 border border-emerald-700 hover:bg-emerald-800/60',
-      };
+      ? {
+          title: "Shella's Food Truck",
+          container: 'bg-gradient-to-b from-teal-900 to-teal-950 border-4 border-orange-500',
+          titleColor: 'text-orange-200',
+          stockHeader: 'text-teal-300',
+          filterActive: 'bg-orange-500 text-orange-950',
+          filterInactive:
+            'bg-teal-900/50 text-teal-300 border border-teal-700 hover:bg-teal-800/60',
+        }
+      : {
+          title: 'General Store',
+          container: 'bg-gradient-to-b from-slate-800 to-slate-900 border-4 border-slate-600',
+          titleColor: 'text-amber-200',
+          stockHeader: 'text-emerald-300',
+          filterActive: 'bg-emerald-500 text-emerald-950',
+          filterInactive:
+            'bg-emerald-900/50 text-emerald-300 border border-emerald-700 hover:bg-emerald-800/60',
+        };
   const [shopInventory, setShopInventory] = useState<ShopItem[]>([]);
-  const [dragState, setDragState] = useState<DragState | null>(null);
 
   type ShopFilter = 'all' | 'ingredients' | 'farming' | 'seeds' | 'materials' | 'magical';
   const [shopFilter, setShopFilter] = useState<ShopFilter>('all');
@@ -122,7 +119,9 @@ const ShopUI: React.FC<ShopUIProps> = ({
     fromShop: boolean;
     maxQuantity: number;
   } | null>(null);
-  const [feedback, setFeedback] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+  const [feedback, setFeedback] = useState<{ message: string; type: 'success' | 'error' } | null>(
+    null
+  );
 
   const handleClose = useCallback(() => {
     audioManager.playSfx('sfx_cash_register');
@@ -164,11 +163,7 @@ const ShopUI: React.FC<ShopUIProps> = ({
   /**
    * Handle drag start (from shop or player inventory)
    */
-  const handleDragStart = (
-    itemId: string,
-    fromShop: boolean,
-    maxQuantity: number
-  ) => {
+  const handleDragStart = (itemId: string, fromShop: boolean, maxQuantity: number) => {
     // If only 1 item, execute immediately
     if (maxQuantity === 1) {
       executeTransaction(itemId, 1, fromShop);
@@ -198,31 +193,6 @@ const ShopUI: React.FC<ShopUIProps> = ({
   const handleSlotContextMenu = (itemId: string, fromShop: boolean, maxQuantity: number) => {
     if (maxQuantity < 1) return;
     handleDragStart(itemId, fromShop, maxQuantity);
-  };
-
-  /**
-   * Handle drag over (allow drop)
-   */
-  const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
-  };
-
-  /**
-   * Handle drop (execute transaction)
-   */
-  const handleDrop = (e: React.DragEvent, targetIsShop: boolean) => {
-    e.preventDefault();
-
-    if (!dragState) return;
-
-    // Can't drop in same inventory
-    if (dragState.fromShop === targetIsShop) {
-      setDragState(null);
-      return;
-    }
-
-    executeTransaction(dragState.itemId, dragState.quantity, dragState.fromShop);
-    setDragState(null);
   };
 
   /**
@@ -280,11 +250,7 @@ const ShopUI: React.FC<ShopUIProps> = ({
   const confirmQuantity = () => {
     if (!pendingTransaction) return;
 
-    executeTransaction(
-      pendingTransaction.itemId,
-      selectedQuantity,
-      pendingTransaction.fromShop
-    );
+    executeTransaction(pendingTransaction.itemId, selectedQuantity, pendingTransaction.fromShop);
   };
 
   /**
@@ -310,7 +276,9 @@ const ShopUI: React.FC<ShopUIProps> = ({
       name: itemDef.displayName,
       description: itemDef.description,
       image: itemDef.image,
-      additionalInfo: canAfford ? `Buy: ${shopItem.buyPrice}g` : `Buy: ${shopItem.buyPrice}g (cannot afford)`,
+      additionalInfo: canAfford
+        ? `Buy: ${shopItem.buyPrice}g`
+        : `Buy: ${shopItem.buyPrice}g (cannot afford)`,
     };
 
     return (
@@ -318,11 +286,19 @@ const ShopUI: React.FC<ShopUIProps> = ({
         <button
           onClick={() => {
             if (shopLongPress.consumeTap()) return;
-            handleSlotClick(shopItem.itemId, true, shopManager.getMaxBuyQuantity(shopItem.itemId, playerGold));
+            handleSlotClick(
+              shopItem.itemId,
+              true,
+              shopManager.getMaxBuyQuantity(shopItem.itemId, playerGold)
+            );
           }}
           onContextMenu={(e) => {
             e.preventDefault();
-            handleSlotContextMenu(shopItem.itemId, true, shopManager.getMaxBuyQuantity(shopItem.itemId, playerGold));
+            handleSlotContextMenu(
+              shopItem.itemId,
+              true,
+              shopManager.getMaxBuyQuantity(shopItem.itemId, playerGold)
+            );
           }}
           onTouchStart={(e) => {
             shopPressRef.current = {
@@ -338,9 +314,10 @@ const ShopUI: React.FC<ShopUIProps> = ({
           className={`
             no-touch-callout
             relative aspect-square rounded-lg border-2 transition-all
-            ${canAfford
-              ? 'bg-emerald-900/40 border-emerald-600 hover:bg-emerald-800/60 cursor-pointer'
-              : 'bg-gray-900/40 border-gray-600 cursor-not-allowed opacity-50'
+            ${
+              canAfford
+                ? 'bg-emerald-900/40 border-emerald-600 hover:bg-emerald-800/60 cursor-pointer'
+                : 'bg-gray-900/40 border-gray-600 cursor-not-allowed opacity-50'
             }
           `}
           disabled={!canAfford}
@@ -376,7 +353,15 @@ const ShopUI: React.FC<ShopUIProps> = ({
   /**
    * Render player inventory slot
    */
-  const renderPlayerSlot = (inventoryItem: { itemId: string; quantity: number; uses?: number; masteryLevel?: number } | null, index: number) => {
+  const renderPlayerSlot = (
+    inventoryItem: {
+      itemId: string;
+      quantity: number;
+      uses?: number;
+      masteryLevel?: number;
+    } | null,
+    index: number
+  ) => {
     if (!inventoryItem) {
       // Empty slot
       return (
@@ -395,8 +380,12 @@ const ShopUI: React.FC<ShopUIProps> = ({
     // Add mastery info if applicable
     let additionalInfo = `Sell: ${sellPrice || 0}g each`;
     if (inventoryItem.masteryLevel !== undefined && inventoryItem.masteryLevel >= 1) {
-      const multiplier = inventoryItem.masteryLevel >= 3 ? '2.0x' :
-                         inventoryItem.masteryLevel === 2 ? '1.5x' : '1.2x';
+      const multiplier =
+        inventoryItem.masteryLevel >= 3
+          ? '2.0x'
+          : inventoryItem.masteryLevel === 2
+            ? '1.5x'
+            : '1.2x';
       additionalInfo += ` (${multiplier} mastery)`;
     }
 
@@ -470,36 +459,38 @@ const ShopUI: React.FC<ShopUIProps> = ({
   const isMagicUnlocked = magicManager.isMagicBookUnlocked();
 
   const SHOP_FILTER_CATEGORIES: Record<ShopFilter, ItemCategory[]> = {
-    all:         [],
+    all: [],
     ingredients: [ItemCategory.INGREDIENT, ItemCategory.FOOD, ItemCategory.CROP],
-    farming:     [ItemCategory.CROP, ItemCategory.SEED, ItemCategory.TOOL],
-    seeds:       [ItemCategory.SEED],
-    materials:   [ItemCategory.MATERIAL, ItemCategory.MISC, ItemCategory.DECORATION],
-    magical:     [ItemCategory.MAGICAL_INGREDIENT, ItemCategory.POTION],
+    farming: [ItemCategory.CROP, ItemCategory.SEED, ItemCategory.TOOL],
+    seeds: [ItemCategory.SEED],
+    materials: [ItemCategory.MATERIAL, ItemCategory.MISC, ItemCategory.DECORATION],
+    magical: [ItemCategory.MAGICAL_INGREDIENT, ItemCategory.POTION],
   };
 
   const shopFilterTabs: { id: ShopFilter; label: string }[] = [
-    { id: 'all',         label: 'All' },
+    { id: 'all', label: 'All' },
     { id: 'ingredients', label: 'Ingredients' },
-    { id: 'farming',     label: 'Farming' },
-    { id: 'seeds',       label: 'Seeds' },
-    { id: 'materials',   label: 'Materials' },
+    { id: 'farming', label: 'Farming' },
+    { id: 'seeds', label: 'Seeds' },
+    { id: 'materials', label: 'Materials' },
     ...(isMagicUnlocked ? [{ id: 'magical' as ShopFilter, label: 'Magical' }] : []),
   ];
 
-  const filteredShopInventory = shopFilter === 'all'
-    ? shopInventory
-    : shopInventory.filter((shopItem) => {
-        const cat = getItem(shopItem.itemId)?.category;
-        return cat !== undefined && SHOP_FILTER_CATEGORIES[shopFilter].includes(cat);
-      });
+  const filteredShopInventory =
+    shopFilter === 'all'
+      ? shopInventory
+      : shopInventory.filter((shopItem) => {
+          const cat = getItem(shopItem.itemId)?.category;
+          return cat !== undefined && SHOP_FILTER_CATEGORIES[shopFilter].includes(cat);
+        });
 
-  const filteredPlayerInventory = playerFilter === 'all'
-    ? playerInventory
-    : playerInventory.filter((item) => {
-        const cat = getItem(item.itemId)?.category;
-        return cat !== undefined && SHOP_FILTER_CATEGORIES[playerFilter].includes(cat);
-      });
+  const filteredPlayerInventory =
+    playerFilter === 'all'
+      ? playerInventory
+      : playerInventory.filter((item) => {
+          const cat = getItem(item.itemId)?.category;
+          return cat !== undefined && SHOP_FILTER_CATEGORIES[playerFilter].includes(cat);
+        });
 
   // Create slots for player inventory (dynamic unlimited capacity)
   const COLS = 6;
@@ -511,7 +502,8 @@ const ShopUI: React.FC<ShopUIProps> = ({
   const totalRows = Math.max(MIN_ROWS, requiredRows);
   const displaySlots = totalRows * COLS;
 
-  const playerSlots: ({ itemId: string; quantity: number } | null)[] = Array(displaySlots).fill(null);
+  const playerSlots: ({ itemId: string; quantity: number } | null)[] =
+    Array(displaySlots).fill(null);
   filteredPlayerInventory.forEach((item, index) => {
     if (index < displaySlots) {
       playerSlots[index] = item;
@@ -537,7 +529,10 @@ const ShopUI: React.FC<ShopUIProps> = ({
               <div className="bg-gradient-to-br from-yellow-600 to-yellow-800 border-4 border-yellow-500 rounded-lg px-6 py-3 shadow-lg">
                 <div className="flex items-center gap-2">
                   <span className="text-2xl">💰</span>
-                  <span className="text-3xl font-bold text-yellow-100" style={{ textShadow: '2px 2px 4px rgba(0,0,0,0.8)' }}>
+                  <span
+                    className="text-3xl font-bold text-yellow-100"
+                    style={{ textShadow: '2px 2px 4px rgba(0,0,0,0.8)' }}
+                  >
                     {playerGold}g
                   </span>
                 </div>
@@ -567,7 +562,9 @@ const ShopUI: React.FC<ShopUIProps> = ({
 
           {/* Season and Time Info */}
           <div className="mb-3 text-sm text-slate-400">
-            <span className="text-cyan-300 font-bold">{currentTime.season} {currentTime.day}</span>
+            <span className="text-cyan-300 font-bold">
+              {currentTime.season} {currentTime.day}
+            </span>
             {' • '}
             <span>Seasonal items available</span>
           </div>
@@ -584,9 +581,7 @@ const ShopUI: React.FC<ShopUIProps> = ({
                     key={tab.id}
                     onClick={() => setShopFilter(tab.id)}
                     className={`px-2.5 py-0.5 rounded-full text-xs font-semibold transition-colors ${
-                      shopFilter === tab.id
-                        ? theme.filterActive
-                        : theme.filterInactive
+                      shopFilter === tab.id ? theme.filterActive : theme.filterInactive
                     }`}
                   >
                     {tab.label}
@@ -595,11 +590,12 @@ const ShopUI: React.FC<ShopUIProps> = ({
               </div>
               <div className="flex-1 overflow-y-auto pr-2 max-h-[500px] shop-scrollbar">
                 <div className="grid grid-cols-6 gap-2">
-                  {filteredShopInventory.map(shopItem => renderShopSlot(shopItem))}
+                  {filteredShopInventory.map((shopItem) => renderShopSlot(shopItem))}
                 </div>
               </div>
               <div className="mt-2 text-xs text-slate-400">
-                Click to buy one • hold or right-click for more • {filteredShopInventory.length}{shopFilter !== 'all' ? ` / ${shopInventory.length}` : ''} items available
+                Click to buy one • hold or right-click for more • {filteredShopInventory.length}
+                {shopFilter !== 'all' ? ` / ${shopInventory.length}` : ''} items available
               </div>
             </div>
 
@@ -637,7 +633,9 @@ const ShopUI: React.FC<ShopUIProps> = ({
 
       {/* Quantity Slider Modal */}
       {showQuantitySlider && pendingTransaction && (
-        <div className={`fixed inset-0 bg-black/90 flex items-center justify-center ${zClass(Z_SHOP_CONFIRM)} pointer-events-auto`}>
+        <div
+          className={`fixed inset-0 bg-black/90 flex items-center justify-center ${zClass(Z_SHOP_CONFIRM)} pointer-events-auto`}
+        >
           <div className="bg-gradient-to-b from-slate-700 to-slate-800 border-4 border-slate-500 rounded-lg p-6 max-w-md w-full">
             <h3 className="text-2xl font-bold text-white mb-4">
               {pendingTransaction.fromShop ? 'Buy' : 'Sell'} How Many?
@@ -659,9 +657,7 @@ const ShopUI: React.FC<ShopUIProps> = ({
                   )}
                   <div>
                     <p className="text-lg font-bold text-amber-200">{itemDef.displayName}</p>
-                    <p className="text-sm text-slate-400">
-                      Max: {pendingTransaction.maxQuantity}
-                    </p>
+                    <p className="text-sm text-slate-400">Max: {pendingTransaction.maxQuantity}</p>
                   </div>
                 </div>
               );
@@ -671,19 +667,25 @@ const ShopUI: React.FC<ShopUIProps> = ({
             <div className="mb-6">
               <div className="flex justify-between items-center mb-2">
                 <label className="text-sm font-bold text-slate-300">Quantity:</label>
-                <span className="text-xs text-slate-400">Max: {pendingTransaction.maxQuantity}</span>
+                <span className="text-xs text-slate-400">
+                  Max: {pendingTransaction.maxQuantity}
+                </span>
               </div>
               <div className="flex items-center justify-center gap-4">
                 <button
-                  onClick={() => setSelectedQuantity(q => Math.max(1, q - 1))}
+                  onClick={() => setSelectedQuantity((q) => Math.max(1, q - 1))}
                   disabled={selectedQuantity <= 1}
                   className="w-12 h-12 bg-slate-600 hover:bg-slate-500 disabled:bg-slate-800 disabled:text-slate-600 disabled:cursor-not-allowed text-white text-2xl font-bold rounded-full transition-colors"
                 >
                   −
                 </button>
-                <span className="text-2xl font-bold text-yellow-300 w-12 text-center">{selectedQuantity}</span>
+                <span className="text-2xl font-bold text-yellow-300 w-12 text-center">
+                  {selectedQuantity}
+                </span>
                 <button
-                  onClick={() => setSelectedQuantity(q => Math.min(pendingTransaction.maxQuantity, q + 1))}
+                  onClick={() =>
+                    setSelectedQuantity((q) => Math.min(pendingTransaction.maxQuantity, q + 1))
+                  }
                   disabled={selectedQuantity >= pendingTransaction.maxQuantity}
                   className="w-12 h-12 bg-slate-600 hover:bg-slate-500 disabled:bg-slate-800 disabled:text-slate-600 disabled:cursor-not-allowed text-white text-2xl font-bold rounded-full transition-colors"
                 >
@@ -698,17 +700,19 @@ const ShopUI: React.FC<ShopUIProps> = ({
               if (!itemDef) return null;
 
               const price = pendingTransaction.fromShop
-                ? shopInventory.find(si => si.itemId === pendingTransaction.itemId)?.buyPrice || 0
+                ? shopInventory.find((si) => si.itemId === pendingTransaction.itemId)?.buyPrice || 0
                 : shopManager.getItemSellPrice(pendingTransaction.itemId, playerInventory) || 0;
 
               const total = price * selectedQuantity;
 
               return (
-                <div className={`mb-6 p-4 rounded-lg border-2 ${
-                  pendingTransaction.fromShop
-                    ? 'bg-red-900/40 border-red-500'
-                    : 'bg-green-900/40 border-green-500'
-                }`}>
+                <div
+                  className={`mb-6 p-4 rounded-lg border-2 ${
+                    pendingTransaction.fromShop
+                      ? 'bg-red-900/40 border-red-500'
+                      : 'bg-green-900/40 border-green-500'
+                  }`}
+                >
                   <p className="text-lg font-bold text-white">
                     {pendingTransaction.fromShop ? 'Total Cost:' : 'Total Earnings:'}
                     <span className="ml-2 text-2xl text-yellow-300">{total}g</span>

--- a/components/SpriteMetadataEditor/SpriteMetadataEditor.tsx
+++ b/components/SpriteMetadataEditor/SpriteMetadataEditor.tsx
@@ -9,7 +9,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { TileType, SpriteMetadata } from '../../types';
-import { SPRITE_METADATA, TILE_LEGEND, TILE_SIZE } from '../../constants';
+import { TILE_LEGEND, TILE_SIZE } from '../../constants';
 import { spriteMetadataOverrides } from '../../utils/SpriteMetadataOverrides';
 import './SpriteMetadataEditor.css';
 
@@ -20,7 +20,7 @@ interface SpriteMetadataEditorProps {
 
 const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, onApply }) => {
   const [selectedTileType, setSelectedTileType] = useState<TileType | null>(null);
-  const [overrideVersion, setOverrideVersion] = useState(0);
+  const [, setOverrideVersion] = useState(0);
   const [searchFilter, setSearchFilter] = useState('');
   const [showCollisionBoxes, setShowCollisionBoxes] = useState(true);
   const [showGrid, setShowGrid] = useState(true);
@@ -29,7 +29,7 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
   // Subscribe to override changes
   useEffect(() => {
     return spriteMetadataOverrides.subscribe(() => {
-      setOverrideVersion(v => v + 1);
+      setOverrideVersion((v) => v + 1);
       onApply?.();
     });
   }, [onApply]);
@@ -38,27 +38,33 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
   const allSprites = spriteMetadataOverrides.getAllMetadata();
 
   // Filter sprites by search
-  const filteredSprites = allSprites.filter(sprite => {
+  const filteredSprites = allSprites.filter((sprite) => {
     if (!searchFilter) return true;
     const tileName = TileType[sprite.tileType].toLowerCase();
     const legendName = TILE_LEGEND[sprite.tileType]?.name.toLowerCase() || '';
-    return tileName.includes(searchFilter.toLowerCase()) ||
-           legendName.includes(searchFilter.toLowerCase());
+    return (
+      tileName.includes(searchFilter.toLowerCase()) ||
+      legendName.includes(searchFilter.toLowerCase())
+    );
   });
 
   // Get currently selected sprite metadata
-  const selectedSprite = selectedTileType !== null
-    ? spriteMetadataOverrides.getMetadata(selectedTileType)
-    : null;
+  const selectedSprite =
+    selectedTileType !== null ? spriteMetadataOverrides.getMetadata(selectedTileType) : null;
 
   // Handle metadata field changes
-  const handleFieldChange = useCallback((
-    field: keyof SpriteMetadata,
-    value: number | boolean | string | { min: number; max: number }
-  ) => {
-    if (selectedTileType === null) return;
-    spriteMetadataOverrides.setOverride(selectedTileType, { [field]: value } as Partial<SpriteMetadata>);
-  }, [selectedTileType]);
+  const handleFieldChange = useCallback(
+    (
+      field: keyof SpriteMetadata,
+      value: number | boolean | string | { min: number; max: number }
+    ) => {
+      if (selectedTileType === null) return;
+      spriteMetadataOverrides.setOverride(selectedTileType, {
+        [field]: value,
+      } as Partial<SpriteMetadata>);
+    },
+    [selectedTileType]
+  );
 
   // Reset selected sprite to defaults
   const handleResetSprite = useCallback(() => {
@@ -164,7 +170,7 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
 
             {/* Sprite grid */}
             <div className="sprite-editor-grid">
-              {filteredSprites.map(sprite => {
+              {filteredSprites.map((sprite) => {
                 const isSelected = selectedTileType === sprite.tileType;
                 const isModified = spriteMetadataOverrides.hasOverride(sprite.tileType);
                 const tileName = TileType[sprite.tileType];
@@ -308,18 +314,24 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
                     />
 
                     {/* Collision box overlay */}
-                    {showCollisionBoxes && selectedSprite.collisionWidth && selectedSprite.collisionHeight && (
-                      <div
-                        className="sprite-preview-collision"
-                        style={{
-                          width: (selectedSprite.collisionWidth || 0) * TILE_SIZE,
-                          height: (selectedSprite.collisionHeight || 0) * TILE_SIZE,
-                          left: (-selectedSprite.offsetX + (selectedSprite.collisionOffsetX || 0)) * TILE_SIZE,
-                          top: (-selectedSprite.offsetY + (selectedSprite.collisionOffsetY || 0)) * TILE_SIZE,
-                        }}
-                        title="Collision Box"
-                      />
-                    )}
+                    {showCollisionBoxes &&
+                      selectedSprite.collisionWidth &&
+                      selectedSprite.collisionHeight && (
+                        <div
+                          className="sprite-preview-collision"
+                          style={{
+                            width: (selectedSprite.collisionWidth || 0) * TILE_SIZE,
+                            height: (selectedSprite.collisionHeight || 0) * TILE_SIZE,
+                            left:
+                              (-selectedSprite.offsetX + (selectedSprite.collisionOffsetX || 0)) *
+                              TILE_SIZE,
+                            top:
+                              (-selectedSprite.offsetY + (selectedSprite.collisionOffsetY || 0)) *
+                              TILE_SIZE,
+                          }}
+                          title="Collision Box"
+                        />
+                      )}
 
                     {/* Depth line indicator (blue horizontal line) */}
                     <div
@@ -330,10 +342,12 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
                         right: 0,
                         height: '2px',
                         background: '#4a90d9',
-                        top: (-selectedSprite.offsetY +
-                          (selectedSprite.depthLineOffset ??
-                            ((selectedSprite.collisionOffsetY ?? selectedSprite.offsetY) +
-                             (selectedSprite.collisionHeight ?? selectedSprite.spriteHeight)))) * TILE_SIZE,
+                        top:
+                          (-selectedSprite.offsetY +
+                            (selectedSprite.depthLineOffset ??
+                              (selectedSprite.collisionOffsetY ?? selectedSprite.offsetY) +
+                                (selectedSprite.collisionHeight ?? selectedSprite.spriteHeight))) *
+                          TILE_SIZE,
                         pointerEvents: 'none',
                         zIndex: 15,
                         boxShadow: '0 0 4px rgba(74, 144, 217, 0.8)',
@@ -357,7 +371,9 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
                           min="0.5"
                           max="20"
                           value={selectedSprite.spriteWidth}
-                          onChange={(e) => handleFieldChange('spriteWidth', parseFloat(e.target.value))}
+                          onChange={(e) =>
+                            handleFieldChange('spriteWidth', parseFloat(e.target.value))
+                          }
                         />
                       </label>
                       <label>
@@ -368,7 +384,9 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
                           min="0.5"
                           max="20"
                           value={selectedSprite.spriteHeight}
-                          onChange={(e) => handleFieldChange('spriteHeight', parseFloat(e.target.value))}
+                          onChange={(e) =>
+                            handleFieldChange('spriteHeight', parseFloat(e.target.value))
+                          }
                         />
                       </label>
                     </div>
@@ -415,7 +433,9 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
                           min="0"
                           max="20"
                           value={selectedSprite.collisionWidth ?? 0}
-                          onChange={(e) => handleFieldChange('collisionWidth', parseFloat(e.target.value))}
+                          onChange={(e) =>
+                            handleFieldChange('collisionWidth', parseFloat(e.target.value))
+                          }
                         />
                       </label>
                       <label>
@@ -426,7 +446,9 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
                           min="0"
                           max="20"
                           value={selectedSprite.collisionHeight ?? 0}
-                          onChange={(e) => handleFieldChange('collisionHeight', parseFloat(e.target.value))}
+                          onChange={(e) =>
+                            handleFieldChange('collisionHeight', parseFloat(e.target.value))
+                          }
                         />
                       </label>
                     </div>
@@ -439,7 +461,9 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
                           min="-20"
                           max="20"
                           value={selectedSprite.collisionOffsetX ?? 0}
-                          onChange={(e) => handleFieldChange('collisionOffsetX', parseFloat(e.target.value))}
+                          onChange={(e) =>
+                            handleFieldChange('collisionOffsetX', parseFloat(e.target.value))
+                          }
                         />
                       </label>
                       <label>
@@ -450,7 +474,9 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
                           min="-20"
                           max="20"
                           value={selectedSprite.collisionOffsetY ?? 0}
-                          onChange={(e) => handleFieldChange('collisionOffsetY', parseFloat(e.target.value))}
+                          onChange={(e) =>
+                            handleFieldChange('collisionOffsetY', parseFloat(e.target.value))
+                          }
                         />
                       </label>
                     </div>
@@ -508,10 +534,12 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
                             min="0.1"
                             max="2"
                             value={selectedSprite.scaleRange?.min ?? 0.98}
-                            onChange={(e) => handleFieldChange('scaleRange', {
-                              min: parseFloat(e.target.value),
-                              max: selectedSprite.scaleRange?.max ?? 1.02,
-                            })}
+                            onChange={(e) =>
+                              handleFieldChange('scaleRange', {
+                                min: parseFloat(e.target.value),
+                                max: selectedSprite.scaleRange?.max ?? 1.02,
+                              })
+                            }
                           />
                         </label>
                         <label>
@@ -522,10 +550,12 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
                             min="0.1"
                             max="2"
                             value={selectedSprite.scaleRange?.max ?? 1.02}
-                            onChange={(e) => handleFieldChange('scaleRange', {
-                              min: selectedSprite.scaleRange?.min ?? 0.98,
-                              max: parseFloat(e.target.value),
-                            })}
+                            onChange={(e) =>
+                              handleFieldChange('scaleRange', {
+                                min: selectedSprite.scaleRange?.min ?? 0.98,
+                                max: parseFloat(e.target.value),
+                              })
+                            }
                           />
                         </label>
                       </div>
@@ -536,8 +566,8 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
                   <div className="sprite-form-section">
                     <h4>Depth Sorting</h4>
                     <p style={{ fontSize: '11px', color: '#888', margin: '0 0 10px 0' }}>
-                      The depth line determines where this sprite sorts with player/NPCs.
-                      Default: collision box bottom.
+                      The depth line determines where this sprite sorts with player/NPCs. Default:
+                      collision box bottom.
                     </p>
                     <div className="sprite-form-row">
                       <label>
@@ -547,16 +577,22 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
                           step="0.1"
                           min="-20"
                           max="20"
-                          value={selectedSprite.depthLineOffset ??
-                            ((selectedSprite.collisionOffsetY ?? selectedSprite.offsetY) +
-                             (selectedSprite.collisionHeight ?? selectedSprite.spriteHeight))}
-                          onChange={(e) => handleFieldChange('depthLineOffset', parseFloat(e.target.value))}
+                          value={
+                            selectedSprite.depthLineOffset ??
+                            (selectedSprite.collisionOffsetY ?? selectedSprite.offsetY) +
+                              (selectedSprite.collisionHeight ?? selectedSprite.spriteHeight)
+                          }
+                          onChange={(e) =>
+                            handleFieldChange('depthLineOffset', parseFloat(e.target.value))
+                          }
                         />
                       </label>
                       {selectedSprite.depthLineOffset !== undefined && (
                         <button
                           className="sprite-editor-btn sprite-editor-btn-small"
-                          onClick={() => handleFieldChange('depthLineOffset', undefined as unknown as number)}
+                          onClick={() =>
+                            handleFieldChange('depthLineOffset', undefined as unknown as number)
+                          }
                           title="Reset to default (collision box bottom)"
                         >
                           Reset
@@ -576,7 +612,9 @@ const SpriteMetadataEditor: React.FC<SpriteMetadataEditorProps> = ({ onClose, on
 
         {/* Footer */}
         <div className="sprite-editor-footer">
-          <p>Press <kbd>F6</kbd> or <kbd>ESC</kbd> to close</p>
+          <p>
+            Press <kbd>F6</kbd> or <kbd>ESC</kbd> to close
+          </p>
         </div>
       </div>
     </div>

--- a/components/TileRenderer.tsx
+++ b/components/TileRenderer.tsx
@@ -8,17 +8,17 @@ import { farmingAssets } from '../assets';
 import { ColorResolver } from '../utils/ColorResolver';
 
 interface TileRendererProps {
-    currentMap: MapDefinition;
-    currentMapId: string | null;
-    visibleRange: {
-        minX: number;
-        maxX: number;
-        minY: number;
-        maxY: number;
-    };
-    seasonKey: 'spring' | 'summer' | 'autumn' | 'winter';
-    farmUpdateTrigger: number;
-    renderVersion?: number;  // Cache-busting prop to force re-render
+  currentMap: MapDefinition;
+  currentMapId: string | null;
+  visibleRange: {
+    minX: number;
+    maxX: number;
+    minY: number;
+    maxY: number;
+  };
+  seasonKey: 'spring' | 'summer' | 'autumn' | 'winter';
+  farmUpdateTrigger: number;
+  renderVersion?: number; // Cache-busting prop to force re-render
 }
 
 /**
@@ -29,198 +29,221 @@ interface TileRendererProps {
  * - Viewport culling for performance
  */
 const TileRenderer: React.FC<TileRendererProps> = ({
-    currentMap,
-    currentMapId,
-    visibleRange,
-    seasonKey,
-    farmUpdateTrigger,
-    renderVersion, // Unused - just for cache busting
+  currentMap,
+  currentMapId,
+  visibleRange,
+  seasonKey,
+  farmUpdateTrigger,
 }) => {
-    return (
-        <>
-            {currentMap.grid.map((row, y) =>
-                row.map((_, x) => {
-                    // Performance: Skip tiles outside viewport
-                    if (x < visibleRange.minX || x > visibleRange.maxX || y < visibleRange.minY || y > visibleRange.maxY) {
-                        return null;
-                    }
+  return (
+    <>
+      {currentMap.grid.map((row, y) =>
+        row.map((_, x) => {
+          // Performance: Skip tiles outside viewport
+          if (
+            x < visibleRange.minX ||
+            x > visibleRange.maxX ||
+            y < visibleRange.minY ||
+            y > visibleRange.maxY
+          ) {
+            return null;
+          }
 
-                    // Check if this tile has a farm plot override
-                    // (farmUpdateTrigger forces re-render when farm plots change)
-                    let tileData = getTileData(x, y);
-                    if (!tileData) return null;
+          // Check if this tile has a farm plot override
+          // (farmUpdateTrigger forces re-render when farm plots change)
+          let tileData = getTileData(x, y);
+          if (!tileData) return null;
 
-                    // Override tile appearance if there's an active farm plot here
-                    let growthStage: number | null = null;
-                    let cropType: string | null = null;
-                    let isHerbDormant = false;
-                    if (currentMapId && farmUpdateTrigger >= 0) { // Include farmUpdateTrigger to force re-evaluation
-                        const plot = farmManager.getPlot(currentMapId, { x, y });
-                        if (plot) {
-                            // Get the tile type for this plot's state
-                            const plotTileType = farmManager.getTileTypeForPlot(plot);
-                            // Get the visual data for this tile type
-                            const plotTileData = getTileData(x, y, plotTileType);
-                            if (plotTileData) {
-                                tileData = plotTileData;
-                            }
-                            // Get growth stage for all growing crops (planted, watered, ready, wilting)
-                            // Also include herb post-harvest states (HERB_COOLDOWN, HERB_DORMANT) — they show the adult sprite
-                            if (plot.state === FarmPlotState.PLANTED ||
-                                plot.state === FarmPlotState.WATERED ||
-                                plot.state === FarmPlotState.READY ||
-                                plot.state === FarmPlotState.WILTING ||
-                                plot.state === FarmPlotState.HERB_COOLDOWN ||
-                                plot.state === FarmPlotState.HERB_DORMANT) {
-                                growthStage = farmManager.getGrowthStage(plot);
-                                cropType = plot.cropType;
-                                isHerbDormant = plot.state === FarmPlotState.HERB_DORMANT;
-                            }
-                        }
-                    }
+          // Override tile appearance if there's an active farm plot here
+          let growthStage: number | null = null;
+          let cropType: string | null = null;
+          let isHerbDormant = false;
+          if (currentMapId && farmUpdateTrigger >= 0) {
+            // Include farmUpdateTrigger to force re-evaluation
+            const plot = farmManager.getPlot(currentMapId, { x, y });
+            if (plot) {
+              // Get the tile type for this plot's state
+              const plotTileType = farmManager.getTileTypeForPlot(plot);
+              // Get the visual data for this tile type
+              const plotTileData = getTileData(x, y, plotTileType);
+              if (plotTileData) {
+                tileData = plotTileData;
+              }
+              // Get growth stage for all growing crops (planted, watered, ready, wilting)
+              // Also include herb post-harvest states (HERB_COOLDOWN, HERB_DORMANT) — they show the adult sprite
+              if (
+                plot.state === FarmPlotState.PLANTED ||
+                plot.state === FarmPlotState.WATERED ||
+                plot.state === FarmPlotState.READY ||
+                plot.state === FarmPlotState.WILTING ||
+                plot.state === FarmPlotState.HERB_COOLDOWN ||
+                plot.state === FarmPlotState.HERB_DORMANT
+              ) {
+                growthStage = farmManager.getGrowthStage(plot);
+                cropType = plot.cropType;
+                isHerbDormant = plot.state === FarmPlotState.HERB_DORMANT;
+              }
+            }
+          }
 
-                    // Select image variant using deterministic hash
-                    let selectedImage: string | null = null;
-                    let selectedImageIndex: number | undefined = undefined;
+          // Select image variant using deterministic hash
+          let selectedImage: string | null = null;
+          let selectedImageIndex: number | undefined = undefined;
 
-                    // Determine which image array to use (seasonal or regular)
-                    let imageArray: string[] | undefined = undefined;
+          // Determine which image array to use (seasonal or regular)
+          let imageArray: string[] | undefined = undefined;
 
-                    if (tileData.seasonalImages) {
-                        // Use seasonal images if available (season cached above for performance)
-                        imageArray = seasonKey in tileData.seasonalImages ? tileData.seasonalImages[seasonKey] : tileData.seasonalImages.default;
+          if (tileData.seasonalImages) {
+            // Use seasonal images if available (season cached above for performance)
+            imageArray =
+              seasonKey in tileData.seasonalImages
+                ? tileData.seasonalImages[seasonKey]
+                : tileData.seasonalImages.default;
+          } else if (tileData.image) {
+            // Fall back to regular images
+            imageArray = tileData.image;
+          }
 
-                    } else if (tileData.image) {
-                        // Fall back to regular images
-                        imageArray = tileData.image;
-                    }
+          // Check if this tile has a multi-tile sprite (if so, don't render its own background image)
+          const hasMultiTileSprite = SPRITE_METADATA.some((s) => s.tileType === tileData.type);
 
-                    // Check if this tile has a multi-tile sprite (if so, don't render its own background image)
-                    const hasMultiTileSprite = SPRITE_METADATA.some(s =>
-                        s.tileType === tileData.type
-                    );
+          // If this tile has a baseType (like cherry trees on grass), use base tile's visuals
+          let renderTileData = tileData;
+          if (hasMultiTileSprite && tileData.baseType !== undefined) {
+            const baseTileData = getTileData(x, y, tileData.baseType);
+            if (baseTileData) {
+              renderTileData = baseTileData;
+              // Re-determine image array for base tile (season cached above)
+              if (renderTileData.seasonalImages) {
+                imageArray =
+                  seasonKey in renderTileData.seasonalImages
+                    ? renderTileData.seasonalImages[seasonKey]
+                    : renderTileData.seasonalImages.default;
+              } else if (renderTileData.image) {
+                imageArray = renderTileData.image;
+              }
+            }
+          }
 
-                    // If this tile has a baseType (like cherry trees on grass), use base tile's visuals
-                    let renderTileData = tileData;
-                    if (hasMultiTileSprite && tileData.baseType !== undefined) {
-                        const baseTileData = getTileData(x, y, tileData.baseType);
-                        if (baseTileData) {
-                            renderTileData = baseTileData;
-                            // Re-determine image array for base tile (season cached above)
-                            if (renderTileData.seasonalImages) {
-                                imageArray = seasonKey in renderTileData.seasonalImages ? renderTileData.seasonalImages[seasonKey] : renderTileData.seasonalImages.default;
-                            } else if (renderTileData.image) {
-                                imageArray = renderTileData.image;
-                            }
-                        }
-                    }
+          // All tiles with images use random selection now (including paths)
+          if (
+            imageArray &&
+            imageArray.length > 0 &&
+            (!hasMultiTileSprite || tileData.baseType !== undefined)
+          ) {
+            const hash = Math.abs(Math.sin(x * 12.9898 + y * 78.233) * 43758.5453);
+            const hashValue = hash % 1;
 
-                    // All tiles with images use random selection now (including paths)
-                    if (imageArray && imageArray.length > 0 && (!hasMultiTileSprite || tileData.baseType !== undefined)) {
-                        const hash = Math.abs(Math.sin(x * 12.9898 + y * 78.233) * 43758.5453);
-                        const hashValue = hash % 1;
+            // For grass tiles (and tiles with grass backgrounds), only show image on 30% of tiles (sparse)
+            // For other tiles, always show image
+            // Use renderTileData since we might be rendering base tile (e.g., grass under cherry tree)
+            const isGrassTile =
+              renderTileData.type === TileType.GRASS ||
+              renderTileData.type === TileType.TREE ||
+              renderTileData.type === TileType.TREE_BIG;
+            const showImage = isGrassTile ? hashValue < 0.3 : true;
 
-                        // For grass tiles (and tiles with grass backgrounds), only show image on 30% of tiles (sparse)
-                        // For other tiles, always show image
-                        // Use renderTileData since we might be rendering base tile (e.g., grass under cherry tree)
-                        const isGrassTile = renderTileData.type === TileType.GRASS ||
-                                            renderTileData.type === TileType.TREE ||
-                                            renderTileData.type === TileType.TREE_BIG;
-                        const showImage = isGrassTile ? hashValue < 0.3 : true;
+            if (showImage) {
+              // For farm plots with growth stages, select sprite based on stage and crop type
+              if (
+                growthStage !== null &&
+                cropType &&
+                (tileData.type === TileType.SOIL_PLANTED ||
+                  tileData.type === TileType.SOIL_WATERED ||
+                  tileData.type === TileType.SOIL_READY ||
+                  tileData.type === TileType.SOIL_WILTING)
+              ) {
+                // Override with growth-stage-specific sprite based on crop type
+                if (growthStage === 0) {
+                  // SEEDLING
+                  selectedImage = farmingAssets.seedling;
+                } else if (growthStage === 1) {
+                  // YOUNG
+                  // Use crop-specific young sprite if available, otherwise use generic
+                  selectedImage =
+                    (farmingAssets as any)[`plant_${cropType}_young`] || farmingAssets.seedling;
+                } else {
+                  // ADULT — dormant herbs may use a winter-specific sprite
+                  const winterKey = `plant_${cropType}_winter`;
+                  const adultKey = `plant_${cropType}_adult`;
+                  selectedImage =
+                    isHerbDormant && (farmingAssets as any)[winterKey]
+                      ? (farmingAssets as any)[winterKey]
+                      : (farmingAssets as any)[adultKey] || farmingAssets.seedling;
+                }
+              } else {
+                // Use a separate hash for image selection to avoid bias
+                const imageHash = Math.abs(Math.sin(x * 99.123 + y * 45.678) * 12345.6789);
+                const index = Math.floor((imageHash % 1) * imageArray.length);
+                selectedImage = imageArray[index];
+                selectedImageIndex = index; // Store for lake edge rotation
+              }
+            }
+          }
 
-                        if (showImage) {
-                            // For farm plots with growth stages, select sprite based on stage and crop type
-                            if (growthStage !== null && cropType && (
-                                tileData.type === TileType.SOIL_PLANTED ||
-                                tileData.type === TileType.SOIL_WATERED ||
-                                tileData.type === TileType.SOIL_READY ||
-                                tileData.type === TileType.SOIL_WILTING
-                            )) {
-                                // Override with growth-stage-specific sprite based on crop type
-                                if (growthStage === 0) { // SEEDLING
-                                    selectedImage = farmingAssets.seedling;
-                                } else if (growthStage === 1) { // YOUNG
-                                    // Use crop-specific young sprite if available, otherwise use generic
-                                    selectedImage = (farmingAssets as any)[`plant_${cropType}_young`] || farmingAssets.seedling;
-                                } else { // ADULT — dormant herbs may use a winter-specific sprite
-                                    const winterKey = `plant_${cropType}_winter`;
-                                    const adultKey = `plant_${cropType}_adult`;
-                                    selectedImage =
-                                        (isHerbDormant && (farmingAssets as any)[winterKey])
-                                            ? (farmingAssets as any)[winterKey]
-                                            : (farmingAssets as any)[adultKey] || farmingAssets.seedling;
-                                }
-                            } else {
-                                // Use a separate hash for image selection to avoid bias
-                                const imageHash = Math.abs(Math.sin(x * 99.123 + y * 45.678) * 12345.6789);
-                                const index = Math.floor((imageHash % 1) * imageArray.length);
-                                selectedImage = imageArray[index];
-                                selectedImageIndex = index; // Store for lake edge rotation
-                            }
-                        }
-                    }
+          // Calculate transforms using centralized utility (respects tile's transform settings)
+          const { transform, filter } = selectedImage
+            ? calculateTileTransforms(tileData, x, y, selectedImageIndex)
+            : { transform: 'none', filter: 'none' };
 
-                    // Calculate transforms using centralized utility (respects tile's transform settings)
-                    const { transform, filter } = selectedImage
-                        ? calculateTileTransforms(tileData, x, y, selectedImageIndex)
-                        : { transform: 'none', filter: 'none' };
+          // Use ColorResolver to get correct color from color scheme (not TILE_LEGEND fallback)
+          // ColorResolver handles season/time-of-day modifiers automatically
+          const tileColor = ColorResolver.getTileColor(renderTileData.type);
 
-                    // Use ColorResolver to get correct color from color scheme (not TILE_LEGEND fallback)
-                    // ColorResolver handles season/time-of-day modifiers automatically
-                    const tileColor = ColorResolver.getTileColor(renderTileData.type);
-
-                    return (
-                        <div
-                            key={`${x}-${y}`}
-                            className={`absolute ${tileColor}`}
-                            style={{
-                                left: x * TILE_SIZE,
-                                top: y * TILE_SIZE,
-                                width: TILE_SIZE,
-                                height: TILE_SIZE,
-                            }}
-                        >
-                            {growthStage !== null && cropType && (
-                                <img
-                                    src={(tileData.type === TileType.SOIL_WATERED || tileData.type === TileType.SOIL_READY)
-                                        ? farmingAssets.tilled_wet
-                                        : farmingAssets.tilled}
-                                    alt="Soil"
-                                    className="absolute"
-                                    style={{
-                                        left: 0,
-                                        top: 0,
-                                        width: TILE_SIZE,
-                                        height: TILE_SIZE,
-                                    }}
-                                />
-                            )}
-                            {selectedImage && (
-                                <img
-                                    src={selectedImage}
-                                    alt={renderTileData.name}
-                                    className="absolute"
-                                    style={{
-                                        left: 0,
-                                        top: 0,
-                                        width: TILE_SIZE,
-                                        height: TILE_SIZE,
-                                        imageRendering: 'pixelated',
-                                        transform: transform,
-                                        filter: isHerbDormant
-                                            ? `${filter !== 'none' ? filter + ' ' : ''}saturate(0.3) brightness(0.7)`
-                                            : filter,
-                                        transformOrigin: 'center center',
-                                        opacity: isHerbDormant ? 0.75 : undefined,
-                                    }}
-                                />
-                            )}
-                        </div>
-                    );
-                })
-            )}
-        </>
-    );
+          return (
+            <div
+              key={`${x}-${y}`}
+              className={`absolute ${tileColor}`}
+              style={{
+                left: x * TILE_SIZE,
+                top: y * TILE_SIZE,
+                width: TILE_SIZE,
+                height: TILE_SIZE,
+              }}
+            >
+              {growthStage !== null && cropType && (
+                <img
+                  src={
+                    tileData.type === TileType.SOIL_WATERED || tileData.type === TileType.SOIL_READY
+                      ? farmingAssets.tilled_wet
+                      : farmingAssets.tilled
+                  }
+                  alt="Soil"
+                  className="absolute"
+                  style={{
+                    left: 0,
+                    top: 0,
+                    width: TILE_SIZE,
+                    height: TILE_SIZE,
+                  }}
+                />
+              )}
+              {selectedImage && (
+                <img
+                  src={selectedImage}
+                  alt={renderTileData.name}
+                  className="absolute"
+                  style={{
+                    left: 0,
+                    top: 0,
+                    width: TILE_SIZE,
+                    height: TILE_SIZE,
+                    imageRendering: 'pixelated',
+                    transform: transform,
+                    filter: isHerbDormant
+                      ? `${filter !== 'none' ? filter + ' ' : ''}saturate(0.3) brightness(0.7)`
+                      : filter,
+                    transformOrigin: 'center center',
+                    opacity: isHerbDormant ? 0.75 : undefined,
+                  }}
+                />
+              )}
+            </div>
+          );
+        })
+      )}
+    </>
+  );
 };
 
 export default TileRenderer;

--- a/components/TouchControls.tsx
+++ b/components/TouchControls.tsx
@@ -54,9 +54,6 @@ const TouchControls: React.FC<TouchControlsProps> = ({
   const dpadButtonText = compact ? 'text-lg' : 'text-xl sm:text-2xl';
   const dpadCenterSize = compact ? 'w-8 h-8' : 'w-10 h-10 sm:w-12 sm:h-12';
 
-  const actionButtonSize = compact ? 'w-10 h-10' : 'w-12 h-12 sm:w-14 sm:h-14';
-  const actionButtonText = compact ? 'text-lg' : 'text-xl sm:text-2xl';
-
   return (
     <div
       className={`touch-controls fixed left-0 right-0 flex justify-between items-end px-4 sm:px-6 pointer-events-auto ${zClass(Z_TOUCH_CONTROLS)}`}
@@ -122,7 +119,11 @@ const TouchControls: React.FC<TouchControlsProps> = ({
             className={`${compact ? 'w-12 h-12' : 'w-14 h-14'} bg-teal-700/90 hover:bg-teal-600/90 active:bg-teal-500/90 rounded-full border-2 border-teal-400/70 flex items-center justify-center text-white text-2xl shadow-md`}
             title="Take Photo"
           >
-            <img src={itemAssets.camera} alt="Take Photo" className={`${compact ? 'w-8 h-8' : 'w-10 h-10'} object-contain`} />
+            <img
+              src={itemAssets.camera}
+              alt="Take Photo"
+              className={`${compact ? 'w-8 h-8' : 'w-10 h-10'} object-contain`}
+            />
           </button>
         )}
         {/* Emote button — the only player-to-player channel (see multiplayer/emotes.ts) */}

--- a/components/TransitionIndicators.tsx
+++ b/components/TransitionIndicators.tsx
@@ -165,7 +165,6 @@ function getTransitionLabel(transition: Transition): string {
 const TransitionIndicators: React.FC<TransitionIndicatorsProps> = ({
   currentMap,
   playerPos,
-  lastTransitionTime,
   gridOffset,
   tileSize = TILE_SIZE,
 }) => {

--- a/components/WeatherOverlay.tsx
+++ b/components/WeatherOverlay.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { WEATHER_ANIMATIONS, TILE_SIZE } from '../constants';
+import { WEATHER_ANIMATIONS } from '../constants';
 
 interface WeatherOverlayProps {
   weather: 'clear' | 'rain' | 'snow' | 'fog' | 'mist' | 'storm' | 'cherry_blossoms';
@@ -22,7 +22,7 @@ const WeatherOverlay: React.FC<WeatherOverlayProps> = ({
 }) => {
   // Filter animations for this layer and current weather
   const layerAnimations = WEATHER_ANIMATIONS.filter(
-    anim => anim.layer === layer && anim.weather === weather
+    (anim) => anim.layer === layer && anim.weather === weather
   );
 
   if (layerAnimations.length === 0) {

--- a/components/book/ImageZoomPopover.tsx
+++ b/components/book/ImageZoomPopover.tsx
@@ -25,34 +25,31 @@ const ImageZoomPopover: React.FC<ImageZoomPopoverProps> = ({
   const [popoverPosition, setPopoverPosition] = useState({ x: 0, y: 0 });
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const handleMouseEnter = useCallback(
-    (e: React.MouseEvent) => {
-      if (!containerRef.current) return;
+  const handleMouseEnter = useCallback(() => {
+    if (!containerRef.current) return;
 
-      const rect = containerRef.current.getBoundingClientRect();
-      const viewportWidth = window.innerWidth;
-      const viewportHeight = window.innerHeight;
+    const rect = containerRef.current.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
 
-      // Position popover to the right of the element by default
-      let x = rect.right + 10;
-      let y = rect.top + rect.height / 2 - zoomSize / 2;
+    // Position popover to the right of the element by default
+    let x = rect.right + 10;
+    let y = rect.top + rect.height / 2 - zoomSize / 2;
 
-      // If would go off right edge, position to the left
-      if (x + zoomSize > viewportWidth - 20) {
-        x = rect.left - zoomSize - 10;
-      }
+    // If would go off right edge, position to the left
+    if (x + zoomSize > viewportWidth - 20) {
+      x = rect.left - zoomSize - 10;
+    }
 
-      // Keep within vertical bounds
-      if (y < 10) y = 10;
-      if (y + zoomSize > viewportHeight - 10) {
-        y = viewportHeight - zoomSize - 10;
-      }
+    // Keep within vertical bounds
+    if (y < 10) y = 10;
+    if (y + zoomSize > viewportHeight - 10) {
+      y = viewportHeight - zoomSize - 10;
+    }
 
-      setPopoverPosition({ x, y });
-      setIsHovered(true);
-    },
-    [zoomSize]
-  );
+    setPopoverPosition({ x, y });
+    setIsHovered(true);
+  }, [zoomSize]);
 
   const handleMouseLeave = useCallback(() => {
     setIsHovered(false);

--- a/components/book/JournalContent.tsx
+++ b/components/book/JournalContent.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect, useCallback } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { BookThemeConfig } from './bookThemes';
 import { BookChapter, useBookPagination } from '../../hooks/useBookPagination';
 import BookSpread from './BookSpread';
@@ -63,16 +63,6 @@ function getNPCIdsWithConversations(): string[] {
     npcIds.add(entry.npcId);
   }
   return [...npcIds];
-}
-
-/**
- * Format an NPC ID into a display name (e.g. "village_elder" → "Village Elder")
- */
-function formatNPCName(npcId: string): string {
-  return npcId
-    .split('_')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
 }
 
 /**

--- a/components/book/PhotoAlbumContent.tsx
+++ b/components/book/PhotoAlbumContent.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { BookThemeConfig, bookStyles } from './bookThemes';
+import { BookThemeConfig } from './bookThemes';
 import BookSpread from './BookSpread';
 import { photoAlbumManager } from '../../utils/photoAlbumManager';
 import { getSharedAlbumService } from '../../firebase/safe';

--- a/components/book/PotionContent.tsx
+++ b/components/book/PotionContent.tsx
@@ -1,16 +1,11 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
-import {
-  PotionRecipeDefinition,
-  PotionLevel,
-  POTION_RECIPES,
-  getPotionRecipe,
-} from '../../data/potionRecipes';
+import { PotionRecipeDefinition, PotionLevel } from '../../data/potionRecipes';
 import { getItem } from '../../data/items';
 import { magicManager, BrewingResult } from '../../utils/MagicManager';
 import { eventBus, GameEvent } from '../../utils/EventBus';
 import { audioManager } from '../../utils/AudioManager';
 import { inventoryManager } from '../../utils/inventoryManager';
-import { BookThemeConfig, getThemeStyles } from './bookThemes';
+import { BookThemeConfig } from './bookThemes';
 import { BookChapter, useBookPagination } from '../../hooks/useBookPagination';
 import BookSpread from './BookSpread';
 import ImageZoomPopover from './ImageZoomPopover';
@@ -43,8 +38,6 @@ const PotionContent: React.FC<PotionContentProps> = ({ theme }) => {
       setMagicUpdateTrigger((prev) => prev + 1);
     });
   }, []);
-
-  const styles = getThemeStyles(theme);
 
   // Get current apprentice level and progress
   const currentLevel = magicManager.getCurrentLevel();
@@ -147,8 +140,6 @@ const PotionContent: React.FC<PotionContentProps> = ({ theme }) => {
     : null;
 
   // Check if we can brew
-  const canBrew = selectedPotion ? magicManager.hasIngredients(selectedPotion.id) : false;
-
   // Difficulty stars display
   const difficultyStars = (difficulty: 1 | 2 | 3) => {
     return '★'.repeat(difficulty) + '☆'.repeat(3 - difficulty);

--- a/components/book/RecipeContent.tsx
+++ b/components/book/RecipeContent.tsx
@@ -5,7 +5,7 @@ import { cookingManager, CookingResult } from '../../utils/CookingManager';
 import { audioManager } from '../../utils/AudioManager';
 import { inventoryManager } from '../../utils/inventoryManager';
 import { Position } from '../../types';
-import { BookThemeConfig, getThemeStyles } from './bookThemes';
+import { BookThemeConfig } from './bookThemes';
 import { BookChapter, useBookPagination } from '../../hooks/useBookPagination';
 import GameIcon from '../GameIcon';
 import BookSpread from './BookSpread';
@@ -46,8 +46,6 @@ const RecipeContent: React.FC<RecipeContentProps> = ({
 }) => {
   const [cookingResult, setCookingResult] = useState<CookingResult | null>(null);
   const [showResult, setShowResult] = useState(false);
-
-  const styles = getThemeStyles(theme);
 
   // Get all recipes
   const allRecipes = useMemo(() => Object.values(RECIPES), []);

--- a/components/dialogue/AIControls.tsx
+++ b/components/dialogue/AIControls.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useRef, useEffect } from 'react';
-import { DIALOGUE_FONT, TEXT_FONT } from './dialogueHelpers';
+import { DIALOGUE_FONT } from './dialogueHelpers';
 
 interface AIControlsProps {
   suggestions: string[];

--- a/components/dialogue/UnifiedDialogueBox.tsx
+++ b/components/dialogue/UnifiedDialogueBox.tsx
@@ -9,7 +9,6 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { NPC, DialogueNode, DialogueResponse } from '../../types';
 import {
-  NPCPersona,
   NPC_PERSONAS,
   buildSystemPrompt,
   GameContext,
@@ -37,7 +36,6 @@ import { globalEventManager } from '../../utils/GlobalEventManager';
 import { eventChainManager } from '../../utils/EventChainManager';
 import { inventoryManager } from '../../utils/inventoryManager';
 import { decorationManager } from '../../utils/DecorationManager';
-import { getItem } from '../../data/items';
 
 import DialogueFrame from './DialogueFrame';
 import DialogueChatHistory from './DialogueChatHistory';

--- a/data/crops.ts
+++ b/data/crops.ts
@@ -85,8 +85,21 @@ export interface CropDefinition {
 
   // Dual-harvest: crop offers two harvest modes via radial menu (e.g. pick flowers vs harvest seeds)
   dualHarvest?: {
-    flowerOption: { label: string; icon: string; color: string; cropYield: number; seedYield: number; flowerItemId?: string };
-    seedOption: { label: string; icon: string; color: string; cropYield: number; seedYield: number };
+    flowerOption: {
+      label: string;
+      icon: string;
+      color: string;
+      cropYield: number;
+      seedYield: number;
+      flowerItemId?: string;
+    };
+    seedOption: {
+      label: string;
+      icon: string;
+      color: string;
+      cropYield: number;
+      seedYield: number;
+    };
   };
 
   // Herb behaviour: plot persists after harvest, re-grows after cooldown, skips young stage
@@ -96,12 +109,9 @@ export interface CropDefinition {
 
 // Time constants (for readability)
 const MINUTE = 60 * 1000;
-const HOUR = 60 * MINUTE;
-const DAY = 24 * HOUR;
 
 // Game time constants - use TimeManager as single source of truth
 const GAME_DAY = TimeManager.MS_PER_GAME_DAY; // 7,200,000 ms (2 real hours)
-const GAME_HOUR = GAME_DAY / 24; // 300,000 ms (5 real minutes)
 
 /**
  * Testing mode: When true, crops grow in real minutes (for testing)
@@ -326,8 +336,21 @@ export const CROPS: Record<string, CropDefinition> = {
     rarity: CropRarity.UNCOMMON,
     seedSource: 'friendship',
     dualHarvest: {
-      flowerOption: { label: 'Pick Flowers', icon: '🌻', color: '#eab308', cropYield: 1, seedYield: 0, flowerItemId: 'crop_sunflower' },
-      seedOption: { label: 'Harvest Seeds', icon: '🌰', color: '#92400e', cropYield: 0, seedYield: 6 },
+      flowerOption: {
+        label: 'Pick Flowers',
+        icon: '🌻',
+        color: '#eab308',
+        cropYield: 1,
+        seedYield: 0,
+        flowerItemId: 'crop_sunflower',
+      },
+      seedOption: {
+        label: 'Harvest Seeds',
+        icon: '🌰',
+        color: '#92400e',
+        cropYield: 0,
+        seedYield: 6,
+      },
     },
   },
 

--- a/data/giftReactions.ts
+++ b/data/giftReactions.ts
@@ -9,8 +9,8 @@
  * Following the centralised data pattern from NPC_FOOD_PREFERENCES.
  */
 
-import { ItemCategory, getItem, ITEMS } from './items';
-import { RECIPES, RecipeCategory } from './recipes';
+import { ItemCategory, getItem } from './items';
+import { RECIPES } from './recipes';
 
 export type GiftReaction = 'loved' | 'liked' | 'neutral' | 'disliked';
 
@@ -51,13 +51,7 @@ export interface GiftReactionDialogue {
 export const NPC_GIFT_PREFERENCES: Record<string, NPCGiftPreferences> = {
   // Chill Bear - loves honey and berries, dislikes spices
   bear: {
-    loves: [
-      'honey',
-      'crop_blueberry',
-      'strawberry_jam',
-      'crop_blackberry',
-      'crop_hazelnut',
-    ],
+    loves: ['honey', 'crop_blueberry', 'strawberry_jam', 'crop_blackberry', 'crop_hazelnut'],
     dislikes: ['allspice', 'curry_powder', 'cinnamon'],
     lovesHomeCookedFood: true,
   },
@@ -254,10 +248,7 @@ export const DEFAULT_GIFT_REACTIONS: Record<GiftReaction, GiftReactionDialogue> 
  * NPC-specific gift reaction dialogue
  * Speaking NPCs have dialogue text, non-speaking NPCs have descriptive actions in italics
  */
-export const NPC_GIFT_REACTIONS: Record<
-  string,
-  Record<GiftReaction, GiftReactionDialogue>
-> = {
+export const NPC_GIFT_REACTIONS: Record<string, Record<GiftReaction, GiftReactionDialogue>> = {
   // === SPEAKING NPCs ===
 
   bear: {
@@ -274,7 +265,7 @@ export const NPC_GIFT_REACTIONS: Record<
       expression: 'default',
     },
     disliked: {
-      text: "*sniffs and wrinkles nose* Ugh, too spicy for my taste. Bears prefer simple flavours, you know.",
+      text: '*sniffs and wrinkles nose* Ugh, too spicy for my taste. Bears prefer simple flavours, you know.',
       expression: 'thinky',
     },
   },
@@ -293,7 +284,7 @@ export const NPC_GIFT_REACTIONS: Record<
       expression: 'default',
     },
     disliked: {
-      text: "Oh... spinach. I never did care for the stuff, dear. But thank you for thinking of me.",
+      text: 'Oh... spinach. I never did care for the stuff, dear. But thank you for thinking of me.',
       expression: 'thinky',
     },
   },
@@ -338,11 +329,11 @@ export const NPC_GIFT_REACTIONS: Record<
 
   witch: {
     loved: {
-      text: 'Ooh, delicious! *cackles* You know the way to a witch\'s heart. Not literally, mind you - that requires a different ritual entirely.',
+      text: "Ooh, delicious! *cackles* You know the way to a witch's heart. Not literally, mind you - that requires a different ritual entirely.",
       expression: 'happy',
     },
     liked: {
-      text: "Hmm, useful. I shall add this to my collection. You have my thanks.",
+      text: 'Hmm, useful. I shall add this to my collection. You have my thanks.',
       expression: 'smile',
     },
     neutral: {
@@ -350,7 +341,7 @@ export const NPC_GIFT_REACTIONS: Record<
       expression: 'default',
     },
     disliked: {
-      text: "A potion? I MAKE these, child! What need have I for my own work? *huffs* Though I suppose it shows you pay attention...",
+      text: 'A potion? I MAKE these, child! What need have I for my own work? *huffs* Though I suppose it shows you pay attention...',
       expression: 'thinky',
     },
   },
@@ -369,7 +360,7 @@ export const NPC_GIFT_REACTIONS: Record<
       expression: 'default',
     },
     disliked: {
-      text: '*She wrinkles her nose slightly.* "That\'s... kind of you. I\'ll find a use for it, I\'m sure."',
+      text: "*She wrinkles her nose slightly.* \"That's... kind of you. I'll find a use for it, I'm sure.\"",
       expression: 'thinky',
     },
   },
@@ -464,7 +455,7 @@ export const NPC_GIFT_REACTIONS: Record<
       expression: 'default',
     },
     disliked: {
-      text: "*puffs up slightly* Savoury? Bleh! I prefer sweet things... but thank you for trying.",
+      text: '*puffs up slightly* Savoury? Bleh! I prefer sweet things... but thank you for trying.',
       expression: 'thinky',
     },
   },
@@ -483,14 +474,14 @@ export const NPC_GIFT_REACTIONS: Record<
       expression: 'default',
     },
     disliked: {
-      text: "*wrinkles nose* Too savoury for my taste... I prefer desserts. But thank you.",
+      text: '*wrinkles nose* Too savoury for my taste... I prefer desserts. But thank you.',
       expression: 'thinky',
     },
   },
 
   mr_fox: {
     loved: {
-      text: '*licks lips* Ah, proper home cooking! You know the way to a fox\'s heart. Most generous!',
+      text: "*licks lips* Ah, proper home cooking! You know the way to a fox's heart. Most generous!",
       expression: 'happy',
     },
     liked: {
@@ -591,7 +582,7 @@ export const NPC_GIFT_REACTIONS: Record<
       expression: 'happy',
     },
     liked: {
-      text: "*The cow accepts your offering and chews thoughtfully, regarding you with warm, gentle eyes.*",
+      text: '*The cow accepts your offering and chews thoughtfully, regarding you with warm, gentle eyes.*',
       expression: 'smile',
     },
     neutral: {

--- a/data/questHandlers/witchGardenHandler.ts
+++ b/data/questHandlers/witchGardenHandler.ts
@@ -7,7 +7,7 @@
  */
 
 import { eventChainManager } from '../../utils/EventChainManager';
-import { handlerRegistry } from '../../utils/EventChainHandlers';
+
 import { eventBus, GameEvent } from '../../utils/EventBus';
 import { DEBUG } from '../../constants';
 
@@ -27,8 +27,7 @@ export const WITCH_GARDEN_STAGES = {
   COMPLETED: 4,
 } as const;
 
-export type WitchGardenStage =
-  (typeof WITCH_GARDEN_STAGES)[keyof typeof WITCH_GARDEN_STAGES];
+export type WitchGardenStage = (typeof WITCH_GARDEN_STAGES)[keyof typeof WITCH_GARDEN_STAGES];
 
 // ============================================================================
 // Default Data
@@ -59,12 +58,16 @@ export function getWitchGardenStage(): WitchGardenStage {
   if (!eventChainManager.isChainStarted(WITCH_GARDEN_QUEST_ID)) {
     return WITCH_GARDEN_STAGES.NOT_STARTED;
   }
-  return (eventChainManager.getStageNumber(WITCH_GARDEN_QUEST_ID) as WitchGardenStage) ||
-    WITCH_GARDEN_STAGES.ACTIVE;
+  return (
+    (eventChainManager.getStageNumber(WITCH_GARDEN_QUEST_ID) as WitchGardenStage) ||
+    WITCH_GARDEN_STAGES.ACTIVE
+  );
 }
 
 export function getGardenCropsGrown(): string[] {
-  return (eventChainManager.getMetadata(WITCH_GARDEN_QUEST_ID, 'gardenCropsGrown') as string[]) || [];
+  return (
+    (eventChainManager.getMetadata(WITCH_GARDEN_QUEST_ID, 'gardenCropsGrown') as string[]) || []
+  );
 }
 
 export function isGardenComplete(): boolean {
@@ -94,7 +97,9 @@ export function recordCropHarvested(cropId: string): boolean {
   eventChainManager.setMetadata(WITCH_GARDEN_QUEST_ID, 'gardenCropsGrown', updatedCrops);
 
   if (DEBUG.QUEST) {
-    console.log(`[WitchGardenQuest] New crop recorded: "${cropId}" (${updatedCrops.length}/${REQUIRED_UNIQUE_CROPS})`);
+    console.log(
+      `[WitchGardenQuest] New crop recorded: "${cropId}" (${updatedCrops.length}/${REQUIRED_UNIQUE_CROPS})`
+    );
   }
 
   if (updatedCrops.length >= REQUIRED_UNIQUE_CROPS) {

--- a/data/tiles.ts
+++ b/data/tiles.ts
@@ -6,7 +6,7 @@
  */
 
 import { TileType, TileData, CollisionType } from '../types';
-import { tileAssets, farmingAssets, orchardAssets } from '../assets';
+import { tileAssets, farmingAssets } from '../assets';
 import { resolveAppleTreeImage } from '../utils/fruitTreeRegistry';
 
 export const TILE_LEGEND: Record<TileType, Omit<TileData, 'type'>> = {

--- a/firebase/cloudSaveService.ts
+++ b/firebase/cloudSaveService.ts
@@ -12,14 +12,12 @@
 
 import {
   doc,
-  setDoc,
   getDoc,
   getDocs,
   deleteDoc,
   collection,
   serverTimestamp,
   writeBatch,
-  Timestamp,
 } from 'firebase/firestore';
 import { getFirebaseDb, isFirebaseInitialized } from './config';
 import { authService } from './authService';

--- a/firebase/safe.ts
+++ b/firebase/safe.ts
@@ -191,9 +191,6 @@ const stubCloudSaveService = {
   migrateLocalSave: async () => {},
 };
 
-/** Stub initializeFirebase when Firebase is not available */
-const stubInitializeFirebase = async () => null;
-
 // Cache the loaded module
 let firebaseModule: typeof import('./index') | null = null;
 let loadPromise: Promise<typeof import('./index') | null> | null = null;

--- a/firebase/sharedDataService.ts
+++ b/firebase/sharedDataService.ts
@@ -21,7 +21,6 @@ import {
   limit,
   where,
   serverTimestamp,
-  Timestamp,
 } from 'firebase/firestore';
 import { getFirebaseDb, isFirebaseInitialized } from './config';
 import { authService } from './authService';
@@ -36,8 +35,6 @@ import {
 // Constants
 // ============================================
 
-const MAX_SUMMARIES_PER_NPC = 50; // Max summaries to fetch per NPC
-const MAX_EVENTS = 100; // Max events to fetch
 const MAX_CONTRIBUTIONS_PER_MINUTE = 10; // Rate limit per user
 
 // Hash user ID for privacy (one-way, consistent)
@@ -256,7 +253,6 @@ class SharedDataService {
 
     // Format summaries into gossip
     const topics = [...new Set(summaries.map((s) => s.topic))];
-    const recentSummary = summaries[0];
 
     if (topics.length === 1) {
       return `Other villagers have been asking ${npcName} about ${topics[0]} recently.`;

--- a/firebase/syncManager.ts
+++ b/firebase/syncManager.ts
@@ -14,7 +14,7 @@
  * - Manual: User-triggered save to cloud
  */
 
-import { doc, getDoc, setDoc, serverTimestamp, Timestamp } from 'firebase/firestore';
+import { doc, getDoc, setDoc, serverTimestamp } from 'firebase/firestore';
 import { getFirebaseDb, isFirebaseInitialized } from './config';
 import { authService } from './authService';
 import { cloudSaveService } from './cloudSaveService';

--- a/hooks/useClickToMove.ts
+++ b/hooks/useClickToMove.ts
@@ -7,8 +7,7 @@
 
 import { useState, useCallback, useRef, MutableRefObject } from 'react';
 import { Position, NPC } from '../types';
-import { findPath, findAdjacentWalkableTile, getDistance } from '../utils/pathfinding';
-import { getTileCoords } from '../utils/mapUtils';
+import { findPath } from '../utils/pathfinding';
 
 /** Threshold for considering a waypoint reached (in tiles) */
 const WAYPOINT_THRESHOLD = 0.15;

--- a/hooks/useInteractionController.ts
+++ b/hooks/useInteractionController.ts
@@ -11,7 +11,7 @@
  */
 
 import { useState, useRef, useCallback, useEffect, MutableRefObject } from 'react';
-import { Position, NPC, TileType } from '../types';
+import { Position, NPC } from '../types';
 import { TILE_SIZE, INTERACTION, DEBUG } from '../constants';
 import { MouseClickInfo } from './useMouseControls';
 import { RadialMenuOption } from '../components/RadialMenu';

--- a/hooks/usePixiRenderer.ts
+++ b/hooks/usePixiRenderer.ts
@@ -13,7 +13,7 @@
 
 import { useRef, useState, useEffect, useCallback } from 'react';
 import * as PIXI from 'pixi.js';
-import { Position, Direction, MapDefinition, TileType, TileData } from '../types';
+import { Position, Direction, MapDefinition, TileData } from '../types';
 import { USE_SPRITE_SHADOWS, TILE_LEGEND } from '../constants';
 import { Z_DEPTH_SORTED_BASE } from '../zIndex';
 import { VisibleRange } from '../utils/viewportUtils';
@@ -36,11 +36,7 @@ import { HighlightLayer } from '../utils/pixi/HighlightLayer';
 import { ThoughtBubbleLayer } from '../utils/pixi/ThoughtBubbleLayer';
 import { WeatherManager } from '../utils/WeatherManager';
 import { shouldShowWeather } from '../data/weatherConfig';
-import {
-  getCoreTextureUrls,
-  getResidentTextureUrls,
-  toSeasonKey,
-} from '../utils/mapTextureSet';
+import { getCoreTextureUrls, getResidentTextureUrls, toSeasonKey } from '../utils/mapTextureSet';
 import { mapManager } from '../maps';
 import { gameState } from '../GameState';
 import { npcManager } from '../NPCManager';

--- a/hooks/useTouchControls.ts
+++ b/hooks/useTouchControls.ts
@@ -9,153 +9,168 @@ import { mapManager } from '../maps';
 import { gameState } from '../GameState';
 import { audioManager } from '../utils/AudioManager';
 import {
-    checkMirrorInteraction,
-    checkStoveInteraction,
-    checkNPCInteraction,
-    checkTransition,
-    handleFarmAction,
-    handleForageAction,
-    ForageResult,
-    FarmActionResult,
+  checkMirrorInteraction,
+  checkStoveInteraction,
+  checkNPCInteraction,
+  checkTransition,
+  handleFarmAction,
+  handleForageAction,
+  ForageResult,
 } from '../utils/actionHandlers';
 
 export interface TouchControlsConfig {
-    playerPosRef: MutableRefObject<Position>;
-    selectedItemSlot: number | null;
-    inventoryItems: Array<{ id: string; name: string; icon: string; quantity: number; value?: number }>;
-    keysPressed: Record<string, boolean>;
-    onShowCharacterCreator: (show: boolean) => void;
-    onSetShowCookingUI: (show: boolean) => void;
-    onSetActiveNPC: (npcId: string | null) => void;
-    onSetPlayerPos: (pos: Position) => void;
-    onMapTransition: (mapId: string, spawnPos: Position) => void;
-    onFarmUpdate: () => void;
-    onFarmActionAnimation: (action: 'till' | 'plant' | 'water' | 'harvest' | 'clear', tilePos?: Position) => void;
-    onForageResult?: (result: ForageResult) => void;
-    onShowToast?: (message: string, type: 'info' | 'warning' | 'error' | 'success') => void;
-    onTakePhoto?: () => void;
+  playerPosRef: MutableRefObject<Position>;
+  selectedItemSlot: number | null;
+  inventoryItems: Array<{
+    id: string;
+    name: string;
+    icon: string;
+    quantity: number;
+    value?: number;
+  }>;
+  keysPressed: Record<string, boolean>;
+  onShowCharacterCreator: (show: boolean) => void;
+  onSetShowCookingUI: (show: boolean) => void;
+  onSetActiveNPC: (npcId: string | null) => void;
+  onSetPlayerPos: (pos: Position) => void;
+  onMapTransition: (mapId: string, spawnPos: Position) => void;
+  onFarmUpdate: () => void;
+  onFarmActionAnimation: (
+    action: 'till' | 'plant' | 'water' | 'harvest' | 'clear',
+    tilePos?: Position
+  ) => void;
+  onForageResult?: (result: ForageResult) => void;
+  onShowToast?: (message: string, type: 'info' | 'warning' | 'error' | 'success') => void;
+  onTakePhoto?: () => void;
 }
 
 export function useTouchControls(config: TouchControlsConfig) {
-    const {
-        playerPosRef,
-        selectedItemSlot,
-        inventoryItems,
-        keysPressed,
-        onShowCharacterCreator,
-        onSetShowCookingUI,
-        onSetActiveNPC,
-        onSetPlayerPos,
-        onMapTransition,
-        onFarmUpdate,
-        onFarmActionAnimation,
-        onForageResult,
-        onShowToast,
-        onTakePhoto,
-    } = config;
+  const {
+    playerPosRef,
+    selectedItemSlot,
+    inventoryItems,
+    keysPressed,
+    onShowCharacterCreator,
+    onSetShowCookingUI,
+    onSetActiveNPC,
+    onSetPlayerPos,
+    onMapTransition,
+    onFarmUpdate,
+    onFarmActionAnimation,
+    onForageResult,
+    onShowToast,
+    onTakePhoto,
+  } = config;
 
-    const handleDirectionPress = (direction: 'up' | 'down' | 'left' | 'right') => {
-        const keyMap = { up: 'w', down: 's', left: 'a', right: 'd' };
-        keysPressed[keyMap[direction]] = true;
-    };
+  const handleDirectionPress = (direction: 'up' | 'down' | 'left' | 'right') => {
+    const keyMap = { up: 'w', down: 's', left: 'a', right: 'd' };
+    keysPressed[keyMap[direction]] = true;
+  };
 
-    const handleDirectionRelease = (direction: 'up' | 'down' | 'left' | 'right') => {
-        const keyMap = { up: 'w', down: 's', left: 'a', right: 'd' };
-        keysPressed[keyMap[direction]] = false;
-    };
+  const handleDirectionRelease = (direction: 'up' | 'down' | 'left' | 'right') => {
+    const keyMap = { up: 'w', down: 's', left: 'a', right: 'd' };
+    keysPressed[keyMap[direction]] = false;
+  };
 
-    const handleActionPress = () => {
-        console.log(`[Touch Action] Player at (${playerPosRef.current.x.toFixed(2)}, ${playerPosRef.current.y.toFixed(2)})`);
+  const handleActionPress = () => {
+    console.log(
+      `[Touch Action] Player at (${playerPosRef.current.x.toFixed(2)}, ${playerPosRef.current.y.toFixed(2)})`
+    );
 
-        const currentMapId = mapManager.getCurrentMapId();
+    const currentMapId = mapManager.getCurrentMapId();
 
-        // Check for farm action first (on current tile)
-        if (currentMapId) {
-            // Get selected item from inventory (if any)
-            const selectedItem = selectedItemSlot !== null ? inventoryItems[selectedItemSlot] : null;
-            const currentTool = selectedItem?.id || 'hand'; // Use selected item or default to 'hand'
+    // Check for farm action first (on current tile)
+    if (currentMapId) {
+      // Get selected item from inventory (if any)
+      const selectedItem = selectedItemSlot !== null ? inventoryItems[selectedItemSlot] : null;
+      const currentTool = selectedItem?.id || 'hand'; // Use selected item or default to 'hand'
 
-            console.log(`[Touch Action] Using tool: ${currentTool} (selected slot: ${selectedItemSlot})`);
+      console.log(`[Touch Action] Using tool: ${currentTool} (selected slot: ${selectedItemSlot})`);
 
-            const farmResult = handleFarmAction(playerPosRef.current, currentTool, currentMapId, onFarmActionAnimation);
+      const farmResult = handleFarmAction(
+        playerPosRef.current,
+        currentTool,
+        currentMapId,
+        onFarmActionAnimation
+      );
 
-            if (farmResult.handled) {
-                onFarmUpdate();
-                return; // Don't check for other interactions
-            }
+      if (farmResult.handled) {
+        onFarmUpdate();
+        return; // Don't check for other interactions
+      }
 
-            // Show feedback message if action failed with a reason
-            if (farmResult.message && onShowToast) {
-                onShowToast(farmResult.message, farmResult.messageType || 'warning');
-                return; // Don't check for other interactions after showing message
-            }
-        }
+      // Show feedback message if action failed with a reason
+      if (farmResult.message && onShowToast) {
+        onShowToast(farmResult.message, farmResult.messageType || 'warning');
+        return; // Don't check for other interactions after showing message
+      }
+    }
 
-        // Check for mirror interaction
-        const foundMirror = checkMirrorInteraction(playerPosRef.current);
-        if (foundMirror) {
-            onShowCharacterCreator(true);
-            return; // Don't check for transitions if we found a mirror
-        }
+    // Check for mirror interaction
+    const foundMirror = checkMirrorInteraction(playerPosRef.current);
+    if (foundMirror) {
+      onShowCharacterCreator(true);
+      return; // Don't check for transitions if we found a mirror
+    }
 
-        // Check for stove interaction (opens cooking interface)
-        const foundStove = checkStoveInteraction(playerPosRef.current);
-        if (foundStove) {
-            onSetShowCookingUI(true);
-            return; // Don't check for other interactions if we found a stove
-        }
+    // Check for stove interaction (opens cooking interface)
+    const foundStove = checkStoveInteraction(playerPosRef.current);
+    if (foundStove) {
+      onSetShowCookingUI(true);
+      return; // Don't check for other interactions if we found a stove
+    }
 
-        // Check for NPC interaction
-        const npcId = checkNPCInteraction(playerPosRef.current);
-        if (npcId) {
-            onSetActiveNPC(npcId);
-            return; // Don't check for transitions if talking to NPC
-        }
+    // Check for NPC interaction
+    const npcId = checkNPCInteraction(playerPosRef.current);
+    if (npcId) {
+      onSetActiveNPC(npcId);
+      return; // Don't check for transitions if talking to NPC
+    }
 
-        // Check for transition
-        const transitionResult = checkTransition(playerPosRef.current, currentMapId);
+    // Check for transition
+    const transitionResult = checkTransition(playerPosRef.current, currentMapId);
 
-        if (transitionResult.success && transitionResult.mapId && transitionResult.spawnPosition) {
-            if (transitionResult.hasDoor) {
-                audioManager.playSfx('sfx_door_open');
-            }
-            onMapTransition(transitionResult.mapId, transitionResult.spawnPosition);
+    if (transitionResult.success && transitionResult.mapId && transitionResult.spawnPosition) {
+      if (transitionResult.hasDoor) {
+        audioManager.playSfx('sfx_door_open');
+      }
+      onMapTransition(transitionResult.mapId, transitionResult.spawnPosition);
 
-            // Save player location when transitioning maps
-            const seedMatch = transitionResult.mapId.match(/_([\d]+)$/);
-            const seed = seedMatch ? parseInt(seedMatch[1]) : undefined;
-            gameState.updatePlayerLocation(transitionResult.mapId, transitionResult.spawnPosition, seed);
-        }
-    };
+      // Save player location when transitioning maps
+      const seedMatch = transitionResult.mapId.match(/_([\d]+)$/);
+      const seed = seedMatch ? parseInt(seedMatch[1]) : undefined;
+      gameState.updatePlayerLocation(transitionResult.mapId, transitionResult.spawnPosition, seed);
+    }
+  };
 
-    const handleResetPress = () => {
-        const currentMap = mapManager.getCurrentMap();
-        if (currentMap && currentMap.spawnPoint) {
-            console.log('[Touch Reset] Teleporting to spawn point:', currentMap.spawnPoint);
-            onSetPlayerPos(currentMap.spawnPoint);
-            playerPosRef.current = currentMap.spawnPoint;
-        }
-    };
+  const handleResetPress = () => {
+    const currentMap = mapManager.getCurrentMap();
+    if (currentMap && currentMap.spawnPoint) {
+      console.log('[Touch Reset] Teleporting to spawn point:', currentMap.spawnPoint);
+      onSetPlayerPos(currentMap.spawnPoint);
+      playerPosRef.current = currentMap.spawnPoint;
+    }
+  };
 
-    const handleForagePress = () => {
-        const currentMapId = mapManager.getCurrentMapId();
-        if (currentMapId) {
-            const result = handleForageAction(playerPosRef.current, currentMapId);
-            console.log(`[Touch Forage] ${result.message}`);
-            onForageResult?.(result);
-        }
-    };
+  const handleForagePress = () => {
+    const currentMapId = mapManager.getCurrentMapId();
+    if (currentMapId) {
+      const result = handleForageAction(playerPosRef.current, currentMapId);
+      console.log(`[Touch Forage] ${result.message}`);
+      onForageResult?.(result);
+    }
+  };
 
-    const handlePhotoPress = () => {
-        onTakePhoto?.();
-    };
+  const handlePhotoPress = () => {
+    onTakePhoto?.();
+  };
 
-    return {
-        handleDirectionPress,
-        handleDirectionRelease,
-        handleActionPress,
-        handleResetPress,
-        handleForagePress,
-        handlePhotoPress,
-    };
+  return {
+    handleDirectionPress,
+    handleDirectionRelease,
+    handleActionPress,
+    handleResetPress,
+    handleForagePress,
+    handlePhotoPress,
+  };
 }

--- a/maps/index.ts
+++ b/maps/index.ts
@@ -27,7 +27,12 @@ import { mushroomMap } from './definitions/mushroomMap';
 import { mushraShop } from './definitions/mushraShop';
 import { ruins } from './definitions/ruins';
 import { personalGarden } from './definitions/personalGarden';
-import { generateRandomForest, generateRandomCave, generateRandomShop, generateLavaMap } from './procedural';
+import {
+  generateRandomForest,
+  generateRandomCave,
+  generateRandomShop,
+  generateLavaMap,
+} from './procedural';
 import { gameState } from '../GameState';
 
 /**
@@ -78,11 +83,7 @@ export function initializeMaps(): void {
  * Handle transition to a map, generating random maps as needed
  * Also updates game state for depth tracking
  */
-export function transitionToMap(
-  mapId: string,
-  spawnPoint?: { x: number; y: number },
-  fromMapId?: string
-) {
+export function transitionToMap(mapId: string, spawnPoint?: { x: number; y: number }) {
   // Track depth changes
   if (mapId.startsWith('RANDOM_')) {
     const type = mapId.replace('RANDOM_', '').toLowerCase();
@@ -129,8 +130,7 @@ export function transitionToMap(
     // stepping out of the forest and straight back in regenerated it entirely.
     // The world still reshuffles daily, which is the variety the seed was for.
     const { totalDays } = TimeManager.getCurrentTime();
-    const dailySeed = (kind: string, depth: number) =>
-      hashString(`${kind}:${totalDays}:${depth}`);
+    const dailySeed = (kind: string, depth: number) => hashString(`${kind}:${totalDays}:${depth}`);
 
     switch (type) {
       case 'forest':

--- a/minigames/combat-encounter/CombatEncounter.tsx
+++ b/minigames/combat-encounter/CombatEncounter.tsx
@@ -323,7 +323,7 @@ const CombatEncounterInner: React.FC<
 
   const [showItemPicker, setShowItemPicker] = useState(false);
   const [stamina, setStamina] = useState(context.actions.getStamina());
-  const [introReady, setIntroReady] = useState(false);
+  const [, setIntroReady] = useState(false);
   const [fadeToBlack, setFadeToBlack] = useState(false);
 
   // Show intro text on mount, wait for player to click Ready

--- a/services/dialogueService.ts
+++ b/services/dialogueService.ts
@@ -9,7 +9,7 @@
  */
 
 import { DialogueNode, NPC, FriendshipTier } from '../types';
-import { TimeManager, Season, TimeOfDay } from '../utils/TimeManager';
+import { TimeManager } from '../utils/TimeManager';
 import { gameState } from '../GameState';
 import { GiftReaction, getGiftReactionDialogue } from '../data/giftReactions';
 import { friendshipManager } from '../utils/FriendshipManager';

--- a/tests/anthropicClient.test.ts
+++ b/tests/anthropicClient.test.ts
@@ -45,7 +45,6 @@ import {
   getStoredApiKey,
   isAIAvailable,
   reinitializeClient,
-  type StructuredAIResponse,
   type NPCEmotion,
 } from '../services/anthropicClient';
 
@@ -112,39 +111,31 @@ describe('anthropicClient', () => {
       clearStoredApiKey();
       reinitializeClient();
 
-      const result = await generateStructuredResponse(
-        'Test system prompt',
-        [],
-        'Hello'
-      );
+      const result = await generateStructuredResponse('Test system prompt', [], 'Hello');
 
       expect(result.error).toBe('AI not available');
-      expect(result.dialogue).toBe("Hmm? I lost my train of thought. What were we discussing?");
+      expect(result.dialogue).toBe('Hmm? I lost my train of thought. What were we discussing?');
     });
 
     it('should parse valid structured response', async () => {
       const mockResponse = {
         moderationScore: 0,
         shouldSendToBed: false,
-        dialogue: "Hello, traveller! Welcome to our village.",
-        action: "waves warmly",
-        emotion: "happy",
-        suggestions: ["Tell me about the village", "What's your name?", "Farewell"],
+        dialogue: 'Hello, traveller! Welcome to our village.',
+        action: 'waves warmly',
+        emotion: 'happy',
+        suggestions: ['Tell me about the village', "What's your name?", 'Farewell'],
       };
 
       mockCreate.mockResolvedValueOnce({
         content: [{ type: 'text', text: JSON.stringify(mockResponse) }],
       });
 
-      const result = await generateStructuredResponse(
-        'You are a friendly villager',
-        [],
-        'Hello!'
-      );
+      const result = await generateStructuredResponse('You are a friendly villager', [], 'Hello!');
 
-      expect(result.dialogue).toBe("Hello, traveller! Welcome to our village.");
-      expect(result.action).toBe("waves warmly");
-      expect(result.emotion).toBe("happy");
+      expect(result.dialogue).toBe('Hello, traveller! Welcome to our village.');
+      expect(result.action).toBe('waves warmly');
+      expect(result.emotion).toBe('happy');
       expect(result.moderationScore).toBe(0);
       expect(result.shouldSendToBed).toBe(false);
       expect(result.suggestions).toHaveLength(3);
@@ -154,11 +145,11 @@ describe('anthropicClient', () => {
     it('should handle moderation - rude message', async () => {
       const mockResponse = {
         moderationScore: 8,
-        moderationReason: "Rude language used",
+        moderationReason: 'Rude language used',
         shouldSendToBed: true,
-        dialogue: "That is no way to speak to an elder! Off to bed with you!",
-        action: "looks disappointed",
-        emotion: "angry",
+        dialogue: 'That is no way to speak to an elder! Off to bed with you!',
+        action: 'looks disappointed',
+        emotion: 'angry',
         suggestions: [],
       };
 
@@ -174,45 +165,49 @@ describe('anthropicClient', () => {
 
       expect(result.moderationScore).toBe(8);
       expect(result.shouldSendToBed).toBe(true);
-      expect(result.moderationReason).toBe("Rude language used");
-      expect(result.emotion).toBe("angry");
+      expect(result.moderationReason).toBe('Rude language used');
+      expect(result.emotion).toBe('angry');
     });
 
     it('should clamp moderation score to 0-10 range', async () => {
       const mockResponse = {
         moderationScore: 15, // Out of range
         shouldSendToBed: false,
-        dialogue: "Hello!",
-        emotion: "neutral",
-        suggestions: ["Hi"],
+        dialogue: 'Hello!',
+        emotion: 'neutral',
+        suggestions: ['Hi'],
       };
 
       mockCreate.mockResolvedValueOnce({
         content: [{ type: 'text', text: JSON.stringify(mockResponse) }],
       });
 
-      const result = await generateStructuredResponse(
-        'Test prompt',
-        [],
-        'Hello'
-      );
+      const result = await generateStructuredResponse('Test prompt', [], 'Hello');
 
       expect(result.moderationScore).toBe(10); // Should be clamped to max
     });
 
     it('should handle all valid emotions', async () => {
       const validEmotions: NPCEmotion[] = [
-        'neutral', 'happy', 'sad', 'surprised', 'angry',
-        'thoughtful', 'worried', 'excited', 'embarrassed', 'loving'
+        'neutral',
+        'happy',
+        'sad',
+        'surprised',
+        'angry',
+        'thoughtful',
+        'worried',
+        'excited',
+        'embarrassed',
+        'loving',
       ];
 
       for (const emotion of validEmotions) {
         const mockResponse = {
           moderationScore: 0,
           shouldSendToBed: false,
-          dialogue: "Test",
+          dialogue: 'Test',
           emotion,
-          suggestions: ["Test"],
+          suggestions: ['Test'],
         };
 
         mockCreate.mockResolvedValueOnce({
@@ -228,9 +223,9 @@ describe('anthropicClient', () => {
       const mockResponse = {
         moderationScore: 0,
         shouldSendToBed: false,
-        dialogue: "Test",
-        emotion: "invalid_emotion",
-        suggestions: ["Test"],
+        dialogue: 'Test',
+        emotion: 'invalid_emotion',
+        suggestions: ['Test'],
       };
 
       mockCreate.mockResolvedValueOnce({
@@ -245,8 +240,8 @@ describe('anthropicClient', () => {
       const mockResponse = {
         moderationScore: 0,
         shouldSendToBed: false,
-        dialogue: "Hello!",
-        emotion: "neutral",
+        dialogue: 'Hello!',
+        emotion: 'neutral',
         suggestions: [],
       };
 
@@ -255,16 +250,16 @@ describe('anthropicClient', () => {
       });
 
       const result = await generateStructuredResponse('Test', [], 'Hello');
-      expect(result.suggestions).toEqual(["Tell me more", "I should go"]);
+      expect(result.suggestions).toEqual(['Tell me more', 'I should go']);
     });
 
     it('should limit suggestions to 4', async () => {
       const mockResponse = {
         moderationScore: 0,
         shouldSendToBed: false,
-        dialogue: "Hello!",
-        emotion: "neutral",
-        suggestions: ["One", "Two", "Three", "Four", "Five", "Six"],
+        dialogue: 'Hello!',
+        emotion: 'neutral',
+        suggestions: ['One', 'Two', 'Three', 'Four', 'Five', 'Six'],
       };
 
       mockCreate.mockResolvedValueOnce({
@@ -279,9 +274,9 @@ describe('anthropicClient', () => {
       const mockResponse = {
         moderationScore: 0,
         shouldSendToBed: false,
-        dialogue: "I remember you!",
-        emotion: "happy",
-        suggestions: ["Good to see you"],
+        dialogue: 'I remember you!',
+        emotion: 'happy',
+        suggestions: ['Good to see you'],
       };
 
       mockCreate.mockResolvedValueOnce({
@@ -310,9 +305,9 @@ describe('anthropicClient', () => {
       const mockResponse = {
         moderationScore: 0,
         shouldSendToBed: false,
-        dialogue: "Hello!",
-        emotion: "neutral",
-        suggestions: ["Hi"],
+        dialogue: 'Hello!',
+        emotion: 'neutral',
+        suggestions: ['Hi'],
       };
 
       mockCreate.mockResolvedValueOnce({
@@ -346,7 +341,7 @@ describe('anthropicClient', () => {
       const result = await generateStructuredResponse('Test', [], 'Hello');
 
       expect(result.error).toBe('API rate limit exceeded');
-      expect(result.dialogue).toBe("Hmm? I lost my train of thought. What were we discussing?");
+      expect(result.dialogue).toBe('Hmm? I lost my train of thought. What were we discussing?');
       expect(result.emotion).toBe('neutral');
     });
 
@@ -358,7 +353,7 @@ describe('anthropicClient', () => {
       const result = await generateStructuredResponse('Test', [], 'Hello');
 
       // Should return default response
-      expect(result.dialogue).toBe("Hmm? I lost my train of thought. What were we discussing?");
+      expect(result.dialogue).toBe('Hmm? I lost my train of thought. What were we discussing?');
       expect(result.emotion).toBe('neutral');
     });
 
@@ -369,16 +364,16 @@ describe('anthropicClient', () => {
 
       const result = await generateStructuredResponse('Test', [], 'Hello');
 
-      expect(result.dialogue).toBe("Hmm? I lost my train of thought. What were we discussing?");
+      expect(result.dialogue).toBe('Hmm? I lost my train of thought. What were we discussing?');
     });
 
     it('should use correct model', async () => {
       const mockResponse = {
         moderationScore: 0,
         shouldSendToBed: false,
-        dialogue: "Hello!",
-        emotion: "neutral",
-        suggestions: ["Hi"],
+        dialogue: 'Hello!',
+        emotion: 'neutral',
+        suggestions: ['Hi'],
       };
 
       mockCreate.mockResolvedValueOnce({
@@ -405,9 +400,9 @@ describe('anthropicClient', () => {
       const mockResponse = {
         moderationScore: 0,
         shouldSendToBed: false,
-        dialogue: "Test",
-        emotion: "neutral",
-        suggestions: ["Test"],
+        dialogue: 'Test',
+        emotion: 'neutral',
+        suggestions: ['Test'],
       };
 
       mockCreate.mockResolvedValueOnce({
@@ -431,9 +426,9 @@ describe('anthropicClient', () => {
       const mockResponse = {
         moderationScore: 0,
         shouldSendToBed: false,
-        dialogue: "Test",
-        emotion: "neutral",
-        suggestions: ["Test"],
+        dialogue: 'Test',
+        emotion: 'neutral',
+        suggestions: ['Test'],
       };
 
       mockCreate.mockResolvedValueOnce({
@@ -446,8 +441,16 @@ describe('anthropicClient', () => {
       const emotionSchema = callArgs.output_format.schema.properties.emotion;
 
       expect(emotionSchema.enum).toEqual([
-        'neutral', 'happy', 'sad', 'surprised', 'angry',
-        'thoughtful', 'worried', 'excited', 'embarrassed', 'loving'
+        'neutral',
+        'happy',
+        'sad',
+        'surprised',
+        'angry',
+        'thoughtful',
+        'worried',
+        'excited',
+        'embarrassed',
+        'loving',
       ]);
     });
   });

--- a/tests/combat.test.ts
+++ b/tests/combat.test.ts
@@ -6,7 +6,7 @@
  * tested here (it carries timer/state-machine complexity that's better
  * covered by an integration test).
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import type { CombatMove } from '../minigames/combat-encounter/combatTypes';
 import { resolveRound, BEATS, COUNTERED_BY } from '../minigames/combat-encounter/combatTypes';
 import {

--- a/tests/cropGrowth.test.ts
+++ b/tests/cropGrowth.test.ts
@@ -3,7 +3,7 @@
  *
  * Uses node environment to avoid jsdom compatibility issues.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 // Mock TimeManager — crops.ts uses both Season enum and TimeManager.MS_PER_GAME_DAY
 vi.mock('../utils/TimeManager', () => ({
@@ -32,7 +32,7 @@ describe('Crop Growth System', () => {
     });
 
     it('should have valid growth times', () => {
-      Object.entries(CROPS).forEach(([id, crop]) => {
+      Object.entries(CROPS).forEach(([_id, crop]) => {
         expect(crop.growthTime).toBeGreaterThan(0);
         expect(crop.growthTimeWatered).toBeGreaterThan(0);
         expect(crop.growthTimeWatered).toBeLessThan(crop.growthTime); // Watered should be faster
@@ -40,7 +40,7 @@ describe('Crop Growth System', () => {
     });
 
     it('should have valid water requirements', () => {
-      Object.entries(CROPS).forEach(([id, crop]) => {
+      Object.entries(CROPS).forEach(([_id, crop]) => {
         expect(crop.waterNeededInterval).toBeGreaterThan(0);
         expect(crop.wiltingGracePeriod).toBeGreaterThan(0);
         expect(crop.deathGracePeriod).toBeGreaterThan(0);
@@ -48,7 +48,7 @@ describe('Crop Growth System', () => {
     });
 
     it('should have positive yields and prices (except decorative crops)', () => {
-      Object.entries(CROPS).forEach(([id, crop]) => {
+      Object.entries(CROPS).forEach(([_id, crop]) => {
         // Decorative crops (e.g. fairy_bluebell) intentionally have 0 yield/price
         if (crop.harvestYield === 0) {
           expect(crop.sellPrice).toBe(0);
@@ -101,7 +101,7 @@ describe('Crop Growth System', () => {
     });
 
     it('watering should provide meaningful time savings', () => {
-      Object.entries(CROPS).forEach(([id, crop]) => {
+      Object.entries(CROPS).forEach(([_id, crop]) => {
         const timeSaved = crop.growthTime - crop.growthTimeWatered;
         const percentSaved = (timeSaved / crop.growthTime) * 100;
 
@@ -118,7 +118,7 @@ describe('Crop Growth System', () => {
         expect(true).toBe(true);
         return;
       }
-      Object.entries(CROPS).forEach(([id, crop]) => {
+      Object.entries(CROPS).forEach(([_id, crop]) => {
         // Water interval should be less than growth time
         // (crops need watering at least once during growth)
         expect(crop.waterNeededInterval).toBeLessThan(crop.growthTime);
@@ -242,7 +242,7 @@ describe('Crop Growth System', () => {
 
   describe('Crop Metadata', () => {
     it('should have display names', () => {
-      Object.entries(CROPS).forEach(([id, crop]) => {
+      Object.entries(CROPS).forEach(([_id, crop]) => {
         expect(crop.displayName).toBeTruthy();
         expect(crop.displayName.length).toBeGreaterThan(0);
         // Display name should be capitalized
@@ -251,20 +251,20 @@ describe('Crop Growth System', () => {
     });
 
     it('should have descriptions', () => {
-      Object.entries(CROPS).forEach(([id, crop]) => {
+      Object.entries(CROPS).forEach(([_id, crop]) => {
         expect(crop.description).toBeTruthy();
         expect(crop.description.length).toBeGreaterThan(10);
       });
     });
 
     it('should have rarity levels', () => {
-      Object.entries(CROPS).forEach(([id, crop]) => {
+      Object.entries(CROPS).forEach(([_id, crop]) => {
         expect(['common', 'uncommon', 'rare', 'very_rare']).toContain(crop.rarity);
       });
     });
 
     it('should have experience values', () => {
-      Object.entries(CROPS).forEach(([id, crop]) => {
+      Object.entries(CROPS).forEach(([_id, crop]) => {
         expect(crop.experience).toBeGreaterThan(0);
       });
     });
@@ -280,7 +280,7 @@ describe('Crop Growth System', () => {
     });
 
     it('should have grace periods in reasonable ranges', () => {
-      Object.entries(CROPS).forEach(([id, crop]) => {
+      Object.entries(CROPS).forEach(([_id, crop]) => {
         // Grace periods should be less than water interval
         expect(crop.wiltingGracePeriod).toBeLessThan(crop.waterNeededInterval);
         expect(crop.deathGracePeriod).toBeLessThan(crop.waterNeededInterval);

--- a/tests/farmManager.test.ts
+++ b/tests/farmManager.test.ts
@@ -51,9 +51,9 @@ vi.mock('../utils/TimeManager', () => ({
 // Mock inventoryManager
 vi.mock('../utils/inventoryManager', () => ({
   inventoryManager: {
-    removeItem: vi.fn((itemId: string, quantity: number) => true),
-    hasItem: vi.fn((itemId: string, quantity: number) => true),
-    addItem: vi.fn((itemId: string, quantity: number) => {}),
+    removeItem: vi.fn((_itemId: string, _quantity: number) => true),
+    hasItem: vi.fn((_itemId: string, _quantity: number) => true),
+    addItem: vi.fn((_itemId: string, _quantity: number) => {}),
     getInventoryData: vi.fn(() => ({ items: {}, tools: {} })),
   },
 }));

--- a/tests/firebase/cloudSaveService.test.ts
+++ b/tests/firebase/cloudSaveService.test.ts
@@ -1,5 +1,5 @@
 /** @vitest-environment node */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { FIRESTORE_PATHS, SAVE_DATA_DOCS } from '../../firebase/types';
 
 /**

--- a/tests/firebase/sharedDataService.test.ts
+++ b/tests/firebase/sharedDataService.test.ts
@@ -1,5 +1,5 @@
 /** @vitest-environment node */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { FIRESTORE_PATHS } from '../../firebase/types';
 
 /**

--- a/tests/firebase/syncManager.test.ts
+++ b/tests/firebase/syncManager.test.ts
@@ -23,7 +23,7 @@ vi.mock('../../firebase/config', () => ({
 
 vi.mock('../../firebase/authService', () => ({
   authService: {
-    onAuthStateChange: vi.fn((cb) => {
+    onAuthStateChange: vi.fn((_cb) => {
       // Return unsubscribe function
       return () => {};
     }),

--- a/tests/globalEvents.test.ts
+++ b/tests/globalEvents.test.ts
@@ -1,5 +1,5 @@
 /** @vitest-environment node */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 /**
  * Global Events System Tests

--- a/tests/palette.test.ts
+++ b/tests/palette.test.ts
@@ -7,7 +7,7 @@
  * Uses happy-dom instead of jsdom to avoid webidl-conversions compatibility issues.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   getPalette,
   getColorHex,
@@ -16,7 +16,6 @@ import {
   exportPalette,
   initializePalette,
   DEFAULT_PALETTE,
-  GamePalette,
 } from '../palette';
 
 // Mock DOM for applyPaletteToDOM

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,4 @@
-import { expect, afterEach } from 'vitest';
+import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
@@ -9,9 +9,9 @@ afterEach(() => {
 
 // Mock localStorage
 const localStorageMock = {
-  getItem: (key: string) => null,
-  setItem: (key: string, value: string) => {},
-  removeItem: (key: string) => {},
+  getItem: (_key: string) => null,
+  setItem: (_key: string, _value: string) => {},
+  removeItem: (_key: string) => {},
   clear: () => {},
 };
 global.localStorage = localStorageMock as Storage;

--- a/tests/tileRegistration.test.ts
+++ b/tests/tileRegistration.test.ts
@@ -28,7 +28,7 @@
 
 /** @vitest-environment node */
 import { describe, it, expect, beforeAll, vi } from 'vitest';
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { initializeMaps, mapManager } from '../maps';
 import { GRID_CODES } from '../maps/gridParser';
 import { COLOR_SCHEMES } from '../maps/colorSchemes';

--- a/utils/CookingManager.ts
+++ b/utils/CookingManager.ts
@@ -365,9 +365,9 @@ class CookingManagerClass {
    * Cook a recipe - consumes ingredients and produces food
    * Returns result with success and any produced items
    * @param recipeId - Recipe to cook
-   * @param campfireBonus - Optional parameter (unused, kept for backwards compatibility)
+   * @param _campfireBonus - Optional parameter (unused, kept for backwards compatibility)
    */
-  cook(recipeId: string, campfireBonus = 0): CookingResult {
+  cook(recipeId: string, _campfireBonus = 0): CookingResult {
     // Cooking costs stamina
     if (!staminaManager.performActivity('cook')) {
       return { success: false, message: "You're too tired to cook right now." };

--- a/utils/DecorationManager.ts
+++ b/utils/DecorationManager.ts
@@ -483,7 +483,6 @@ class DecorationManagerClass {
     unlocked: boolean;
     hint?: string;
   }> {
-    const colourMap = getPaintColourMap();
     return Object.values(PAINT_RECIPES).map((recipe) => ({
       paintId: recipe.resultItemId,
       colour: recipe.colour ?? '#888888',

--- a/utils/FriendshipManager.ts
+++ b/utils/FriendshipManager.ts
@@ -22,7 +22,7 @@ import { characterData, FriendshipData } from './CharacterData';
 import { eventBus, GameEvent } from './EventBus';
 import { TimeManager } from './TimeManager';
 import { inventoryManager } from './inventoryManager';
-import { getItem, ItemCategory } from '../data/items';
+import { getItem } from '../data/items';
 import { RECIPES, NPC_FOOD_PREFERENCES, RecipeCategory } from '../data/recipes';
 import { getGiftReaction, GiftReaction } from '../data/giftReactions';
 import {
@@ -64,7 +64,6 @@ import {
 import {
   isGhostQuestActive,
   advanceGhostQuestToHasBook,
-  GHOST_QUEEN_QUEST_ID,
 } from '../data/questHandlers/ghostQueenHandler';
 
 // Tier reward definitions - items given when reaching a tier with certain NPCs
@@ -398,7 +397,7 @@ class FriendshipManagerClass {
   giveGift(
     npcId: string,
     itemId: string,
-    npc?: NPC
+    _npc?: NPC
   ): { points: number; reaction: GiftReaction; questCompleted?: boolean; dialogueNodeId?: string } {
     const item = getItem(itemId);
     if (!item) {
@@ -552,14 +551,21 @@ class FriendshipManagerClass {
     dialogueNodeId?: string;
   } | null {
     // ===== ESTRANGED SISTERS: Accept letter from Althea =====
-    if (itemId === SISTERS_ITEMS.LETTER && getEstrangedSistersStage() === SISTERS_STAGES.LETTER_GIVEN) {
+    if (
+      itemId === SISTERS_ITEMS.LETTER &&
+      getEstrangedSistersStage() === SISTERS_STAGES.LETTER_GIVEN
+    ) {
       const nodeId = deliverLetterToJuniper();
-      if (DEBUG.FRIENDSHIP) console.log('[FriendshipManager] Witch receives Althea\'s letter via gift.');
+      if (DEBUG.FRIENDSHIP)
+        console.log("[FriendshipManager] Witch receives Althea's letter via gift.");
       return { points: 0, reaction: 'neutral', dialogueNodeId: nodeId };
     }
 
     // ===== ESTRANGED SISTERS: Accept photograph of Althea =====
-    if (itemId === SISTERS_ITEMS.PHOTO && getEstrangedSistersStage() === SISTERS_STAGES.PHOTO_NEEDED) {
+    if (
+      itemId === SISTERS_ITEMS.PHOTO &&
+      getEstrangedSistersStage() === SISTERS_STAGES.PHOTO_NEEDED
+    ) {
       const nodeId = deliverPhotoToJuniper();
       if (DEBUG.FRIENDSHIP) console.log('[FriendshipManager] Witch receives photograph via gift.');
       return { points: 0, reaction: 'neutral', dialogueNodeId: nodeId };
@@ -634,7 +640,8 @@ class FriendshipManagerClass {
       markCookiesDelivered();
       const points = 100;
       this.addPoints('old_woman_knitting', points, 'althea chores: cookies delivered');
-      if (DEBUG.FRIENDSHIP) console.log('[FriendshipManager] Althea receives cookies! (+${points})');
+      if (DEBUG.FRIENDSHIP)
+        console.log('[FriendshipManager] Althea receives cookies! (+${points})');
       return { points, reaction: 'loved', dialogueNodeId: 'chores_cookies_accepted' };
     }
 

--- a/utils/MagicEffects.ts
+++ b/utils/MagicEffects.ts
@@ -11,9 +11,9 @@
 
 import { WeatherType } from '../data/weatherConfig';
 import { mapManager } from '../maps';
-import { TimeManager, TimeOfDay } from './TimeManager';
+import { TimeManager } from './TimeManager';
 import { farmManager } from './farmManager';
-import { friendshipManager } from './FriendshipManager';
+
 import { Position, FarmPlotState } from '../types';
 
 // ============================================================================
@@ -806,13 +806,6 @@ export function hasPotionEffect(potionId: string): boolean {
  * Get all VFX types used by potion effects (for preloading)
  */
 export function getAllVFXTypes(): string[] {
-  const vfxTypes = new Set<string>();
-
-  Object.values(POTION_EFFECTS).forEach((effect) => {
-    // Execute with dummy callbacks to get vfxType
-    // This is a bit hacky, but works for getting static vfx types
-  });
-
   // Manually list all VFX types for now
   return [
     'shrink',

--- a/utils/MagicManager.ts
+++ b/utils/MagicManager.ts
@@ -24,7 +24,6 @@
 import {
   PotionRecipeDefinition,
   PotionLevel,
-  POTION_RECIPES,
   getPotionRecipe,
   getPotionRecipesByLevel,
 } from '../data/potionRecipes';

--- a/utils/ShopManager.ts
+++ b/utils/ShopManager.ts
@@ -3,16 +3,15 @@
  * Handles buying, selling, and inventory filtering for the shop system
  */
 
-import { ITEMS, ItemDefinition, getItem } from '../data/items';
+import { ItemDefinition, getItem } from '../data/items';
 import {
-  GENERAL_STORE_INVENTORY,
   ShopItem,
   getSeasonalInventory,
   getMushrasShopInventory,
   getShellaShopInventory,
   getBuyPrice,
   getSellPrice,
-  Season as ShopSeason
+  Season as ShopSeason,
 } from '../data/shopInventory';
 import { TimeManager, Season as GameSeason } from './TimeManager';
 import { inventoryManager } from './inventoryManager';
@@ -24,7 +23,7 @@ import { cookingManager } from './CookingManager';
 export interface TransactionResult {
   success: boolean;
   message: string;
-  goldChange?: number;  // Positive = gained, negative = spent
+  goldChange?: number; // Positive = gained, negative = spent
 }
 
 /**
@@ -33,8 +32,8 @@ export interface TransactionResult {
 export interface InventoryItem {
   itemId: string;
   quantity: number;
-  uses?: number;  // Current uses remaining for this item (only if item has maxUses defined)
-  masteryLevel?: number;  // Mastery level when food was cooked (0 = not mastered, 1-3 = times cooked when produced)
+  uses?: number; // Current uses remaining for this item (only if item has maxUses defined)
+  masteryLevel?: number; // Mastery level when food was cooked (0 = not mastered, 1-3 = times cooked when produced)
 }
 
 /**
@@ -132,7 +131,7 @@ export class ShopManager {
   ): TransactionResult {
     // Get shop item
     const shopInventory = this.getInventoryForShop(shopId);
-    const shopItem = shopInventory.find(item => item.itemId === itemId);
+    const shopItem = shopInventory.find((item) => item.itemId === itemId);
 
     if (!shopItem) {
       return {
@@ -217,7 +216,7 @@ export class ShopManager {
     }
 
     // Check player has item
-    const inventoryItem = playerInventory.find(item => item.itemId === itemId);
+    const inventoryItem = playerInventory.find((item) => item.itemId === itemId);
     if (!inventoryItem || inventoryItem.quantity < quantity) {
       return {
         success: false,
@@ -241,8 +240,12 @@ export class ShopManager {
     // Add mastery bonus info to message if applicable
     let message = `Sold ${quantity}× ${itemDef.displayName} for ${totalEarnings}g`;
     if (inventoryItem.masteryLevel !== undefined && inventoryItem.masteryLevel >= 1) {
-      const multiplier = inventoryItem.masteryLevel >= 3 ? '2.0x' :
-                         inventoryItem.masteryLevel === 2 ? '1.5x' : '1.2x';
+      const multiplier =
+        inventoryItem.masteryLevel >= 3
+          ? '2.0x'
+          : inventoryItem.masteryLevel === 2
+            ? '1.5x'
+            : '1.2x';
       message += ` (${multiplier} mastery bonus)`;
     }
 
@@ -368,7 +371,7 @@ export class ShopManager {
    * @returns Maximum sellable quantity
    */
   public getMaxSellQuantity(itemId: string, playerInventory: InventoryItem[]): number {
-    const inventoryItem = playerInventory.find(item => item.itemId === itemId);
+    const inventoryItem = playerInventory.find((item) => item.itemId === itemId);
     return inventoryItem?.quantity || 0;
   }
 
@@ -379,7 +382,7 @@ export class ShopManager {
    * @returns Sell price with mastery bonus, or undefined if not sellable
    */
   public getItemSellPrice(itemId: string, playerInventory: InventoryItem[]): number | undefined {
-    const inventoryItem = playerInventory.find(item => item.itemId === itemId);
+    const inventoryItem = playerInventory.find((item) => item.itemId === itemId);
     if (!inventoryItem) return undefined;
 
     return getSellPrice(itemId, inventoryItem.masteryLevel);

--- a/utils/actionHandlers.ts
+++ b/utils/actionHandlers.ts
@@ -4,14 +4,7 @@
  */
 
 import { Position, TileType, CollisionType, SizeTier, FarmPlotState, NPC } from '../types';
-import {
-  getTileData,
-  getAdjacentTiles,
-  getTileCoords,
-  getSurroundingTiles,
-  hasTileTypeNearby,
-  findTileTypeNearby,
-} from './mapUtils';
+import { getTileData, getAdjacentTiles, getTileCoords } from './mapUtils';
 import { deskManager } from './deskManager';
 import { mapManager, transitionToMap } from '../maps';
 import { gameState } from '../GameState';
@@ -20,30 +13,14 @@ import { farmManager } from './farmManager';
 import { inventoryManager } from './inventoryManager';
 import { characterData } from './CharacterData';
 import { getCrop } from '../data/crops';
-import { getCropIdFromSeed, getItem, ItemCategory } from '../data/items';
-import { TimeManager, Season } from './TimeManager';
-import { WATER_CAN, TIMING, DEBUG } from '../constants';
+import { getCropIdFromSeed } from '../data/items';
+
+import { WATER_CAN, DEBUG } from '../constants';
 import { staminaManager } from './StaminaManager';
-import { itemAssets, groceryAssets, magicalAssets } from '../assets';
+
 import { getTierName } from './MagicEffects';
-import {
-  ForageResult,
-  handleForageAction,
-  handleBlackberryHarvest,
-  handleHazelnutHarvest,
-  handleBlueberryHarvest,
-  handleRedBerryHarvest,
-} from './forageHandlers';
-import { decorationManager } from './DecorationManager';
+
 import { cookingManager, CookingResult } from './CookingManager';
-import { getFrameStyle } from './frameStyles';
-import { isMrFoxPicnicAtStage } from '../data/questHandlers/mrFoxPicnicHandler';
-import { getMiniGamesForPlacedItem, getMiniGamesForNPC } from '../minigames/registry';
-import { miniGameManager } from '../minigames/MiniGameManager';
-import type { MiniGameTriggerData } from '../minigames/types';
-import { fruitTreeManager } from './fruitTreeManager';
-import { yuleCelebrationManager } from './YuleCelebrationManager';
-import { eventBus, GameEvent } from './EventBus';
 
 // Re-export forage types and handlers for consumers importing from actionHandlers
 export type { ForageResult } from './forageHandlers';
@@ -289,16 +266,8 @@ export function checkTransition(
 
   try {
     // Transition to new map (pass current map ID for depth tracking)
-    const { map, spawn } = transitionToMap(
-      transition.toMapId,
-      transition.toPosition,
-      currentMapId || undefined
-    );
+    const { map, spawn } = transitionToMap(transition.toMapId, transition.toPosition);
     if (DEBUG.MAP) console.log(`[Action] Successfully loaded map: ${map.id} (${map.name})`);
-
-    // Extract seed from random map IDs (e.g., "forest_1234" -> 1234)
-    const seedMatch = map.id.match(/_([\d]+)$/);
-    const seed = seedMatch ? parseInt(seedMatch[1]) : undefined;
 
     return {
       success: true,

--- a/utils/cobwebInteractions.ts
+++ b/utils/cobwebInteractions.ts
@@ -14,9 +14,7 @@ import {
   getCobwebsRemaining,
   markCobwebCleaned,
   isAltheaChoresActive,
-  QUEST_ID,
 } from '../data/questHandlers/altheaChoresHandler';
-import { gameState } from '../GameState';
 
 /**
  * Result of a cobweb click check
@@ -178,7 +176,9 @@ export function isInCobwebCleaningArea(mapId: string): boolean {
  */
 export function canCleanCobwebs(mapId: string, currentToolId: string | undefined): boolean {
   return (
-    isAltheaChoresActive() && isInCobwebCleaningArea(mapId) && isFeatherDusterEquipped(currentToolId)
+    isAltheaChoresActive() &&
+    isInCobwebCleaningArea(mapId) &&
+    isFeatherDusterEquipped(currentToolId)
   );
 }
 

--- a/utils/dialogueHandlers.ts
+++ b/utils/dialogueHandlers.ts
@@ -63,11 +63,9 @@ import {
   setHasMetGhost,
   wasRudeToGhost,
   setWasRudeToGhost,
-  startGhostQuest,
   completeGhostQuest,
   isGhostQuestStarted,
   advanceGhostQuestToHasBook,
-  GHOST_QUEEN_QUEST_ID,
 } from '../data/questHandlers/ghostQueenHandler';
 import { createQueenAvericiaaNPC } from './npcs/village/queenAvaricia';
 

--- a/utils/gameInitializer.ts
+++ b/utils/gameInitializer.ts
@@ -1,5 +1,5 @@
 import { runSelfTests } from './testUtils';
-import { initializeMaps, mapManager, transitionToMap } from '../maps';
+import { initializeMaps, mapManager } from '../maps';
 import { gameState } from '../GameState';
 import { characterData } from './CharacterData';
 import { initializePalette } from '../palette';

--- a/utils/interactions/providers/transition.ts
+++ b/utils/interactions/providers/transition.ts
@@ -10,7 +10,7 @@ import { getTierName } from '../../MagicEffects';
 import { mapManager, transitionToMap } from '../../../maps';
 
 export function transitionProvider(ctx: InteractionContext): AvailableInteraction[] {
-  const { position, currentMapId, playerSizeTier, isContextMenu, onTransition } = ctx;
+  const { position, playerSizeTier, isContextMenu, onTransition } = ctx;
   const interactions: AvailableInteraction[] = [];
 
   /**
@@ -78,14 +78,8 @@ export function transitionProvider(ctx: InteractionContext): AvailableInteractio
         color: '#34d399',
         execute: () => {
           try {
-            const result = transitionToMap(
-              transition.toMapId,
-              transition.toPosition,
-              currentMapId || undefined
-            );
+            const result = transitionToMap(transition.toMapId, transition.toPosition);
             const map = result.map;
-            const seedMatch = map.id.match(/_([\d]+)$/);
-            const seed = seedMatch ? parseInt(seedMatch[1]) : undefined;
             onTransition?.({
               success: true,
               mapId: map.id,

--- a/utils/inventoryManager.ts
+++ b/utils/inventoryManager.ts
@@ -11,7 +11,7 @@
  * - Materials and misc items
  */
 
-import { ItemCategory, getItem, ITEMS } from '../data/items';
+import { ItemCategory, getItem } from '../data/items';
 import { characterData } from './CharacterData';
 import { eventBus, GameEvent } from './EventBus';
 import { CAMERA } from '../constants';

--- a/utils/npcs/homeNPCs.ts
+++ b/utils/npcs/homeNPCs.ts
@@ -4,7 +4,7 @@
  * NPCs that appear in home/family settings.
  */
 
-import { NPC, Direction, Position } from '../../types';
+import { NPC, Position } from '../../types';
 import { npcAssets, dialogueSpriteAssets } from '../../assets';
 import { createStaticNPC } from './createNPC';
 
@@ -22,11 +22,7 @@ import { createStaticNPC } from './createNPC';
  * @param position Where to place the NPC
  * @param name Optional name (defaults to "Mum")
  */
-export function createMumNPC(
-  id: string,
-  position: Position,
-  name: string = 'Mum'
-): NPC {
+export function createMumNPC(id: string, position: Position, name: string = 'Mum'): NPC {
   return createStaticNPC({
     id,
     name,
@@ -47,32 +43,66 @@ export function createMumNPC(
         text: 'Hello, love! Welcome home. Have you had a good day?',
         expression: 'smile',
         seasonalText: {
-          spring: 'Good morning, dear! Spring is here - perfect weather for the garden. Would you like some breakfast before you head out?',
-          summer: 'Hello, sweetheart! It\'s warm today. I\'ve made some cold lemonade if you\'d like some.',
-          autumn: 'Welcome home, love. The leaves are turning such beautiful colours. I\'ve been thinking about making some autumn preserves.',
-          winter: 'Come in from the cold, dear! I\'ve got the fire going. Warm yourself up before you go back out.',
+          spring:
+            'Good morning, dear! Spring is here - perfect weather for the garden. Would you like some breakfast before you head out?',
+          summer:
+            "Hello, sweetheart! It's warm today. I've made some cold lemonade if you'd like some.",
+          autumn:
+            "Welcome home, love. The leaves are turning such beautiful colours. I've been thinking about making some autumn preserves.",
+          winter:
+            "Come in from the cold, dear! I've got the fire going. Warm yourself up before you go back out.",
         },
         timeOfDayText: {
-          day: 'Hello, love! I\'m just tidying up around the house. Is there anything you need?',
-          night: 'You\'re back late, dear! I hope you\'re not working too hard. Get some rest, won\'t you?',
+          day: "Hello, love! I'm just tidying up around the house. Is there anything you need?",
+          night:
+            "You're back late, dear! I hope you're not working too hard. Get some rest, won't you?",
         },
         weatherText: {
-          rain: 'Come in out of that rain, dear! You\'ll catch your death of cold. Let me get you a towel and some warm tea.',
-          snow: 'It\'s snowing heavily out there! Please be careful if you go outside. And do wear a scarf, won\'t you?',
-          fog: 'This fog is quite thick today. Do be careful if you\'re going out - it\'s easy to lose your way in weather like this.',
-          mist: 'Such a misty day! Rather peaceful, isn\'t it? Perfect weather for staying home and having a cup of tea.',
-          storm: 'Goodness, what a storm! I do hope everyone in the village is safe. Please stay inside until it passes, love.',
-          cherry_blossoms: 'Look at those beautiful petals falling! The cherry tree is in full bloom. It reminds me of when you were little - you loved catching the petals.',
+          rain: "Come in out of that rain, dear! You'll catch your death of cold. Let me get you a towel and some warm tea.",
+          snow: "It's snowing heavily out there! Please be careful if you go outside. And do wear a scarf, won't you?",
+          fog: "This fog is quite thick today. Do be careful if you're going out - it's easy to lose your way in weather like this.",
+          mist: "Such a misty day! Rather peaceful, isn't it? Perfect weather for staying home and having a cup of tea.",
+          storm:
+            'Goodness, what a storm! I do hope everyone in the village is safe. Please stay inside until it passes, love.',
+          cherry_blossoms:
+            'Look at those beautiful petals falling! The cherry tree is in full bloom. It reminds me of when you were little - you loved catching the petals.',
         },
         responses: [
           { text: 'Tell me about the village.', nextId: 'village_chat' },
-          { text: 'Can you teach me to cook?', nextId: 'teach_cooking', hiddenIfCookingCourseComplete: true },
-          { text: 'How can I learn more recipes?', nextId: 'learn_more_recipes', requiredCookingCourseComplete: true },
-          { text: 'What are you working on?', nextId: 'home_tasks', requiredCookingCourseComplete: true },
-          { text: 'Tell me about yourself, Mum.', nextId: 'about_mum', requiredCookingCourseComplete: true },
+          {
+            text: 'Can you teach me to cook?',
+            nextId: 'teach_cooking',
+            hiddenIfCookingCourseComplete: true,
+          },
+          {
+            text: 'How can I learn more recipes?',
+            nextId: 'learn_more_recipes',
+            requiredCookingCourseComplete: true,
+          },
+          {
+            text: 'What are you working on?',
+            nextId: 'home_tasks',
+            requiredCookingCourseComplete: true,
+          },
+          {
+            text: 'Tell me about yourself, Mum.',
+            nextId: 'about_mum',
+            requiredCookingCourseComplete: true,
+          },
           // Mr Fox's Picnic quest — disappears 7 in-game days after the picnic wraps up
-          { text: 'How did the picnic go?', nextId: 'mfp_post_quest', requiredQuest: 'mr_fox_picnic', requiredQuestStage: 9, hiddenIfQuestStageDaysElapsed: { questId: 'mr_fox_picnic', days: 7 } },
-          { text: 'Do you know anything about a place called Nevarre?', nextId: 'nevarre_enquiry', requiredQuest: 'ghost_queen', hiddenIfQuestCompleted: 'ghost_queen' },
+          {
+            text: 'How did the picnic go?',
+            nextId: 'mfp_post_quest',
+            requiredQuest: 'mr_fox_picnic',
+            requiredQuestStage: 9,
+            hiddenIfQuestStageDaysElapsed: { questId: 'mr_fox_picnic', days: 7 },
+          },
+          {
+            text: 'Do you know anything about a place called Nevarre?',
+            nextId: 'nevarre_enquiry',
+            requiredQuest: 'ghost_queen',
+            hiddenIfQuestCompleted: 'ghost_queen',
+          },
         ],
       },
       {
@@ -84,13 +114,17 @@ export function createMumNPC(
       },
       {
         id: 'home_tasks',
-        text: 'Oh, just the usual - keeping the house tidy, preparing meals. It\'s simple work, but it keeps me busy.',
+        text: "Oh, just the usual - keeping the house tidy, preparing meals. It's simple work, but it keeps me busy.",
         expression: 'default',
         seasonalText: {
-          spring: 'I\'ve been planting flowers in the window boxes. The spring blooms bring such joy to our home!',
-          summer: 'I\'m preserving berries for winter. The summer harvest is always bountiful if we care for it properly.',
-          autumn: 'Making warm blankets and preparing for the colder months. Winter will be here before we know it.',
-          winter: 'Keeping the fire going and making hearty soups. It\'s important to stay warm and well-fed in winter.',
+          spring:
+            "I've been planting flowers in the window boxes. The spring blooms bring such joy to our home!",
+          summer:
+            "I'm preserving berries for winter. The summer harvest is always bountiful if we care for it properly.",
+          autumn:
+            'Making warm blankets and preparing for the colder months. Winter will be here before we know it.',
+          winter:
+            "Keeping the fire going and making hearty soups. It's important to stay warm and well-fed in winter.",
         },
         responses: [
           { text: 'Can I help with anything?', nextId: 'offer_help' },
@@ -99,22 +133,23 @@ export function createMumNPC(
       },
       {
         id: 'offer_help',
-        text: 'That\'s very sweet of you, dear. Just knowing you\'re safe and happy is help enough. But do take care of yourself out there.',
+        text: "That's very sweet of you, dear. Just knowing you're safe and happy is help enough. But do take care of yourself out there.",
         expression: 'happy',
       },
       {
         id: 'village_chat',
-        text: 'The village is such a peaceful place. I\'m grateful we have such lovely neighbours. Everyone looks after each other here.',
+        text: "The village is such a peaceful place. I'm grateful we have such lovely neighbours. Everyone looks after each other here.",
         seasonalText: {
-          spring: 'The village comes alive in spring! Children playing in the fields, farmers planting crops... it\'s a wonderful time of year.',
-          summer: 'Summer brings travellers through the village. I always enjoy hearing their stories from faraway places.',
-          autumn: 'Autumn is harvest time. The whole village works together to bring in the crops. It\'s beautiful to see.',
-          winter: 'Winter can be hard, but the village pulls together. We share what we have and keep each other warm.',
+          spring:
+            "The village comes alive in spring! Children playing in the fields, farmers planting crops... it's a wonderful time of year.",
+          summer:
+            'Summer brings travellers through the village. I always enjoy hearing their stories from faraway places.',
+          autumn:
+            "Autumn is harvest time. The whole village works together to bring in the crops. It's beautiful to see.",
+          winter:
+            'Winter can be hard, but the village pulls together. We share what we have and keep each other warm.',
         },
-        responses: [
-          { text: 'It is peaceful here.' },
-          { text: 'Thank you for the chat.' },
-        ],
+        responses: [{ text: 'It is peaceful here.' }, { text: 'Thank you for the chat.' }],
       },
       {
         id: 'learn_more_recipes',
@@ -124,36 +159,100 @@ export function createMumNPC(
       },
       {
         id: 'teach_cooking',
-        text: 'Oh, I\'d love to teach you! Cooking is such a wonderful skill. Let me show you some of my favourite recipes.',
+        text: "Oh, I'd love to teach you! Cooking is such a wonderful skill. Let me show you some of my favourite recipes.",
         expression: 'happy',
         responses: [
           // Fireplace intro — shown until player has opened the fireplace for the first time
-          { text: 'That sounds wonderful! Where do I start?', nextId: 'fireplace_intro', hiddenIfFireplaceTutorialComplete: true },
+          {
+            text: 'That sounds wonderful! Where do I start?',
+            nextId: 'fireplace_intro',
+            hiddenIfFireplaceTutorialComplete: true,
+          },
 
           // After fireplace tutorial — choose a domain (only shown if no domain started yet)
-          { text: 'Can you teach me some savoury dishes?', nextId: 'choose_savoury', requiredFireplaceTutorialComplete: true, hiddenIfAnyDomainStarted: true },
-          { text: 'I want to learn about desserts.', nextId: 'choose_dessert', requiredFireplaceTutorialComplete: true, hiddenIfAnyDomainStarted: true },
-          { text: 'Tell me about baking.', nextId: 'choose_baking', requiredFireplaceTutorialComplete: true, hiddenIfAnyDomainStarted: true },
+          {
+            text: 'Can you teach me some savoury dishes?',
+            nextId: 'choose_savoury',
+            requiredFireplaceTutorialComplete: true,
+            hiddenIfAnyDomainStarted: true,
+          },
+          {
+            text: 'I want to learn about desserts.',
+            nextId: 'choose_dessert',
+            requiredFireplaceTutorialComplete: true,
+            hiddenIfAnyDomainStarted: true,
+          },
+          {
+            text: 'Tell me about baking.',
+            nextId: 'choose_baking',
+            requiredFireplaceTutorialComplete: true,
+            hiddenIfAnyDomainStarted: true,
+          },
 
           // Continue with current domain (shown if domain started but not mastered)
-          { text: 'Continue with savoury cooking.', nextId: 'learn_savoury', requiredDomainStarted: 'savoury', hiddenIfDomainMastered: 'savoury' },
-          { text: 'Continue with desserts.', nextId: 'learn_desserts', requiredDomainStarted: 'dessert', hiddenIfDomainMastered: 'dessert' },
-          { text: 'Continue with baking.', nextId: 'learn_baking', requiredDomainStarted: 'baking', hiddenIfDomainMastered: 'baking' },
+          {
+            text: 'Continue with savoury cooking.',
+            nextId: 'learn_savoury',
+            requiredDomainStarted: 'savoury',
+            hiddenIfDomainMastered: 'savoury',
+          },
+          {
+            text: 'Continue with desserts.',
+            nextId: 'learn_desserts',
+            requiredDomainStarted: 'dessert',
+            hiddenIfDomainMastered: 'dessert',
+          },
+          {
+            text: 'Continue with baking.',
+            nextId: 'learn_baking',
+            requiredDomainStarted: 'baking',
+            hiddenIfDomainMastered: 'baking',
+          },
 
           // Start new domain (shown if a different domain is mastered, allowing player to start another)
-          { text: 'Teach me about savoury dishes.', nextId: 'choose_savoury', hiddenIfDomainStarted: 'savoury', requiredDomainMastered: 'dessert' },
-          { text: 'Teach me about savoury dishes.', nextId: 'choose_savoury', hiddenIfDomainStarted: 'savoury', requiredDomainMastered: 'baking' },
-          { text: 'Teach me about desserts.', nextId: 'choose_dessert', hiddenIfDomainStarted: 'dessert', requiredDomainMastered: 'savoury' },
-          { text: 'Teach me about desserts.', nextId: 'choose_dessert', hiddenIfDomainStarted: 'dessert', requiredDomainMastered: 'baking' },
-          { text: 'Teach me about baking.', nextId: 'choose_baking', hiddenIfDomainStarted: 'baking', requiredDomainMastered: 'savoury' },
-          { text: 'Teach me about baking.', nextId: 'choose_baking', hiddenIfDomainStarted: 'baking', requiredDomainMastered: 'dessert' },
+          {
+            text: 'Teach me about savoury dishes.',
+            nextId: 'choose_savoury',
+            hiddenIfDomainStarted: 'savoury',
+            requiredDomainMastered: 'dessert',
+          },
+          {
+            text: 'Teach me about savoury dishes.',
+            nextId: 'choose_savoury',
+            hiddenIfDomainStarted: 'savoury',
+            requiredDomainMastered: 'baking',
+          },
+          {
+            text: 'Teach me about desserts.',
+            nextId: 'choose_dessert',
+            hiddenIfDomainStarted: 'dessert',
+            requiredDomainMastered: 'savoury',
+          },
+          {
+            text: 'Teach me about desserts.',
+            nextId: 'choose_dessert',
+            hiddenIfDomainStarted: 'dessert',
+            requiredDomainMastered: 'baking',
+          },
+          {
+            text: 'Teach me about baking.',
+            nextId: 'choose_baking',
+            hiddenIfDomainStarted: 'baking',
+            requiredDomainMastered: 'savoury',
+          },
+          {
+            text: 'Teach me about baking.',
+            nextId: 'choose_baking',
+            hiddenIfDomainStarted: 'baking',
+            requiredDomainMastered: 'dessert',
+          },
 
           { text: 'Maybe later.' },
         ],
       },
       {
         id: 'fireplace_intro',
-        text: 'You can make tea right here in this kitchen, using the fireplace! *She points to the crackling fire.* Click on it and give it a try — the ingredients are on the shelf. Tea warms the soul, and it\'s the perfect place to start.',
+        text: "You can make tea right here in this kitchen, using the fireplace! *She points to the crackling fire.* Click on it and give it a try — the ingredients are on the shelf. Tea warms the soul, and it's the perfect place to start.",
         expression: 'happy',
         responses: [],
       },
@@ -168,7 +267,7 @@ export function createMumNPC(
       },
       {
         id: 'choose_dessert',
-        text: 'Desserts are my favourite! Sweet treats that bring joy to everyone. But remember, love - once you choose desserts, you must master all three recipes before moving to other areas. It\'s important to finish what you start. Are you ready to commit to learning desserts?',
+        text: "Desserts are my favourite! Sweet treats that bring joy to everyone. But remember, love - once you choose desserts, you must master all three recipes before moving to other areas. It's important to finish what you start. Are you ready to commit to learning desserts?",
         expression: 'happy',
         responses: [
           { text: 'Yes, I want to learn desserts!', nextId: 'learn_desserts' },
@@ -188,26 +287,78 @@ export function createMumNPC(
         id: 'learn_savoury',
         text: 'Savoury dishes are hearty and satisfying. What would you like to learn?',
         responses: [
-          { text: 'Spaghetti with meat sauce.', nextId: 'learn_spaghetti', hiddenIfRecipeUnlocked: 'spaghetti_meat_sauce' },
-          { text: 'Pizza with potatoes.', nextId: 'learn_potato_pizza', hiddenIfRecipeUnlocked: 'potato_pizza' },
-          { text: 'Roast dinner.', nextId: 'learn_roast_dinner', requiredRecipeMastered: 'spaghetti_meat_sauce', hiddenIfRecipeUnlocked: 'roast_dinner' },
-          { text: 'Roast dinner.', nextId: 'not_ready_roast_dinner', hiddenIfRecipeMastered: 'spaghetti_meat_sauce' },
-          { text: "I've already learned all your recipes...", nextId: 'domain_mastery_needed', requiredAllDomainRecipesUnlocked: 'savoury', hiddenIfDomainMastered: 'savoury' },
+          {
+            text: 'Spaghetti with meat sauce.',
+            nextId: 'learn_spaghetti',
+            hiddenIfRecipeUnlocked: 'spaghetti_meat_sauce',
+          },
+          {
+            text: 'Pizza with potatoes.',
+            nextId: 'learn_potato_pizza',
+            hiddenIfRecipeUnlocked: 'potato_pizza',
+          },
+          {
+            text: 'Roast dinner.',
+            nextId: 'learn_roast_dinner',
+            requiredRecipeMastered: 'spaghetti_meat_sauce',
+            hiddenIfRecipeUnlocked: 'roast_dinner',
+          },
+          {
+            text: 'Roast dinner.',
+            nextId: 'not_ready_roast_dinner',
+            hiddenIfRecipeMastered: 'spaghetti_meat_sauce',
+          },
+          {
+            text: "I've already learned all your recipes...",
+            nextId: 'domain_mastery_needed',
+            requiredAllDomainRecipesUnlocked: 'savoury',
+            hiddenIfDomainMastered: 'savoury',
+          },
           { text: 'Not right now.' },
         ],
       },
-      { id: 'learn_spaghetti', text: 'Spaghetti with meat sauce - a family favourite! You\'ll need pasta, tomatoes, beef mince, and some herbs. I\'ll add it to your recipe book.', responses: [] },
-      { id: 'learn_potato_pizza', text: 'Pizza with potatoes is a rustic treat! Flour for the base, potatoes, cheese, and a bit of olive oil. Delicious!', responses: [] },
-      { id: 'learn_roast_dinner', text: 'A proper Sunday roast! Meat, potatoes, carrots, and broccoli - all the trimmings. I\'ll show you how.', responses: [] },
+      {
+        id: 'learn_spaghetti',
+        text: "Spaghetti with meat sauce - a family favourite! You'll need pasta, tomatoes, beef mince, and some herbs. I'll add it to your recipe book.",
+        responses: [],
+      },
+      {
+        id: 'learn_potato_pizza',
+        text: 'Pizza with potatoes is a rustic treat! Flour for the base, potatoes, cheese, and a bit of olive oil. Delicious!',
+        responses: [],
+      },
+      {
+        id: 'learn_roast_dinner',
+        text: "A proper Sunday roast! Meat, potatoes, carrots, and broccoli - all the trimmings. I'll show you how.",
+        responses: [],
+      },
       {
         id: 'learn_desserts',
         text: 'Desserts are my speciality! Let me show you something sweet.',
         responses: [
           { text: 'Teach me crêpes!', nextId: 'learn_crepes', hiddenIfRecipeUnlocked: 'crepes' },
-          { text: 'What about marzipan chocolates?', nextId: 'learn_marzipan', hiddenIfRecipeUnlocked: 'marzipan_chocolates' },
-          { text: 'Ice cream sounds lovely!', nextId: 'learn_ice_cream', requiredRecipeMastered: 'crepes', hiddenIfRecipeUnlocked: 'vanilla_ice_cream' },
-          { text: 'Ice cream sounds lovely!', nextId: 'not_ready_ice_cream', hiddenIfRecipeMastered: 'crepes' },
-          { text: "I've already learned all your recipes...", nextId: 'domain_mastery_needed', requiredAllDomainRecipesUnlocked: 'dessert', hiddenIfDomainMastered: 'dessert' },
+          {
+            text: 'What about marzipan chocolates?',
+            nextId: 'learn_marzipan',
+            hiddenIfRecipeUnlocked: 'marzipan_chocolates',
+          },
+          {
+            text: 'Ice cream sounds lovely!',
+            nextId: 'learn_ice_cream',
+            requiredRecipeMastered: 'crepes',
+            hiddenIfRecipeUnlocked: 'vanilla_ice_cream',
+          },
+          {
+            text: 'Ice cream sounds lovely!',
+            nextId: 'not_ready_ice_cream',
+            hiddenIfRecipeMastered: 'crepes',
+          },
+          {
+            text: "I've already learned all your recipes...",
+            nextId: 'domain_mastery_needed',
+            requiredAllDomainRecipesUnlocked: 'dessert',
+            hiddenIfDomainMastered: 'dessert',
+          },
           { text: 'Never mind.' },
         ],
       },
@@ -216,24 +367,82 @@ export function createMumNPC(
         text: 'Baking is wonderful! The smell of fresh bread fills the whole house. What would you like to learn?',
         responses: [
           { text: 'How to make bread.', nextId: 'learn_bread', hiddenIfRecipeUnlocked: 'bread' },
-          { text: 'Chocolate cookies, please!', nextId: 'learn_biscuits', hiddenIfRecipeUnlocked: 'cookies' },
-          { text: 'Chocolate cake!', nextId: 'learn_chocolate_cake', requiredRecipeMastered: 'cookies', hiddenIfRecipeUnlocked: 'chocolate_cake' },
-          { text: 'Chocolate cake!', nextId: 'not_ready_chocolate_cake', hiddenIfRecipeMastered: 'cookies' },
-          { text: "I've already learned all your recipes...", nextId: 'domain_mastery_needed', requiredAllDomainRecipesUnlocked: 'baking', hiddenIfDomainMastered: 'baking' },
+          {
+            text: 'Chocolate cookies, please!',
+            nextId: 'learn_biscuits',
+            hiddenIfRecipeUnlocked: 'cookies',
+          },
+          {
+            text: 'Chocolate cake!',
+            nextId: 'learn_chocolate_cake',
+            requiredRecipeMastered: 'cookies',
+            hiddenIfRecipeUnlocked: 'chocolate_cake',
+          },
+          {
+            text: 'Chocolate cake!',
+            nextId: 'not_ready_chocolate_cake',
+            hiddenIfRecipeMastered: 'cookies',
+          },
+          {
+            text: "I've already learned all your recipes...",
+            nextId: 'domain_mastery_needed',
+            requiredAllDomainRecipesUnlocked: 'baking',
+            hiddenIfDomainMastered: 'baking',
+          },
           { text: 'Not right now.' },
         ],
       },
-      { id: 'learn_crepes', text: 'Crêpes with strawberry jam - delightful! They\'re thin and delicate. I\'ll write down the recipe for you.', responses: [] },
-      { id: 'learn_marzipan', text: 'Marzipan chocolates are a bit tricky, but so rewarding! You\'ll need almonds, sugar, and good dark chocolate. Here\'s the recipe.', responses: [] },
-      { id: 'learn_ice_cream', text: 'Homemade vanilla ice cream - nothing beats it! You\'ll need cream, sugar, vanilla, and patience. I\'ll add it to your book.', expression: 'smile', responses: [] },
-      { id: 'learn_bread', text: 'Bread is the foundation of cooking! The secret is a good sourdough starter - here, take some of mine. Keep it fed and it\'ll last you forever. I\'ll write down the recipe for you.', responses: [] },
-      { id: 'learn_biscuits', text: 'Chocolate cookies are perfect with a cup of tea! Butter, flour, cocoa powder, and chocolate chips - they bake up lovely and rich. Here\'s the recipe.', responses: [] },
-      { id: 'learn_chocolate_cake', text: 'Chocolate cake! Everyone\'s favourite. Rich, moist, and absolutely delicious. I\'ll show you how to make it.', responses: [] },
+      {
+        id: 'learn_crepes',
+        text: "Crêpes with strawberry jam - delightful! They're thin and delicate. I'll write down the recipe for you.",
+        responses: [],
+      },
+      {
+        id: 'learn_marzipan',
+        text: "Marzipan chocolates are a bit tricky, but so rewarding! You'll need almonds, sugar, and good dark chocolate. Here's the recipe.",
+        responses: [],
+      },
+      {
+        id: 'learn_ice_cream',
+        text: "Homemade vanilla ice cream - nothing beats it! You'll need cream, sugar, vanilla, and patience. I'll add it to your book.",
+        expression: 'smile',
+        responses: [],
+      },
+      {
+        id: 'learn_bread',
+        text: "Bread is the foundation of cooking! The secret is a good sourdough starter - here, take some of mine. Keep it fed and it'll last you forever. I'll write down the recipe for you.",
+        responses: [],
+      },
+      {
+        id: 'learn_biscuits',
+        text: "Chocolate cookies are perfect with a cup of tea! Butter, flour, cocoa powder, and chocolate chips - they bake up lovely and rich. Here's the recipe.",
+        responses: [],
+      },
+      {
+        id: 'learn_chocolate_cake',
+        text: "Chocolate cake! Everyone's favourite. Rich, moist, and absolutely delicious. I'll show you how to make it.",
+        responses: [],
+      },
 
       // Not ready dialogues for recipes with prerequisites
-      { id: 'not_ready_chocolate_cake', text: 'Chocolate cake is quite advanced, dear. Master the chocolate cookies recipe first - once you\'ve got the hang of basic baking, then we can tackle the cake. Practice makes perfect!', expression: 'default', responses: [] },
-      { id: 'not_ready_ice_cream', text: 'Ice cream is tricky, love. Show me you\'ve mastered crêpes first, then I\'ll teach you the secrets of making perfect ice cream.', expression: 'default', responses: [] },
-      { id: 'not_ready_roast_dinner', text: 'A roast dinner is quite a challenge! Master the spaghetti recipe first, dear, then we\'ll work our way up to a proper Sunday roast.', expression: 'default', responses: [] },
+      {
+        id: 'not_ready_chocolate_cake',
+        text: "Chocolate cake is quite advanced, dear. Master the chocolate cookies recipe first - once you've got the hang of basic baking, then we can tackle the cake. Practice makes perfect!",
+        expression: 'default',
+        responses: [],
+      },
+      {
+        id: 'not_ready_ice_cream',
+        text: "Ice cream is tricky, love. Show me you've mastered crêpes first, then I'll teach you the secrets of making perfect ice cream.",
+        expression: 'default',
+        responses: [],
+      },
+      {
+        id: 'not_ready_roast_dinner',
+        text: "A roast dinner is quite a challenge! Master the spaghetti recipe first, dear, then we'll work our way up to a proper Sunday roast.",
+        expression: 'default',
+        responses: [],
+      },
 
       {
         id: 'domain_mastery_needed',
@@ -245,7 +454,7 @@ export function createMumNPC(
       // Personal story dialogues
       {
         id: 'about_mum',
-        text: '*She smiles warmly.* About me? Well, my name is Ava, though you\'ve always just called me Mum. Is there something specific you\'d like to know, love?',
+        text: "*She smiles warmly.* About me? Well, my name is Ava, though you've always just called me Mum. Is there something specific you'd like to know, love?",
         expression: 'smile',
         responses: [
           { text: 'What was your life like before the village?', nextId: 'past_life' },
@@ -256,7 +465,7 @@ export function createMumNPC(
       },
       {
         id: 'past_life',
-        text: '*She pauses, a wistful look in her eyes.* When I was a little girl, I lived in a big house far from here. My parents had lots of money, but... they weren\'t happy. When I grew up, I moved to the city and became a chef. I was successful, but it was stressful.',
+        text: "*She pauses, a wistful look in her eyes.* When I was a little girl, I lived in a big house far from here. My parents had lots of money, but... they weren't happy. When I grew up, I moved to the city and became a chef. I was successful, but it was stressful.",
         expression: 'default',
         responses: [
           { text: 'What happened then?', nextId: 'moved_to_village' },
@@ -269,12 +478,12 @@ export function createMumNPC(
         expression: 'happy',
         responses: [
           { text: 'Tell me more about Dad.', nextId: 'about_dad' },
-          { text: 'I\'m glad you\'re happy here.' },
+          { text: "I'm glad you're happy here." },
         ],
       },
       {
         id: 'about_dad',
-        text: '*Her expression becomes tender but tinged with sadness.* Your father, Theo... he\'s an explorer, always off discovering new places. He\'s away travelling for most of the year. I miss him terribly, but I understand his adventurous spirit.',
+        text: "*Her expression becomes tender but tinged with sadness.* Your father, Theo... he's an explorer, always off discovering new places. He's away travelling for most of the year. I miss him terribly, but I understand his adventurous spirit.",
         expression: 'default',
         responses: [
           { text: 'When will he come back?', nextId: 'dad_return' },
@@ -283,21 +492,21 @@ export function createMumNPC(
       },
       {
         id: 'dad_return',
-        text: '*She looks away for a moment.* I... I\'m not sure, love. Theo has his reasons for staying away. Perhaps when you\'re older, I can explain more. For now, just know that he loves you very much.',
+        text: "*She looks away for a moment.* I... I'm not sure, love. Theo has his reasons for staying away. Perhaps when you're older, I can explain more. For now, just know that he loves you very much.",
         expression: 'default',
       },
       {
         id: 'mum_hobbies',
-        text: '*Her eyes light up.* Oh, I love reading! Especially fantasy books - the ones with dragons and magic and brave heroes. There\'s something wonderful about escaping into another world for a while. I\'ve got quite a collection upstairs!',
+        text: "*Her eyes light up.* Oh, I love reading! Especially fantasy books - the ones with dragons and magic and brave heroes. There's something wonderful about escaping into another world for a while. I've got quite a collection upstairs!",
         expression: 'happy',
         responses: [
           { text: 'Any favourites?', nextId: 'favourite_books' },
-          { text: 'That\'s lovely, Mum.' },
+          { text: "That's lovely, Mum." },
         ],
       },
       {
         id: 'favourite_books',
-        text: 'Oh, I couldn\'t possibly choose just one! I love stories about ordinary people who discover they can do extraordinary things. *She chuckles.* Maybe that\'s why I like living here. This village has a certain... magic to it, don\'t you think?',
+        text: "Oh, I couldn't possibly choose just one! I love stories about ordinary people who discover they can do extraordinary things. *She chuckles.* Maybe that's why I like living here. This village has a certain... magic to it, don't you think?",
         expression: 'smile',
       },
 
@@ -306,26 +515,24 @@ export function createMumNPC(
       // -----------------------------------------------------------------------
       {
         id: 'mfp_blanket_ask',
-        text: 'A picnic blanket? Well, there might be one tucked away in the seed shed — the little outbuilding in the common kitchen garden. I warn you though, love, it\'s a dreadful mess in there. You\'d need a good tidy-up before you\'d find anything.',
+        text: "A picnic blanket? Well, there might be one tucked away in the seed shed — the little outbuilding in the common kitchen garden. I warn you though, love, it's a dreadful mess in there. You'd need a good tidy-up before you'd find anything.",
         expression: 'default',
         responses: [
-          { text: 'I\'ll sort it out! Leave it to me.', nextId: 'mfp_blanket_agreed' },
+          { text: "I'll sort it out! Leave it to me.", nextId: 'mfp_blanket_agreed' },
           { text: 'Maybe later.' },
         ],
       },
       {
         id: 'mfp_blanket_agreed',
-        text: 'That\'s the spirit! Thank you, love. You\'re a treasure.',
+        text: "That's the spirit! Thank you, love. You're a treasure.",
         expression: 'happy',
         responses: [],
       },
       {
         id: 'mfp_food_ask',
-        text: '*She claps her hands together.* A picnic! Oh, how perfectly lovely! Of course I\'ll help. Now then — here\'s a wicker basket. Fill it with three different dishes, something for every course. You know how to cook, don\'t you? Come to me if you need to learn a new recipe.',
+        text: "*She claps her hands together.* A picnic! Oh, how perfectly lovely! Of course I'll help. Now then — here's a wicker basket. Fill it with three different dishes, something for every course. You know how to cook, don't you? Come to me if you need to learn a new recipe.",
         expression: 'happy',
-        responses: [
-          { text: 'Thank you, Mum — I\'ll get right to it!', nextId: 'mfp_food_agreed' },
-        ],
+        responses: [{ text: "Thank you, Mum — I'll get right to it!", nextId: 'mfp_food_agreed' }],
       },
       {
         id: 'mfp_food_agreed',
@@ -343,7 +550,7 @@ export function createMumNPC(
       },
       {
         id: 'mfp_post_quest_2',
-        text: '*She puts a hand to her heart.* Oh, how sweet! Those two are perfectly matched, don\'t you think? I do hope something lovely comes of it. You\'re a wonderful matchmaker, love — though I suspect you\'ll deny all credit.',
+        text: "*She puts a hand to her heart.* Oh, how sweet! Those two are perfectly matched, don't you think? I do hope something lovely comes of it. You're a wonderful matchmaker, love — though I suspect you'll deny all credit.",
         expression: 'happy',
         responses: [],
       },

--- a/utils/npcs/village/queenAvaricia.ts
+++ b/utils/npcs/village/queenAvaricia.ts
@@ -20,7 +20,6 @@ import { npcAssets } from '../../../assets';
 import { createStaticNPC } from '../createNPC';
 import {
   isGhostQuestComplete,
-  isGhostQuestStarted,
   GHOST_QUEEN_QUEST_ID,
 } from '../../../data/questHandlers/ghostQueenHandler';
 

--- a/utils/npcs/village/shopkeeper.ts
+++ b/utils/npcs/village/shopkeeper.ts
@@ -6,7 +6,7 @@
 
 import { NPC, Position, EntryAnimation } from '../../../types';
 import { npcAssets } from '../../../assets';
-import { TIMING } from '../../../constants';
+
 import { createStaticNPC } from '../createNPC';
 
 /**
@@ -253,7 +253,7 @@ export function createShopkeeperNPC(
           autumn:
             "*tilts head thoughtfully* Autumn is the finest season for listening. Everyone's in a hurry, everyone has something to say. The harvest gossip alone is worth standing out here for. And the colours — *gestures vaguely at the trees* — well. Even a fox can appreciate that.",
           winter:
-            "*tucks paws together* One must admit winter is somewhat less comfortable. But there is something peaceful about watching snow settle on the square. Very few clouds worth studying, mind you — they all look the same in winter. Grey. Featureless. A disappointment.",
+            '*tucks paws together* One must admit winter is somewhat less comfortable. But there is something peaceful about watching snow settle on the square. Very few clouds worth studying, mind you — they all look the same in winter. Grey. Featureless. A disappointment.',
         },
       },
       {
@@ -264,15 +264,15 @@ export function createShopkeeperNPC(
       // ── Good friend: rotating personal conversations ──────────────────────
       {
         id: 'fox_dreams',
-        text: "*is quiet for a moment, watching the square* If I am honest... what I want, above most things, is for this shop to do well. Not extravagantly — I am not a greedy fox. But enough to mean something. *pauses* And a family, in time. A litter, perhaps. Someone to hand this all on to. I think about it sometimes. Standing here in the evenings, watching the light go off the rooftops. Whether there might be small foxes running about one day. *straightens lapel* It is a simple sort of dream. But it is mine.",
+        text: '*is quiet for a moment, watching the square* If I am honest... what I want, above most things, is for this shop to do well. Not extravagantly — I am not a greedy fox. But enough to mean something. *pauses* And a family, in time. A litter, perhaps. Someone to hand this all on to. I think about it sometimes. Standing here in the evenings, watching the light go off the rooftops. Whether there might be small foxes running about one day. *straightens lapel* It is a simple sort of dream. But it is mine.',
       },
       {
         id: 'fox_city_life',
-        text: "*considers carefully* I did wonder, once, whether I ought to be somewhere larger. A city, perhaps — better opportunities, more customers, all of that. I even went to visit my cousin. Lives in the capital. Very grand. Marble floors. Dining on the finest things. *pause* But everything else came with it too. The noise, the rush, the sense that if you slipped for a moment, someone would simply step over you. *long pause* My cousin seemed perfectly content. But I came home after three days and felt an enormous amount of relief. I rather think this village was waiting for me.",
+        text: '*considers carefully* I did wonder, once, whether I ought to be somewhere larger. A city, perhaps — better opportunities, more customers, all of that. I even went to visit my cousin. Lives in the capital. Very grand. Marble floors. Dining on the finest things. *pause* But everything else came with it too. The noise, the rush, the sense that if you slipped for a moment, someone would simply step over you. *long pause* My cousin seemed perfectly content. But I came home after three days and felt an enormous amount of relief. I rather think this village was waiting for me.',
       },
       {
         id: 'fox_village_wishes',
-        text: "*gazes along the high street* I do wish there were more people here. More life in it. *slight pause* Not that I am unhappy — I love this village, genuinely. But a village this size ought to have a bakery, I think. Proper bread, fresh every morning. A bookshop would not go amiss either. And perhaps — *brightens slightly* — a little café. Somewhere to sit in the afternoon. *wry* I am not talking about competition, you understand. I stock groceries. A café is something else entirely. Just... people. Activity. The sort of place that pulls in travellers who might then wander into a shop.",
+        text: '*gazes along the high street* I do wish there were more people here. More life in it. *slight pause* Not that I am unhappy — I love this village, genuinely. But a village this size ought to have a bakery, I think. Proper bread, fresh every morning. A bookshop would not go amiss either. And perhaps — *brightens slightly* — a little café. Somewhere to sit in the afternoon. *wry* I am not talking about competition, you understand. I stock groceries. A café is something else entirely. Just... people. Activity. The sort of place that pulls in travellers who might then wander into a shop.',
       },
 
       // ── Mr Fox's Picnic Quest ─────────────────────────────────────────────
@@ -299,11 +299,11 @@ export function createShopkeeperNPC(
         text: "*pauses and smooths his lapel* Ah. Well. There is... a matter. Rather a personal one. I wasn't going to mention it, but since you've asked...",
         responses: [
           {
-            text: "You can tell me.",
+            text: 'You can tell me.',
             nextId: 'mfp_explanation',
           },
           {
-            text: "Sorry for prying!",
+            text: 'Sorry for prying!',
           },
         ],
       },
@@ -311,7 +311,7 @@ export function createShopkeeperNPC(
       // The decline path
       {
         id: 'mfp_decline',
-        text: "*straightens up* Quite all right, quite all right. No need to trouble yourself on my account. I shall... manage. Probably.",
+        text: '*straightens up* Quite all right, quite all right. No need to trouble yourself on my account. I shall... manage. Probably.',
         responses: [
           {
             text: "Actually — what's the matter?",
@@ -329,7 +329,7 @@ export function createShopkeeperNPC(
         text: "Well... *clears throat* ...truth be told, I have rather developed a — a — a *fondness* for Miss Periwinkle. The rabbit who visits young Celia. She is — she is quite extraordinary, in my view. Clever, and kind, and she laughs at things I say even when they aren't entirely funny. And I find myself at a complete and utter loss about what to do about it.",
         responses: [
           {
-            text: "You could invite her on a picnic!",
+            text: 'You could invite her on a picnic!',
             nextId: 'mfp_suggestion',
           },
         ],
@@ -341,7 +341,7 @@ export function createShopkeeperNPC(
         text: "*eyes light up* A picnic! Yes! Yes, of course! That is — that is marvellous. A picnic in the meadow, warm afternoon, perhaps some good food... *deflates slightly* Ah. There is one small snag. I don't actually own a picnic blanket.",
         responses: [
           {
-            text: "I could ask my mother if she has one.",
+            text: 'I could ask my mother if she has one.',
             nextId: 'mfp_blanket_offer',
           },
         ],
@@ -363,16 +363,16 @@ export function createShopkeeperNPC(
       // Progress check during the quest (from greeting)
       {
         id: 'mfp_progress_check',
-        text: "*straightens lapel* Yes, well. The picnic situation is very much on my mind. I do appreciate your help.",
+        text: '*straightens lapel* Yes, well. The picnic situation is very much on my mind. I do appreciate your help.',
       },
 
       // Stage 4: Player has the blanket and can give it
       {
         id: 'mfp_give_blanket',
-        text: "Oh! Is that — is that the picnic blanket? *reaches forward, then composes himself* My goodness. You actually found one. Thank you — truly, thank you.",
+        text: 'Oh! Is that — is that the picnic blanket? *reaches forward, then composes himself* My goodness. You actually found one. Thank you — truly, thank you.',
         responses: [
           {
-            text: "It was buried in the seed shed. I had to tidy the whole place up to find it.",
+            text: 'It was buried in the seed shed. I had to tidy the whole place up to find it.',
             nextId: 'mfp_blanket_thanks',
           },
         ],
@@ -380,10 +380,10 @@ export function createShopkeeperNPC(
 
       {
         id: 'mfp_blanket_thanks',
-        text: "*blinks* You tidied the shed? The whole shed? ...Good heavens. I — well. That is really rather above and beyond, and I want you to know I am genuinely, sincerely grateful. *smooths the blanket carefully* This is going to be perfect. Absolutely perfect. Now all I need is — *stops suddenly*",
+        text: '*blinks* You tidied the shed? The whole shed? ...Good heavens. I — well. That is really rather above and beyond, and I want you to know I am genuinely, sincerely grateful. *smooths the blanket carefully* This is going to be perfect. Absolutely perfect. Now all I need is — *stops suddenly*',
         responses: [
           {
-            text: "Is something wrong?",
+            text: 'Is something wrong?',
             nextId: 'mfp_cooking_confession',
           },
         ],
@@ -392,10 +392,10 @@ export function createShopkeeperNPC(
       // Mr Fox admits he cannot cook
       {
         id: 'mfp_cooking_confession',
-        text: "*pauses* ...There is, I confess, one further issue. I cannot cook. At all. I attempted boiled eggs once. They were somehow simultaneously raw and burnt. I do not know how I managed it. *long pause* So the question of what to put IN the picnic basket remains rather open.",
+        text: '*pauses* ...There is, I confess, one further issue. I cannot cook. At all. I attempted boiled eggs once. They were somehow simultaneously raw and burnt. I do not know how I managed it. *long pause* So the question of what to put IN the picnic basket remains rather open.',
         responses: [
           {
-            text: "Perhaps I could ask my mother for help?",
+            text: 'Perhaps I could ask my mother for help?',
             nextId: 'mfp_cooking_agreed',
           },
         ],
@@ -403,7 +403,7 @@ export function createShopkeeperNPC(
 
       {
         id: 'mfp_cooking_agreed',
-        text: "Your mother? *brightens considerably* Oh, now THERE is an idea. She is an excellent cook, from what I understand. If you could prevail upon her — yes, I think that might work rather well.",
+        text: 'Your mother? *brightens considerably* Oh, now THERE is an idea. She is an excellent cook, from what I understand. If you could prevail upon her — yes, I think that might work rather well.',
         responses: [
           {
             text: "I'll ask her.",
@@ -416,7 +416,7 @@ export function createShopkeeperNPC(
       // Stage 8: Player has a full basket and can give it
       {
         id: 'mfp_give_basket',
-        text: "*peers into basket, then looks up with wide eyes* Oh. Oh my. That looks — that looks wonderful. *swallows* Right. I am going to do this. I am going to invite Miss Periwinkle on a picnic. Thank you. Truly.",
+        text: '*peers into basket, then looks up with wide eyes* Oh. Oh my. That looks — that looks wonderful. *swallows* Right. I am going to do this. I am going to invite Miss Periwinkle on a picnic. Thank you. Truly.',
         responses: [
           {
             text: "You've got this, Mr Fox. Go for it!",
@@ -459,7 +459,7 @@ export function createShopkeeperNPC(
 
       {
         id: 'fox_shop_guide',
-        text: "*straightens up with evident satisfaction* I run a well-organised shop. If thou hast ever wondered what precisely I stock and why, this is thy moment. What category interests thee?",
+        text: '*straightens up with evident satisfaction* I run a well-organised shop. If thou hast ever wondered what precisely I stock and why, this is thy moment. What category interests thee?',
         responses: [
           { text: 'Tell me about seeds.', nextId: 'fox_seeds_hub' },
           { text: 'What fresh produce do you carry?', nextId: 'fox_fresh_produce' },
@@ -475,7 +475,7 @@ export function createShopkeeperNPC(
 
       {
         id: 'fox_seeds_hub',
-        text: "Seeds are my most seasonally complex category, so pay attention. I divide them into four groups: spring-only, spring-and-summer, herb seeds, and the autumn varieties. Which wouldst thou like to know about?",
+        text: 'Seeds are my most seasonally complex category, so pay attention. I divide them into four groups: spring-only, spring-and-summer, herb seeds, and the autumn varieties. Which wouldst thou like to know about?',
         responses: [
           { text: 'Spring-only seeds.', nextId: 'fox_seeds_spring' },
           { text: 'Spring and summer seeds.', nextId: 'fox_seeds_summer' },
@@ -487,140 +487,118 @@ export function createShopkeeperNPC(
 
       {
         id: 'fox_seeds_spring',
-        text: "These must go in the ground during spring. Miss the window and thou art waiting a full year — I cannot stress this enough. *ticks off on fingers* Radish at 5 gold — the fastest crop I stock, good for beginners. Potato at 5 gold. Pea at 8. Salad at 7. Spinach at 8. Broccoli at 20. Cauliflower at 25 — I only stock those in spring, naturally. And the two larger investments: melon at 30 gold and pumpkin at 50. Those last two are strictly spring-only. No exceptions.",
+        text: 'These must go in the ground during spring. Miss the window and thou art waiting a full year — I cannot stress this enough. *ticks off on fingers* Radish at 5 gold — the fastest crop I stock, good for beginners. Potato at 5 gold. Pea at 8. Salad at 7. Spinach at 8. Broccoli at 20. Cauliflower at 25 — I only stock those in spring, naturally. And the two larger investments: melon at 30 gold and pumpkin at 50. Those last two are strictly spring-only. No exceptions.',
         seasonalText: {
           spring:
-            "These must go in during spring — and thou art in luck, because it *is* spring. *ticks off on fingers* Radish at 5 gold, potato at 5, pea at 8, salad at 7, spinach at 8, broccoli at 20, cauliflower at 25 — which I only stock this season. Melon at 30 and pumpkin at 50 gold. The pumpkin in particular is worth planning for. Get them in early.",
+            'These must go in during spring — and thou art in luck, because it *is* spring. *ticks off on fingers* Radish at 5 gold, potato at 5, pea at 8, salad at 7, spinach at 8, broccoli at 20, cauliflower at 25 — which I only stock this season. Melon at 30 and pumpkin at 50 gold. The pumpkin in particular is worth planning for. Get them in early.',
           summer:
-            "I am afraid spring-only seeds are no longer available. Pumpkin, melon, cauliflower, broccoli, spinach, salad, pea, and potato all needed to go in during spring. My apologies — this is the risk of late planning.",
+            'I am afraid spring-only seeds are no longer available. Pumpkin, melon, cauliflower, broccoli, spinach, salad, pea, and potato all needed to go in during spring. My apologies — this is the risk of late planning.',
           autumn:
-            "Spring seeds are, by definition, for spring. They are all gone now. If thou art already thinking ahead to next year — which I respect enormously — come back when spring arrives. I keep thorough stock.",
+            'Spring seeds are, by definition, for spring. They are all gone now. If thou art already thinking ahead to next year — which I respect enormously — come back when spring arrives. I keep thorough stock.',
           winter:
-            "Spring seeds will not be available until spring returns. I know that is obvious, but thou wouldst be surprised how often I am asked. Come back in a few months.",
+            'Spring seeds will not be available until spring returns. I know that is obvious, but thou wouldst be surprised how often I am asked. Come back in a few months.',
         },
-        responses: [
-          { text: 'Back to seeds.', nextId: 'fox_seeds_hub' },
-        ],
+        responses: [{ text: 'Back to seeds.', nextId: 'fox_seeds_hub' }],
       },
 
       {
         id: 'fox_seeds_summer',
-        text: "A more forgiving category — these can go in during spring or summer, so there is a second chance if one misses the first sowing. *counts* Tomato seeds at 15 gold — popular, versatile, good for cooking. Cucumber at 10. Corn at 25. Chili at 15 gold. All can be planted in either spring or summer, though earlier planting gives a longer growing season.",
+        text: 'A more forgiving category — these can go in during spring or summer, so there is a second chance if one misses the first sowing. *counts* Tomato seeds at 15 gold — popular, versatile, good for cooking. Cucumber at 10. Corn at 25. Chili at 15 gold. All can be planted in either spring or summer, though earlier planting gives a longer growing season.',
         seasonalText: {
           spring:
-            "Good timing — all four are currently in stock and ready to plant. Tomato at 15, cucumber at 10, corn at 25, chili at 15 gold. If thou art also sowing spring-only crops, do those first and come back for these — they are in no hurry.",
+            'Good timing — all four are currently in stock and ready to plant. Tomato at 15, cucumber at 10, corn at 25, chili at 15 gold. If thou art also sowing spring-only crops, do those first and come back for these — they are in no hurry.',
           summer:
-            "Still available and still plantable! This is precisely why I call them the forgiving group. Tomato at 15, cucumber at 10, corn at 25, chili at 15. Get them in now and thou shouldst have a good harvest before autumn.",
+            'Still available and still plantable! This is precisely why I call them the forgiving group. Tomato at 15, cucumber at 10, corn at 25, chili at 15. Get them in now and thou shouldst have a good harvest before autumn.',
           autumn:
-            "These are spring-and-summer seeds — the planting window is now closed. I still stock them, but planting now would be a wasted investment. They will be back next spring.",
+            'These are spring-and-summer seeds — the planting window is now closed. I still stock them, but planting now would be a wasted investment. They will be back next spring.',
           winter:
-            "Spring and summer seeds will return with the warmer weather. I recommend making a shopping list now while thou art thinking about it.",
+            'Spring and summer seeds will return with the warmer weather. I recommend making a shopping list now while thou art thinking about it.',
         },
-        responses: [
-          { text: 'Back to seeds.', nextId: 'fox_seeds_hub' },
-        ],
+        responses: [{ text: 'Back to seeds.', nextId: 'fox_seeds_hub' }],
       },
 
       {
         id: 'fox_seeds_herbs',
-        text: "Herb seeds are a rewarding category — they regrow after harvest, so one purchase goes a long way. Thyme seeds at 8 gold, lavender at 10, and mint at 10. All three can be planted in spring or summer. *slight pause* I should note I also sell dried thyme and rosemary as spices if thou dost not wish to grow thy own — though growing is considerably cheaper in the long run.",
+        text: 'Herb seeds are a rewarding category — they regrow after harvest, so one purchase goes a long way. Thyme seeds at 8 gold, lavender at 10, and mint at 10. All three can be planted in spring or summer. *slight pause* I should note I also sell dried thyme and rosemary as spices if thou dost not wish to grow thy own — though growing is considerably cheaper in the long run.',
         seasonalText: {
           spring:
-            "All three herb seeds are in and ready: thyme at 8, lavender at 10, mint at 10. Spring is a fine time to establish herbs — they will be producing well by summer.",
+            'All three herb seeds are in and ready: thyme at 8, lavender at 10, mint at 10. Spring is a fine time to establish herbs — they will be producing well by summer.',
           summer:
-            "Still available and plantable: thyme at 8, lavender at 10, mint at 10. Herb plants established in summer will provide harvests through the rest of the season.",
+            'Still available and plantable: thyme at 8, lavender at 10, mint at 10. Herb plants established in summer will provide harvests through the rest of the season.',
           autumn:
-            "Herb seeds are spring and summer plantings only — they are out of season now. The dried herb spices are still available year-round, however, if thou needest thyme or rosemary for cooking.",
+            'Herb seeds are spring and summer plantings only — they are out of season now. The dried herb spices are still available year-round, however, if thou needest thyme or rosemary for cooking.',
           winter:
-            "Herb seeds will return in spring. For cooking herbs this winter, I stock dried thyme, rosemary, and basil in the spice section.",
+            'Herb seeds will return in spring. For cooking herbs this winter, I stock dried thyme, rosemary, and basil in the spice section.',
         },
-        responses: [
-          { text: 'Back to seeds.', nextId: 'fox_seeds_hub' },
-        ],
+        responses: [{ text: 'Back to seeds.', nextId: 'fox_seeds_hub' }],
       },
 
       {
         id: 'fox_seeds_autumn',
-        text: "Two interesting cases. Onion seeds are exclusively an autumn planting at 12 gold — the only crop I know of that categorically refuses any other season. Then there is the carrot at 8 gold: planted in spring, and fresh carrots also come into stock in autumn when they are harvested. They are, in other words, useful across the year.",
+        text: 'Two interesting cases. Onion seeds are exclusively an autumn planting at 12 gold — the only crop I know of that categorically refuses any other season. Then there is the carrot at 8 gold: planted in spring, and fresh carrots also come into stock in autumn when they are harvested. They are, in other words, useful across the year.',
         seasonalText: {
           spring:
-            "Carrot seeds at 8 gold are available now for spring planting. Onion seeds are an autumn-only item — I do not stock them until then. Fresh carrots will be available again in autumn.",
+            'Carrot seeds at 8 gold are available now for spring planting. Onion seeds are an autumn-only item — I do not stock them until then. Fresh carrots will be available again in autumn.',
           summer:
-            "Carrot seeds are a spring crop and are no longer in stock for planting. Onion seeds will not arrive until autumn. Come back then.",
+            'Carrot seeds are a spring crop and are no longer in stock for planting. Onion seeds will not arrive until autumn. Come back then.',
           autumn:
-            "*brightens slightly* Autumn is precisely the right moment for this section. Onion seeds are in — 12 gold — plant them now. And fresh carrots have just arrived in the produce section at 35 gold if thou dost not wish to grow them thyself.",
+            '*brightens slightly* Autumn is precisely the right moment for this section. Onion seeds are in — 12 gold — plant them now. And fresh carrots have just arrived in the produce section at 35 gold if thou dost not wish to grow them thyself.',
           winter:
-            "Onion seeds were an autumn item and are out of stock until next autumn. I find winter is a good time to plan the spring garden — makes the cold months feel purposeful.",
+            'Onion seeds were an autumn item and are out of stock until next autumn. I find winter is a good time to plan the spring garden — makes the cold months feel purposeful.',
         },
-        responses: [
-          { text: 'Back to seeds.', nextId: 'fox_seeds_hub' },
-        ],
+        responses: [{ text: 'Back to seeds.', nextId: 'fox_seeds_hub' }],
       },
 
       {
         id: 'fox_fresh_produce',
-        text: "Fresh produce changes with the seasons — I buy from local farms when things are in harvest. What is available right now depends on the time of year.",
+        text: 'Fresh produce changes with the seasons — I buy from local farms when things are in harvest. What is available right now depends on the time of year.',
         seasonalText: {
           spring:
-            "*counts carefully* Spring produce: fresh strawberries at 45 gold, fresh salad at 35, fresh spinach at 30, and fresh carrots at 35. Strawberry jam also comes in at 25 gold — good if thou dost not wish to cook it thyself. All lovely young growth.",
+            '*counts carefully* Spring produce: fresh strawberries at 45 gold, fresh salad at 35, fresh spinach at 30, and fresh carrots at 35. Strawberry jam also comes in at 25 gold — good if thou dost not wish to cook it thyself. All lovely young growth.',
           summer:
-            "Summer is generous. Strawberries are still coming in at 45 gold, and fresh tomatoes have just started at 12 gold. Salad at 35 and spinach at 30 are still excellent. Strawberry jam remains at 25 gold. And I have sunflower bouquets this season only — 80 gold, a real statement piece.",
+            'Summer is generous. Strawberries are still coming in at 45 gold, and fresh tomatoes have just started at 12 gold. Salad at 35 and spinach at 30 are still excellent. Strawberry jam remains at 25 gold. And I have sunflower bouquets this season only — 80 gold, a real statement piece.',
           autumn:
-            "*raises a finger* Blackberries are in at 50 gold — and this is the only time of year thou wilt find them. Do not dawdle. Fresh tomatoes are still going at 12 gold, and carrots are back at 35 gold. Strawberry jam holds on through autumn at 25 gold. The salad and spinach are finished for the year, I am afraid.",
+            '*raises a finger* Blackberries are in at 50 gold — and this is the only time of year thou wilt find them. Do not dawdle. Fresh tomatoes are still going at 12 gold, and carrots are back at 35 gold. Strawberry jam holds on through autumn at 25 gold. The salad and spinach are finished for the year, I am afraid.',
           winter:
-            "*folds paws* Fresh produce is done for the year. Winter is a pantry season — everything I stock now is shelf-stable. The fresh crops will return with spring. In the meantime, I have tinned tomatoes in the pantry section, which are a reasonable substitute for certain recipes.",
+            '*folds paws* Fresh produce is done for the year. Winter is a pantry season — everything I stock now is shelf-stable. The fresh crops will return with spring. In the meantime, I have tinned tomatoes in the pantry section, which are a reasonable substitute for certain recipes.',
         },
-        responses: [
-          { text: 'Back to categories.', nextId: 'fox_shop_guide' },
-        ],
+        responses: [{ text: 'Back to categories.', nextId: 'fox_shop_guide' }],
       },
 
       {
         id: 'fox_pantry',
-        text: "*with calm authority* Pantry staples are available year-round, no exceptions. Flour at 6 gold. Whole grain wheat at 5. Sugar at 8. Salt at 3 — the cheapest item in the shop, and I will not apologise for that. Yeast at 5 gold. Rice at 8. Pasta at 10. Bread at 12 gold, delivered regularly. Tinned tomatoes at 10 gold — useful all winter. Vinegar at 8. And water at 1 gold, which I include for completeness, though I have always felt slightly embarrassed charging for it.",
-        responses: [
-          { text: 'Back to categories.', nextId: 'fox_shop_guide' },
-        ],
+        text: '*with calm authority* Pantry staples are available year-round, no exceptions. Flour at 6 gold. Whole grain wheat at 5. Sugar at 8. Salt at 3 — the cheapest item in the shop, and I will not apologise for that. Yeast at 5 gold. Rice at 8. Pasta at 10. Bread at 12 gold, delivered regularly. Tinned tomatoes at 10 gold — useful all winter. Vinegar at 8. And water at 1 gold, which I include for completeness, though I have always felt slightly embarrassed charging for it.',
+        responses: [{ text: 'Back to categories.', nextId: 'fox_shop_guide' }],
       },
 
       {
         id: 'fox_dairy',
-        text: "*gestures to the chilled section* Dairy is a reliable year-round category. Milk at 8 gold — the most versatile thing I stock. Cream at 12. Butter at 10. Buttermilk at 12 — essential for certain bakes. Cheese at 20 gold. Eggs at 5 gold, which I would buy in bulk if I were thee. *slight pause* I also stock almonds at 15 gold here — not dairy, technically, but they group well with the baking ingredients.",
-        responses: [
-          { text: 'Back to categories.', nextId: 'fox_shop_guide' },
-        ],
+        text: '*gestures to the chilled section* Dairy is a reliable year-round category. Milk at 8 gold — the most versatile thing I stock. Cream at 12. Butter at 10. Buttermilk at 12 — essential for certain bakes. Cheese at 20 gold. Eggs at 5 gold, which I would buy in bulk if I were thee. *slight pause* I also stock almonds at 15 gold here — not dairy, technically, but they group well with the baking ingredients.',
+        responses: [{ text: 'Back to categories.', nextId: 'fox_shop_guide' }],
       },
 
       {
         id: 'fox_spices',
-        text: "*with quiet enthusiasm* Spices and herbs are a section I take particular interest in. Basil at 10 gold. Dried thyme at 8 — also available as a living herb seed, as I mentioned. Rosemary at 10 gold, likewise. Allspice at 12. Curry powder at 15 — a blend I source specifically. Black pepper at 8, which I would recommend keeping permanently stocked. Cinnamon at 15. *shifts to the oils* Olive oil at 15 gold and sunflower oil at 12. I consider oils to be liquid spices. Others may disagree.",
-        responses: [
-          { text: 'Back to categories.', nextId: 'fox_shop_guide' },
-        ],
+        text: '*with quiet enthusiasm* Spices and herbs are a section I take particular interest in. Basil at 10 gold. Dried thyme at 8 — also available as a living herb seed, as I mentioned. Rosemary at 10 gold, likewise. Allspice at 12. Curry powder at 15 — a blend I source specifically. Black pepper at 8, which I would recommend keeping permanently stocked. Cinnamon at 15. *shifts to the oils* Olive oil at 15 gold and sunflower oil at 12. I consider oils to be liquid spices. Others may disagree.',
+        responses: [{ text: 'Back to categories.', nextId: 'fox_shop_guide' }],
       },
 
       {
         id: 'fox_proteins',
-        text: "*matter-of-factly* The protein section. Meat at 35 gold — good quality, general purpose. Minced meat at 30, for those who prefer it prepared. Tinned tuna at 15 gold — shelf-stable and underrated. And gravy at 8 gold, which I classify as a protein accompaniment. *brief pause* I am aware that as a fox there is a certain irony in my stocking meat products. I prefer not to dwell on it.",
-        responses: [
-          { text: 'Back to categories.', nextId: 'fox_shop_guide' },
-        ],
+        text: '*matter-of-factly* The protein section. Meat at 35 gold — good quality, general purpose. Minced meat at 30, for those who prefer it prepared. Tinned tuna at 15 gold — shelf-stable and underrated. And gravy at 8 gold, which I classify as a protein accompaniment. *brief pause* I am aware that as a fox there is a certain irony in my stocking meat products. I prefer not to dwell on it.',
+        responses: [{ text: 'Back to categories.', nextId: 'fox_shop_guide' }],
       },
 
       {
         id: 'fox_tools',
-        text: "*taps counter decisively* Tools. The hoe at 50 gold — tills soil for planting, essential for farming. The watering can at 75 gold — crops must be watered each day or they wilt. *slight pause* The watering can is, I suspect, the item most purchased twice: once by enthusiastic beginners who lose it in the shed, and again when they find it. Fertiliser at 15 gold — applied to tilled soil before planting, it accelerates crop growth considerably. Worth the investment if thou art in a hurry.",
-        responses: [
-          { text: 'Back to categories.', nextId: 'fox_shop_guide' },
-        ],
+        text: '*taps counter decisively* Tools. The hoe at 50 gold — tills soil for planting, essential for farming. The watering can at 75 gold — crops must be watered each day or they wilt. *slight pause* The watering can is, I suspect, the item most purchased twice: once by enthusiastic beginners who lose it in the shed, and again when they find it. Fertiliser at 15 gold — applied to tilled soil before planting, it accelerates crop growth considerably. Worth the investment if thou art in a hurry.',
+        responses: [{ text: 'Back to categories.', nextId: 'fox_shop_guide' }],
       },
 
       {
         id: 'fox_specials',
         text: "*with something approaching enthusiasm* Several items that deserve individual mention. For baking: chocolate at 25 gold, vanilla at 20 — essential, do not substitute — cocoa powder at 18, and baking powder at 7. *shifts to another section* For decoration and crafting: linen at 15 gold, wooden frames at 20, ceramic vases at 25, plant pots at 15. The camera at 180 gold is a significant investment, but remarkable for documenting one's travels. *leans forward slightly* And I stock sunflower bouquets at 80 gold — but only in summer. One cannot rush flowers.",
-        responses: [
-          { text: 'Back to categories.', nextId: 'fox_shop_guide' },
-        ],
+        responses: [{ text: 'Back to categories.', nextId: 'fox_shop_guide' }],
       },
     ],
     friendshipConfig: {

--- a/utils/pathfinding.ts
+++ b/utils/pathfinding.ts
@@ -6,7 +6,7 @@
  */
 
 import { Position, NPC, isTileSolid } from '../types';
-import { PLAYER_SIZE } from '../constants';
+
 import { metadataCache } from './MetadataCache';
 import { getTileData, getTileCoords } from './mapUtils';
 import { mapManager } from '../maps';

--- a/utils/pixi/BackgroundImageLayer.ts
+++ b/utils/pixi/BackgroundImageLayer.ts
@@ -83,7 +83,8 @@ export class BackgroundImageLayer {
     wallpaperId: string;
   }> = [];
   // Time-conditioned sprites (e.g. day/sunset/night backgrounds) tracked for periodic re-check
-  private timeLayerEntries: Array<{ sprite: PIXI.Sprite; showWhen: 'day' | 'sunset' | 'night' }> = [];
+  private timeLayerEntries: Array<{ sprite: PIXI.Sprite; showWhen: 'day' | 'sunset' | 'night' }> =
+    [];
   // Interval polling the game clock to toggle timeLayerEntries visibility, cleared in dispose()
   private timeCheckIntervalId: ReturnType<typeof setInterval> | null = null;
   // Unsubscribe functions for this instance's EventBus listeners, released in dispose()
@@ -141,7 +142,10 @@ export class BackgroundImageLayer {
 
     // Periodically re-check day/night layer visibility against the game clock.
     // Nothing emits a regular "clock ticked" event, so this owns its own poll.
-    this.timeCheckIntervalId = setInterval(() => this.updateTimeLayers(), TIMING.TIME_LAYER_CHECK_MS);
+    this.timeCheckIntervalId = setInterval(
+      () => this.updateTimeLayers(),
+      TIMING.TIME_LAYER_CHECK_MS
+    );
   }
 
   /**
@@ -179,10 +183,7 @@ export class BackgroundImageLayer {
    * Screen position of a centered layer of the given scaled size: centred in the
    * viewport, then panned. One place, so every caller agrees.
    */
-  private centeredPosition(
-    scaledWidth: number,
-    scaledHeight: number
-  ): { x: number; y: number } {
+  private centeredPosition(scaledWidth: number, scaledHeight: number): { x: number; y: number } {
     const viewportWidth = this.scalingConfig?.viewportWidth ?? window.innerWidth;
     const viewportHeight = this.scalingConfig?.viewportHeight ?? window.innerHeight;
     return {
@@ -246,12 +247,13 @@ export class BackgroundImageLayer {
    *
    * @param map - The map definition
    * @param mapId - The map ID
-   * @param skipForeground - If true, skip foreground layers (render them as DOM instead)
+   * @param _skipForeground - Ignored; retained for call compatibility. Foreground layers
+   *   always load here and render as DOM for proper NPC z-ordering.
    */
   async loadLayers(
     map: MapDefinition,
     mapId: string,
-    skipForeground: boolean = true // Default to true - foreground layers render as DOM for proper NPC z-ordering
+    _skipForeground: boolean = true
   ): Promise<void> {
     // Skip if already loaded for this map
     if (this.currentMapId === mapId && this.backgroundSprites.length > 0) {

--- a/utils/pixi/TileLayer.ts
+++ b/utils/pixi/TileLayer.ts
@@ -93,7 +93,7 @@ export const CROP_ADULT_SIZES: Record<
 
   // Herbs (1.2x1.2 tile) - slightly oversized for a lush look
   thyme: { width: 1.2, height: 1.2, offsetX: -0.1, offsetY: -0.125 },
-  lavender: { width: 1.8, height: 1.8, offsetX: -0.4, offsetY: -0.650 },
+  lavender: { width: 1.8, height: 1.8, offsetX: -0.4, offsetY: -0.65 },
   mint: { width: 1.4, height: 1.4, offsetX: -0.2, offsetY: -0.3 },
 
   // Small crops (1x1 tile) - centred on soil tile
@@ -408,7 +408,7 @@ export class TileLayer extends PixiLayer {
             const winterKey = `plant_${cropType}_winter`;
             const adultKey = `plant_${cropType}_adult`;
             imageUrl =
-              (isHerbDormant && (farmingAssets as any)[winterKey])
+              isHerbDormant && (farmingAssets as any)[winterKey]
                 ? (farmingAssets as any)[winterKey]
                 : (farmingAssets as any)[adultKey] || farmingAssets.seedling;
           }
@@ -433,7 +433,7 @@ export class TileLayer extends PixiLayer {
     const soilKey = `${x},${y}_soil`;
     const needsSoilBg = growthStage !== null && cropType && !hideSpriteDuringSnow;
     const soilImageUrl = needsSoilBg
-      ? (tileData.type === TileType.SOIL_WATERED || tileData.type === TileType.SOIL_READY)
+      ? tileData.type === TileType.SOIL_WATERED || tileData.type === TileType.SOIL_READY
         ? farmingAssets.tilled_wet
         : farmingAssets.tilled
       : null;
@@ -978,7 +978,7 @@ export class TileLayer extends PixiLayer {
    * Only supports palette colors: 'bg-palette-sage' → '#87AE73'
    * Results are cached for performance
    */
-  private getHexFromTailwind(colorClass: string, map: MapDefinition): number {
+  private getHexFromTailwind(colorClass: string, _map: MapDefinition): number {
     // Check cache first
     const cached = TileLayer.hexColorCache.get(colorClass);
     if (cached !== undefined) {

--- a/utils/placeholderSprites.ts
+++ b/utils/placeholderSprites.ts
@@ -142,7 +142,7 @@ function generateSVGSprite(
   return `data:image/svg+xml,${encoded}`;
 }
 
-function getHairPath(hairStyle: string, direction: Direction): string {
+function getHairPath(hairStyle: string, _direction: Direction): string {
   // Simple hair shapes - can be enhanced later
   switch (hairStyle) {
     case 'short':

--- a/utils/testUtils.ts
+++ b/utils/testUtils.ts
@@ -3,7 +3,7 @@
 // FIX: Added and exported the 'runSelfTests' function to resolve the import error in App.tsx.
 // This function performs basic sanity checks as suggested by its usage context.
 import { TILE_LEGEND, MAP_DATA, MAP_WIDTH, MAP_HEIGHT } from '../constants';
-import { TileType, Direction, isTileSolid } from '../types';
+import { TileType, isTileSolid } from '../types';
 import { mapManager } from '../maps';
 import { COLOR_SCHEMES } from '../maps/colorSchemes';
 import { GRID_CODES, parseGrid, gridToString } from '../maps/gridParser';
@@ -261,7 +261,7 @@ function validateSpawnPoints(): void {
     }
 
     // Validate transition spawn points (require safe spawn tiles)
-    const transitionTests = map.transitions.map((t, idx) => ({
+    const transitionTests = map.transitions.map((t) => ({
       label: `${mapId} → ${t.label || t.toMapId} (${t.toPosition.x}, ${t.toPosition.y})`,
       position: t.toPosition,
     }));
@@ -367,45 +367,41 @@ function validateFarmSystem(): void {
  */
 function validateInventorySystem(): void {
   // Dynamic import to avoid circular dependencies
-  import('../data/items').then(
-    ({ ITEMS, getItem, getSeedForCrop, getCropItemId, getSeedItemId }) => {
-      import('../data/crops').then(({ CROPS }) => {
-        // Validate that all crops have corresponding seed and crop items
-        for (const cropId of Object.keys(CROPS)) {
-          const seedItem = getSeedForCrop(cropId);
-          if (!seedItem) {
-            console.error(`[Sanity Check] Crop "${cropId}" has no corresponding seed item`);
-          }
-
-          // Skip crop item check for decorative crops (harvestYield: 0)
-          const cropDef = CROPS[cropId];
-          if (cropDef.harvestYield > 0) {
-            const cropItemId = getCropItemId(cropId);
-            const cropItem = getItem(cropItemId);
-            if (!cropItem) {
-              console.error(
-                `[Sanity Check] Crop "${cropId}" has no corresponding crop item (expected "${cropItemId}")`
-              );
-            }
-          }
+  import('../data/items').then(({ ITEMS, getItem, getSeedForCrop, getCropItemId }) => {
+    import('../data/crops').then(({ CROPS }) => {
+      // Validate that all crops have corresponding seed and crop items
+      for (const cropId of Object.keys(CROPS)) {
+        const seedItem = getSeedForCrop(cropId);
+        if (!seedItem) {
+          console.error(`[Sanity Check] Crop "${cropId}" has no corresponding seed item`);
         }
 
-        // Validate that all seed items reference valid crops
-        for (const [itemId, item] of Object.entries(ITEMS)) {
-          if (item.category === 'seed' && item.cropId) {
-            const crop = CROPS[item.cropId];
-            if (!crop) {
-              console.error(
-                `[Sanity Check] Seed item "${itemId}" references non-existent crop "${item.cropId}"`
-              );
-            }
+        // Skip crop item check for decorative crops (harvestYield: 0)
+        const cropDef = CROPS[cropId];
+        if (cropDef.harvestYield > 0) {
+          const cropItemId = getCropItemId(cropId);
+          const cropItem = getItem(cropItemId);
+          if (!cropItem) {
+            console.error(
+              `[Sanity Check] Crop "${cropId}" has no corresponding crop item (expected "${cropItemId}")`
+            );
           }
         }
+      }
 
-        console.log(
-          `[Sanity Check] Inventory system: ${Object.keys(ITEMS).length} items validated`
-        );
-      });
-    }
-  );
+      // Validate that all seed items reference valid crops
+      for (const [itemId, item] of Object.entries(ITEMS)) {
+        if (item.category === 'seed' && item.cropId) {
+          const crop = CROPS[item.cropId];
+          if (!crop) {
+            console.error(
+              `[Sanity Check] Seed item "${itemId}" references non-existent crop "${item.cropId}"`
+            );
+          }
+        }
+      }
+
+      console.log(`[Sanity Check] Inventory system: ${Object.keys(ITEMS).length} items validated`);
+    });
+  });
 }


### PR DESCRIPTION
Sweeps all 174 `no-unused-vars` warnings to zero, so lint output becomes signal instead of noise.

## What was cleaned

**Unused imports (48 files)** — removed via a small AST codemod driven by the eslint JSON, verified by `tsc`. Includes over-broad imports (e.g. `queenAvaricia` importing `isGhostQuestStarted` it never used).

**Dead locals** — each investigated before deletion; nothing here was a live feature:
- `ShopUI`: the abandoned HTML5 drag-and-drop path (`handleDragOver`/`handleDrop` + `dragState` state + `DragState` interface) — superseded by the left-click-trades-one / right-click-opens-slider UX the surviving comments document
- Map-transition `seed` extraction in `actionHandlers`/`transition.ts` — computed but never returned; the seed is already encoded in `map.id`
- `sharedDataService`: unused `MAX_SUMMARIES_PER_NPC`/`MAX_EVENTS` fetch limits, unused `recentSummary`
- `MagicEffects.getAllVFXTypes`: empty `forEach` + dead `vfxTypes` Set (the manual list below it was always the real implementation)
- Computed-but-never-rendered values: `CookingInterface`'s `canCook`/`missingIngredients`, `PlacedItems`' `decayProgress`, `PotionContent`'s `canBrew`, `Inventory`'s unfiltered `displaySlots` (the filtered twin is live), `DebugOverlay`'s `isClicked` (the highlight renders from `clickedTile` in its own element)
- Unused constants: `crops.ts` `DAY`/`GAME_HOUR`, `NPCInteractionIndicators` `TOOLTIP_DISTANCE`, orphaned `stubInitializeFirebase`, dead `formatNPCName`

**Unused arguments** — removed where no caller passes them (`transitionToMap`'s `fromMapId`, `renderVersion`, `npcUpdateTrigger`, `lastTransitionTime`, `mapWidth`, Bookshelf/CookingInterface prop bindings, react-markdown `node` params in HelpBrowser); `_`-prefixed where signatures must stay (test mocks, `cook`'s `campfireBonus`, `getHexFromTailwind`'s `map`).

## Two behaviours now documented instead of silently ignored

- `BackgroundImageLayer.loadLayers`' `skipForeground` never affected the body — foreground layers always load. Doc updated; signature kept (two callers pass `false`).
- `FriendshipManager.giveGift`'s `npc` argument is ignored (GiftModal passes it). Renamed `_npc`.

## Verification

- `npm run verify`: tsc clean, **866/866 tests pass**
- eslint: **0 unused-var warnings** (was 174); total warnings 277 → 103 (remaining: `no-explicit-any` 60, `exhaustive-deps` 40, 3 unused eslint-disable directives — tracked separately)