### PR TITLE
Name the shop trade flow honestly; drop three stale lint directives

### DIFF
--- a/components/ShopUI.tsx
+++ b/components/ShopUI.tsx
@@ -113,7 +113,7 @@ const ShopUI: React.FC<ShopUIProps> = ({
   const [shopFilter, setShopFilter] = useState<ShopFilter>('all');
   const [playerFilter, setPlayerFilter] = useState<ShopFilter>('all');
   const [selectedQuantity, setSelectedQuantity] = useState<number>(1);
-  const [showQuantitySlider, setShowQuantitySlider] = useState<boolean>(false);
+  const [showQuantityStepper, setShowQuantityStepper] = useState<boolean>(false);
   const [pendingTransaction, setPendingTransaction] = useState<{
     itemId: string;
     fromShop: boolean;
@@ -161,19 +161,19 @@ const ShopUI: React.FC<ShopUIProps> = ({
   const currentTime = TimeManager.getCurrentTime();
 
   /**
-   * Handle drag start (from shop or player inventory)
+   * Start a trade: single items execute immediately; multi-item stacks open the stepper.
    */
-  const handleDragStart = (itemId: string, fromShop: boolean, maxQuantity: number) => {
+  const initiateTrade = (itemId: string, fromShop: boolean, maxQuantity: number) => {
     // If only 1 item, execute immediately
     if (maxQuantity === 1) {
       executeTransaction(itemId, 1, fromShop);
       return;
     }
 
-    // Show quantity slider for multi-item stacks
+    // Open the quantity stepper for multi-item stacks
     setPendingTransaction({ itemId, fromShop, maxQuantity });
     setSelectedQuantity(1);
-    setShowQuantitySlider(true);
+    setShowQuantityStepper(true);
   };
 
   /**
@@ -192,7 +192,7 @@ const ShopUI: React.FC<ShopUIProps> = ({
   /** Right-click / long-press a slot: choose how many. */
   const handleSlotContextMenu = (itemId: string, fromShop: boolean, maxQuantity: number) => {
     if (maxQuantity < 1) return;
-    handleDragStart(itemId, fromShop, maxQuantity);
+    initiateTrade(itemId, fromShop, maxQuantity);
   };
 
   /**
@@ -240,7 +240,7 @@ const ShopUI: React.FC<ShopUIProps> = ({
       }
     }
 
-    setShowQuantitySlider(false);
+    setShowQuantityStepper(false);
     setPendingTransaction(null);
   };
 
@@ -257,7 +257,7 @@ const ShopUI: React.FC<ShopUIProps> = ({
    * Cancel quantity selection
    */
   const cancelQuantity = () => {
-    setShowQuantitySlider(false);
+    setShowQuantityStepper(false);
     setPendingTransaction(null);
     setSelectedQuantity(1);
   };
@@ -631,8 +631,8 @@ const ShopUI: React.FC<ShopUIProps> = ({
         </div>
       </div>
 
-      {/* Quantity Slider Modal */}
-      {showQuantitySlider && pendingTransaction && (
+      {/* Quantity Stepper Modal */}
+      {showQuantityStepper && pendingTransaction && (
         <div
           className={`fixed inset-0 bg-black/90 flex items-center justify-center ${zClass(Z_SHOP_CONFIRM)} pointer-events-auto`}
         >

--- a/components/book/JournalContent.tsx
+++ b/components/book/JournalContent.tsx
@@ -78,7 +78,6 @@ const JournalContent: React.FC<JournalContentProps> = ({ theme }) => {
   const [diaryRefreshKey, setDiaryRefreshKey] = useState(0);
 
   // Build journal entries for each chapter
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const entriesByChapter = useMemo(() => {
     // Active quests
     const activeQuests: JournalEntry[] = eventChainManager.getActiveChains().map((progress) => {

--- a/firebase/cloudSaveService.ts
+++ b/firebase/cloudSaveService.ts
@@ -53,7 +53,6 @@ const MAX_SAVE_SLOTS = 3;
  * Recursively replace `undefined` values with `null` in an object.
  * Firestore rejects `undefined` but accepts `null`.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function stripUndefined<T>(obj: T): T {
   if (obj === undefined) return null as unknown as T;
   if (obj === null || typeof obj !== 'object') return obj;

--- a/minigames/skiing/SkiingGame.tsx
+++ b/minigames/skiing/SkiingGame.tsx
@@ -612,7 +612,6 @@ export const SkiingGame: React.FC<MiniGameComponentProps> = ({ context, onComple
           const hitThreshold = ((objDrawWidth + playerCollisionWidth) / 2) * COLLISION_FUDGE;
           if (objScreenY < playerAnchorY && screenSeparation < hitThreshold) {
             if (debugRef.current) {
-              // eslint-disable-next-line no-console
               console.log(
                 `[Skiing] HIT kind=${obj.kind} zDiff=${zDiff.toFixed(0)} ` +
                   `screenSeparation=${screenSeparation.toFixed(1)}px hitThreshold=${hitThreshold.toFixed(1)}px | ` +


### PR DESCRIPTION
Follow-up to the #74 sweep archaeology: the shop's drag-and-drop never shipped (click won before the first commit), but its name survived on the live code path.

- `handleDragStart` → `initiateTrade`: it starts a trade — executes immediately for single items, opens the quantity stepper for stacks
- `showQuantitySlider` → `showQuantityStepper`: steppers replaced the slider in `647aa0e`, the state name lagged three months behind

Also removes the three `eslint-disable` directives the linter reports as unused:

- `JournalContent.tsx` — `react-hooks/exhaustive-deps` (rule no longer fires there)
- `cloudSaveService.ts` — `no-explicit-any` over `stripUndefined`, which contains no `any`
- `SkiingGame.tsx` — `no-console`, a rule this config never enabled (no-op from the day it was written)

Mechanical rename + comment edits only; no behaviour change. `npm run verify`: tsc clean, 874/874 tests.