### PR TITLE
Type the window debug globals; drop the (window as any) casts

### DIFF
--- a/components/ShopUI.tsx
+++ b/components/ShopUI.tsx
@@ -113,7 +113,7 @@ const ShopUI: React.FC<ShopUIProps> = ({
   const [shopFilter, setShopFilter] = useState<ShopFilter>('all');
   const [playerFilter, setPlayerFilter] = useState<ShopFilter>('all');
   const [selectedQuantity, setSelectedQuantity] = useState<number>(1);
-  const [showQuantitySlider, setShowQuantitySlider] = useState<boolean>(false);
+  const [showQuantityStepper, setShowQuantityStepper] = useState<boolean>(false);
   const [pendingTransaction, setPendingTransaction] = useState<{
     itemId: string;
     fromShop: boolean;
@@ -161,19 +161,19 @@ const ShopUI: React.FC<ShopUIProps> = ({
   const currentTime = TimeManager.getCurrentTime();
 
   /**
-   * Handle drag start (from shop or player inventory)
+   * Start a trade: single items execute immediately; multi-item stacks open the stepper.
    */
-  const handleDragStart = (itemId: string, fromShop: boolean, maxQuantity: number) => {
+  const initiateTrade = (itemId: string, fromShop: boolean, maxQuantity: number) => {
     // If only 1 item, execute immediately
     if (maxQuantity === 1) {
       executeTransaction(itemId, 1, fromShop);
       return;
     }
 
-    // Show quantity slider for multi-item stacks
+    // Open the quantity stepper for multi-item stacks
     setPendingTransaction({ itemId, fromShop, maxQuantity });
     setSelectedQuantity(1);
-    setShowQuantitySlider(true);
+    setShowQuantityStepper(true);
   };
 
   /**
@@ -192,7 +192,7 @@ const ShopUI: React.FC<ShopUIProps> = ({
   /** Right-click / long-press a slot: choose how many. */
   const handleSlotContextMenu = (itemId: string, fromShop: boolean, maxQuantity: number) => {
     if (maxQuantity < 1) return;
-    handleDragStart(itemId, fromShop, maxQuantity);
+    initiateTrade(itemId, fromShop, maxQuantity);
   };
 
   /**
@@ -240,7 +240,7 @@ const ShopUI: React.FC<ShopUIProps> = ({
       }
     }
 
-    setShowQuantitySlider(false);
+    setShowQuantityStepper(false);
     setPendingTransaction(null);
   };
 
@@ -257,7 +257,7 @@ const ShopUI: React.FC<ShopUIProps> = ({
    * Cancel quantity selection
    */
   const cancelQuantity = () => {
-    setShowQuantitySlider(false);
+    setShowQuantityStepper(false);
     setPendingTransaction(null);
     setSelectedQuantity(1);
   };
@@ -631,8 +631,8 @@ const ShopUI: React.FC<ShopUIProps> = ({
         </div>
       </div>
 
-      {/* Quantity Slider Modal */}
-      {showQuantitySlider && pendingTransaction && (
+      {/* Quantity Stepper Modal */}
+      {showQuantityStepper && pendingTransaction && (
         <div
           className={`fixed inset-0 bg-black/90 flex items-center justify-center ${zClass(Z_SHOP_CONFIRM)} pointer-events-auto`}
         >

--- a/components/book/JournalContent.tsx
+++ b/components/book/JournalContent.tsx
@@ -78,7 +78,6 @@ const JournalContent: React.FC<JournalContentProps> = ({ theme }) => {
   const [diaryRefreshKey, setDiaryRefreshKey] = useState(0);
 
   // Build journal entries for each chapter
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const entriesByChapter = useMemo(() => {
     // Active quests
     const activeQuests: JournalEntry[] = eventChainManager.getActiveChains().map((progress) => {

--- a/firebase/cloudSaveService.ts
+++ b/firebase/cloudSaveService.ts
@@ -53,7 +53,6 @@ const MAX_SAVE_SLOTS = 3;
  * Recursively replace `undefined` values with `null` in an object.
  * Firestore rejects `undefined` but accepts `null`.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function stripUndefined<T>(obj: T): T {
   if (obj === undefined) return null as unknown as T;
   if (obj === null || typeof obj !== 'object') return obj;

--- a/minigames/skiing/SkiingGame.tsx
+++ b/minigames/skiing/SkiingGame.tsx
@@ -612,7 +612,6 @@ export const SkiingGame: React.FC<MiniGameComponentProps> = ({ context, onComple
           const hitThreshold = ((objDrawWidth + playerCollisionWidth) / 2) * COLLISION_FUDGE;
           if (objScreenY < playerAnchorY && screenSeparation < hitThreshold) {
             if (debugRef.current) {
-              // eslint-disable-next-line no-console
               console.log(
                 `[Skiing] HIT kind=${obj.kind} zDiff=${zDiff.toFixed(0)} ` +
                   `screenSeparation=${screenSeparation.toFixed(1)}px hitThreshold=${hitThreshold.toFixed(1)}px | ` +

--- a/utils/PerformanceMonitor.ts
+++ b/utils/PerformanceMonitor.ts
@@ -16,7 +16,7 @@
  *   const metrics = performanceMonitor.getMetrics();
  *
  *   // Expose for headless testing:
- *   (window as any).__PERF_MONITOR__ = performanceMonitor;
+ *   window.__PERF_MONITOR__ = performanceMonitor;
  */
 
 /**
@@ -360,9 +360,9 @@ class PerformanceMonitor {
 // Singleton instance
 export const performanceMonitor = new PerformanceMonitor();
 
-// Expose globally for headless testing
+// Expose globally for headless testing (typed in vite-env.d.ts)
 if (typeof window !== 'undefined') {
-  (window as any).__PERF_MONITOR__ = performanceMonitor;
+  window.__PERF_MONITOR__ = performanceMonitor;
 }
 
 export default performanceMonitor;

--- a/utils/gameInitializer.ts
+++ b/utils/gameInitializer.ts
@@ -30,23 +30,23 @@ import { cutsceneManager } from './CutsceneManager';
  * Call this first so TimeManager and cutscene system are available immediately.
  */
 export function initializeGameCore(): void {
-  // Expose game objects to window for testing/debugging
-  (window as any).gameState = gameState;
-  (window as any).mapManager = mapManager;
-  (window as any).inventoryManager = inventoryManager;
-  (window as any).cookingManager = cookingManager;
-  (window as any).magicManager = magicManager;
-  (window as any).__PERF_MONITOR__ = performanceMonitor;
-  (window as any).audioManager = audioManager;
-  (window as any).textureManager = textureManager;
+  // Expose game objects to window for testing/debugging (typed in vite-env.d.ts)
+  window.gameState = gameState;
+  window.mapManager = mapManager;
+  window.inventoryManager = inventoryManager;
+  window.cookingManager = cookingManager;
+  window.magicManager = magicManager;
+  window.__PERF_MONITOR__ = performanceMonitor;
+  window.audioManager = audioManager;
+  window.textureManager = textureManager;
   // Exposed for scripts/perf-test.js, which has to get past the title screen
   // and any season cutscene before it can measure the game itself.
-  (window as any).cutsceneManager = cutsceneManager;
+  window.cutsceneManager = cutsceneManager;
 
   // Dev tools for colour system testing
-  (window as any).TimeManager = TimeManager;
-  (window as any).Season = Season;
-  (window as any).ColorResolver = ColorResolver;
+  window.TimeManager = TimeManager;
+  window.Season = Season;
+  window.ColorResolver = ColorResolver;
 
   // Log dev commands help
   console.log(`

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -28,3 +28,25 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+/**
+ * Debug/test globals attached to `window` by utils/gameInitializer.ts (and
+ * utils/PerformanceMonitor.ts for the monitor). All optional: they only exist
+ * after game init, and scripts/perf-test.js probes them with `typeof` checks
+ * before use — so nothing may assume they are present.
+ */
+interface Window {
+  gameState?: typeof import('./GameState').gameState;
+  mapManager?: typeof import('./maps').mapManager;
+  inventoryManager?: typeof import('./utils/inventoryManager').inventoryManager;
+  cookingManager?: typeof import('./utils/CookingManager').cookingManager;
+  magicManager?: typeof import('./utils/MagicManager').magicManager;
+  __PERF_MONITOR__?: typeof import('./utils/PerformanceMonitor').performanceMonitor;
+  audioManager?: typeof import('./utils/AudioManager').audioManager;
+  textureManager?: typeof import('./utils/TextureManager').textureManager;
+  /** Used by scripts/perf-test.js to skip the title screen and season cutscenes */
+  cutsceneManager?: typeof import('./utils/CutsceneManager').cutsceneManager;
+  TimeManager?: typeof import('./utils/TimeManager').TimeManager;
+  Season?: typeof import('./utils/TimeManager').Season;
+  ColorResolver?: typeof import('./utils/ColorResolver').ColorResolver;
+}


### PR DESCRIPTION
Replaces the 13 `(window as any)` casts across `utils/gameInitializer.ts` and `utils/PerformanceMonitor.ts` with a single typed contract: a `Window` interface augmentation in `vite-env.d.ts` covering the twelve debug globals (`gameState`, the managers, `__PERF_MONITOR__`, `TimeManager`/`Season`/`ColorResolver`, and `cutsceneManager` for `scripts/perf-test.js`).

## Design notes

- **Every property is optional** — the globals only exist after game init, and `perf-test.js` probes them with `typeof` checks before use. The type documents that reality instead of promising presence.
- **Types come from `typeof import(...)`** — type-only, so no runtime cycles; if an exported manager is renamed, the window contract type-checks against it.
- Autocomplete on `window.mapManager` etc. now works when debugging from devtools.

Mechanical: assignments drop the cast; doc comments updated. No behaviour change.

`npm run verify`: tsc clean, 874/874 tests. `no-explicit-any` warnings: 60 → 47.