### PR TITLE
Fix stale chat history in dialogue; make useChatHistory dep-safe

### DIFF
--- a/components/AIDialogueBox.tsx
+++ b/components/AIDialogueBox.tsx
@@ -174,10 +174,16 @@ const AIDialogueBox: React.FC<AIDialogueBoxProps> = ({
     return () => window.removeEventListener('resize', checkScreenSize);
   }, []);
 
-  // Load persisted history and generate greeting on mount
+  // Load persisted history and generate greeting on mount.
+  // Deliberately mount-only: the greeting is an AI call that must fire once per
+  // opened dialogue, not per render or per unrelated dep change. Note this is
+  // the pre-unified dialogue UI (superseded by UnifiedDialogueBox) and is not
+  // currently mounted anywhere; loadInitialGreeting is a plain closure, so
+  // listing it would re-fire the AI call every render.
   useEffect(() => {
     loadHistory(npc.id);
     loadInitialGreeting();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Sync streaming state into chat bubbles

--- a/components/dialogue/UnifiedDialogueBox.tsx
+++ b/components/dialogue/UnifiedDialogueBox.tsx
@@ -108,7 +108,19 @@ const UnifiedDialogueBox: React.FC<UnifiedDialogueBoxProps> = ({
     handleError,
   } = useStreamingDialogue();
 
-  const chatHistory = useChatHistory();
+  const {
+    chatMessages,
+    scrollRef,
+    handleScroll,
+    scrollToBottom,
+    loadHistory,
+    addPlayerMessage,
+    addAssistantMessage,
+    startStreamingMessage,
+    updateStreamingMessage,
+    finaliseStreamingMessage,
+    replaceStreamingWithFallback,
+  } = useChatHistory();
 
   const persona = NPC_PERSONAS[npc.id];
   const canUseAI = isAIAvailable() && persona?.aiEnabled;
@@ -121,8 +133,11 @@ const UnifiedDialogueBox: React.FC<UnifiedDialogueBoxProps> = ({
   // -------------------------------------------------------------------------
 
   useEffect(() => {
-    chatHistory.loadHistory(npc.id);
-  }, []);
+    loadHistory(npc.id);
+    // loadHistory is a stable useCallback, so this re-runs only when the NPC
+    // changes — which matters: App renders this box without a key, so it stays
+    // mounted across NPC switches and must swap in the new NPC's history.
+  }, [loadHistory, npc.id]);
 
   // Reset to initialNodeId when NPC changes
   useEffect(() => {
@@ -166,93 +181,18 @@ const UnifiedDialogueBox: React.FC<UnifiedDialogueBoxProps> = ({
         // `typewriter` flag gets set, so the completion callback that reveals the
         // response controls would never fire. Skip hiding the controls in that
         // case rather than waiting on a typewriter animation that isn't coming.
-        const lastMessage = chatHistory.chatMessages[chatHistory.chatMessages.length - 1];
+        const lastMessage = chatMessages[chatMessages.length - 1];
         const isDuplicateMessage =
           lastMessage?.role === 'assistant' && lastMessage.content === dialogue.text;
 
         setTypewriterDone(isDuplicateMessage);
-        chatHistory.addAssistantMessage(dialogue.text, undefined, undefined, true);
+        addAssistantMessage(dialogue.text, undefined, undefined, true);
         addToChatHistory(npc.id, 'assistant', `[${currentNodeId}] ${dialogue.text}`);
       }
     };
     loadDialogue();
-  }, [npc, currentNodeId, mode]);
+  }, [npc, currentNodeId, mode, chatMessages, addAssistantMessage, onNodeChange]);
 
-  // -------------------------------------------------------------------------
-  // Scripted response handling
-  // -------------------------------------------------------------------------
-
-  const handleScriptedResponse = useCallback(
-    (response: DialogueResponse | string) => {
-      if (typeof response === 'string') {
-        if (response === '__AI_CHAT__') {
-          switchToAI();
-          return;
-        }
-        if (response) {
-          let target = response;
-          if (onNodeChange) {
-            const redirect = onNodeChange(npc.id, response);
-            if (redirect) target = redirect;
-          }
-          setCurrentNodeId(target);
-        } else {
-          onClose();
-        }
-        return;
-      }
-
-      // Add player's response as a chat bubble
-      chatHistory.addPlayerMessage(response.text);
-      addToChatHistory(npc.id, 'user', response.text);
-
-      // Record to diary
-      if (currentDialogue?.text) {
-        recordScriptedConversation(
-          npc.id,
-          npc.name,
-          playerName,
-          response.text,
-          currentDialogue.text
-        ).catch(() => {});
-      }
-
-      // Process quest actions
-      if (response.startsQuest) gameState.startQuest(response.startsQuest);
-      if (response.advancesQuest) {
-        const stage = gameState.getQuestStage(response.advancesQuest);
-        gameState.setQuestStage(response.advancesQuest, stage + 1);
-      }
-      if (response.completesQuest) gameState.completeQuest(response.completesQuest);
-      if (response.setsQuestStage) {
-        gameState.setQuestStage(response.setsQuestStage.questId, response.setsQuestStage.stage);
-      }
-      if (response.givesItems) {
-        for (const gift of response.givesItems) {
-          inventoryManager.addItem(gift.itemId, gift.quantity);
-        }
-      }
-      if (response.grantsEasel) decorationManager.grantEasel();
-      if (response.addsFriendshipPoints && npc?.id) {
-        friendshipManager.addPoints(npc.id, response.addsFriendshipPoints, 'dialogue_choice');
-      }
-
-      // Navigate to next node
-      if (response.nextId) {
-        let target = response.nextId;
-        if (onNodeChange) {
-          const redirect = onNodeChange(npc.id, response.nextId);
-          if (redirect) target = redirect;
-        }
-        setCurrentNodeId(target);
-      } else {
-        onClose();
-      }
-    },
-    [npc.id, currentDialogue, onNodeChange, onClose, playerName]
-  );
-
-  // -------------------------------------------------------------------------
   // AI mode: game context
   // -------------------------------------------------------------------------
 
@@ -323,10 +263,10 @@ const UnifiedDialogueBox: React.FC<UnifiedDialogueBoxProps> = ({
       );
 
       if (response.error) {
-        chatHistory.addAssistantMessage(getFallbackGreeting(persona));
+        addAssistantMessage(getFallbackGreeting(persona));
         setSuggestions(getDefaultSuggestions(persona));
       } else {
-        chatHistory.addAssistantMessage(response.dialogue, response.emotion, response.action);
+        addAssistantMessage(response.dialogue, response.emotion, response.action);
         setCurrentEmotion(response.emotion);
         setSuggestions(
           response.suggestions.length > 0 ? response.suggestions : getDefaultSuggestions(persona)
@@ -338,12 +278,112 @@ const UnifiedDialogueBox: React.FC<UnifiedDialogueBoxProps> = ({
         setHistory((prev) => [...prev, { role: 'assistant', content: full }]);
       }
     } catch {
-      chatHistory.addAssistantMessage(getFallbackGreeting(persona));
+      addAssistantMessage(getFallbackGreeting(persona));
       setSuggestions(getDefaultSuggestions(persona));
     } finally {
       setIsLoading(false);
     }
-  }, [npc.id, npc.name, persona, playerName, getGameContext]);
+  }, [npc.id, npc.name, persona, playerName, getGameContext, addAssistantMessage]);
+
+  // Conversation summary for diary + shared data
+  // -------------------------------------------------------------------------
+
+  const contributeConversationSummary = useCallback(
+    (playerMessage: string, npcResponse: string) => {
+      const gameTime = TimeManager.getCurrentTime();
+      const topic = playerMessage.length > 90 ? playerMessage.slice(0, 87) + '...' : playerMessage;
+      const snippet = npcResponse.length > 300 ? npcResponse.slice(0, 297) + '...' : npcResponse;
+      const summary = `${playerName}: "${topic}" — ${npc.name}: "${snippet}"`;
+
+      getSharedDataService()
+        .addConversationSummary(npc.id, npc.name, topic, summary.slice(0, 1000), 'neutral', {
+          season: gameTime.season,
+          gameDay: gameTime.day,
+        })
+        .catch((err) => console.warn('[AI] Failed to contribute conversation summary:', err));
+
+      recordConversation(npc.id, npc.name, playerName, playerMessage, npcResponse).catch((err) =>
+        console.warn('[AI] Failed to record diary entry:', err)
+      );
+    },
+    [npc.id, npc.name, playerName]
+  );
+
+  // -------------------------------------------------------------------------
+  // Scripted response handling
+  // -------------------------------------------------------------------------
+
+  const handleScriptedResponse = useCallback(
+    (response: DialogueResponse | string) => {
+      if (typeof response === 'string') {
+        if (response === '__AI_CHAT__') {
+          switchToAI();
+          return;
+        }
+        if (response) {
+          let target = response;
+          if (onNodeChange) {
+            const redirect = onNodeChange(npc.id, response);
+            if (redirect) target = redirect;
+          }
+          setCurrentNodeId(target);
+        } else {
+          onClose();
+        }
+        return;
+      }
+
+      // Add player's response as a chat bubble
+      addPlayerMessage(response.text);
+      addToChatHistory(npc.id, 'user', response.text);
+
+      // Record to diary
+      if (currentDialogue?.text) {
+        recordScriptedConversation(
+          npc.id,
+          npc.name,
+          playerName,
+          response.text,
+          currentDialogue.text
+        ).catch(() => {});
+      }
+
+      // Process quest actions
+      if (response.startsQuest) gameState.startQuest(response.startsQuest);
+      if (response.advancesQuest) {
+        const stage = gameState.getQuestStage(response.advancesQuest);
+        gameState.setQuestStage(response.advancesQuest, stage + 1);
+      }
+      if (response.completesQuest) gameState.completeQuest(response.completesQuest);
+      if (response.setsQuestStage) {
+        gameState.setQuestStage(response.setsQuestStage.questId, response.setsQuestStage.stage);
+      }
+      if (response.givesItems) {
+        for (const gift of response.givesItems) {
+          inventoryManager.addItem(gift.itemId, gift.quantity);
+        }
+      }
+      if (response.grantsEasel) decorationManager.grantEasel();
+      if (response.addsFriendshipPoints && npc?.id) {
+        friendshipManager.addPoints(npc.id, response.addsFriendshipPoints, 'dialogue_choice');
+      }
+
+      // Navigate to next node
+      if (response.nextId) {
+        let target = response.nextId;
+        if (onNodeChange) {
+          const redirect = onNodeChange(npc.id, response.nextId);
+          if (redirect) target = redirect;
+        }
+        setCurrentNodeId(target);
+      } else {
+        onClose();
+      }
+    },
+    [npc.id, npc.name, currentDialogue, onNodeChange, onClose, playerName, switchToAI, addPlayerMessage]
+  );
+
+  // -------------------------------------------------------------------------
 
   // -------------------------------------------------------------------------
   // AI mode: send message
@@ -358,14 +398,14 @@ const UnifiedDialogueBox: React.FC<UnifiedDialogueBoxProps> = ({
         return;
       }
 
-      chatHistory.addPlayerMessage(message);
+      addPlayerMessage(message);
       setSuggestions([]);
       setError(null);
       setShowCustomInput(false);
       setInputText('');
 
       startStreaming();
-      chatHistory.startStreamingMessage();
+      startStreamingMessage();
       addToChatHistory(npc.id, 'user', message, playerName);
 
       let streamedAction: string | undefined;
@@ -402,7 +442,7 @@ const UnifiedDialogueBox: React.FC<UnifiedDialogueBoxProps> = ({
           },
           onComplete: () => {
             handleComplete();
-            chatHistory.finaliseStreamingMessage(streamedDialogue, undefined, streamedAction);
+            finaliseStreamingMessage(streamedDialogue, undefined, streamedAction);
             if (streamedAction) setCurrentEmotion(streamState.emotion);
 
             const full = streamedAction
@@ -433,7 +473,7 @@ const UnifiedDialogueBox: React.FC<UnifiedDialogueBoxProps> = ({
             try {
               const resp = await generateStructuredResponse(systemPrompt, history, message);
               if (!resp.error) {
-                chatHistory.replaceStreamingWithFallback(resp.dialogue, resp.emotion, resp.action);
+                replaceStreamingWithFallback(resp.dialogue, resp.emotion, resp.action);
                 setCurrentEmotion(resp.emotion);
                 setSuggestions(
                   resp.suggestions.length > 0 ? resp.suggestions : getDefaultSuggestions(persona)
@@ -454,19 +494,19 @@ const UnifiedDialogueBox: React.FC<UnifiedDialogueBoxProps> = ({
                 }
               } else {
                 setError(resp.error);
-                chatHistory.replaceStreamingWithFallback(getFallbackResponse(persona));
+                replaceStreamingWithFallback(getFallbackResponse(persona));
                 setSuggestions(getDefaultSuggestions(persona));
               }
             } catch {
               setError('Failed to get response');
-              chatHistory.replaceStreamingWithFallback(getFallbackResponse(persona));
+              replaceStreamingWithFallback(getFallbackResponse(persona));
               setSuggestions(getDefaultSuggestions(persona));
             }
           },
         });
       } catch {
         setError('Failed to get response');
-        chatHistory.replaceStreamingWithFallback(getFallbackResponse(persona));
+        replaceStreamingWithFallback(getFallbackResponse(persona));
         setSuggestions(getDefaultSuggestions(persona));
       }
     },
@@ -489,6 +529,11 @@ const UnifiedDialogueBox: React.FC<UnifiedDialogueBoxProps> = ({
       handleSuggestions,
       handleComplete,
       handleError,
+      addPlayerMessage,
+      startStreamingMessage,
+      finaliseStreamingMessage,
+      replaceStreamingWithFallback,
+      contributeConversationSummary,
     ]
   );
 
@@ -498,45 +543,22 @@ const UnifiedDialogueBox: React.FC<UnifiedDialogueBoxProps> = ({
 
   useEffect(() => {
     if (streamState.isStreaming && streamState.dialogueText) {
-      chatHistory.updateStreamingMessage(
+      updateStreamingMessage(
         streamState.dialogueText,
         streamState.emotion,
         streamState.action
       );
       setCurrentEmotion(streamState.emotion);
     }
-  }, [streamState.dialogueText, streamState.emotion, streamState.action, streamState.isStreaming]);
+  }, [streamState.dialogueText, streamState.emotion, streamState.action, streamState.isStreaming, updateStreamingMessage]);
 
   useEffect(() => {
     if (streamState.isStreaming && streamState.dialogueText) {
-      chatHistory.scrollToBottom();
+      scrollToBottom();
     }
-  }, [streamState.dialogueText, streamState.isStreaming]);
+  }, [streamState.dialogueText, streamState.isStreaming, scrollToBottom]);
 
   // -------------------------------------------------------------------------
-  // Conversation summary for diary + shared data
-  // -------------------------------------------------------------------------
-
-  const contributeConversationSummary = useCallback(
-    (playerMessage: string, npcResponse: string) => {
-      const gameTime = TimeManager.getCurrentTime();
-      const topic = playerMessage.length > 90 ? playerMessage.slice(0, 87) + '...' : playerMessage;
-      const snippet = npcResponse.length > 300 ? npcResponse.slice(0, 297) + '...' : npcResponse;
-      const summary = `${playerName}: "${topic}" — ${npc.name}: "${snippet}"`;
-
-      getSharedDataService()
-        .addConversationSummary(npc.id, npc.name, topic, summary.slice(0, 1000), 'neutral', {
-          season: gameTime.season,
-          gameDay: gameTime.day,
-        })
-        .catch((err) => console.warn('[AI] Failed to contribute conversation summary:', err));
-
-      recordConversation(npc.id, npc.name, playerName, playerMessage, npcResponse).catch((err) =>
-        console.warn('[AI] Failed to record diary entry:', err)
-      );
-    },
-    [npc.id, npc.name, playerName]
-  );
 
   // -------------------------------------------------------------------------
   // Switch back to scripted
@@ -600,9 +622,9 @@ const UnifiedDialogueBox: React.FC<UnifiedDialogueBoxProps> = ({
     >
       {/* Scrollable chat history */}
       <DialogueChatHistory
-        messages={chatHistory.chatMessages}
-        scrollRef={chatHistory.scrollRef}
-        onScroll={chatHistory.handleScroll}
+        messages={chatMessages}
+        scrollRef={scrollRef}
+        onScroll={handleScroll}
         npcName={npc.name}
         playerName={playerName}
         isLoading={isActivelyLoading}

--- a/hooks/useChatHistory.ts
+++ b/hooks/useChatHistory.ts
@@ -5,7 +5,7 @@
  * and handles auto-scroll to bottom with pause-on-user-scroll.
  */
 
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { getChatHistory } from '../services/aiChatHistory';
 import { parseAssistantContent } from '../components/ChatBubble';
 import { NPCEmotion } from '../services/anthropicClient';
@@ -193,17 +193,35 @@ export function useChatHistory() {
     scrollToBottom();
   }, [chatMessages, scrollToBottom]);
 
-  return {
-    chatMessages,
-    scrollRef,
-    handleScroll,
-    scrollToBottom,
-    loadHistory,
-    addPlayerMessage,
-    addAssistantMessage,
-    startStreamingMessage,
-    updateStreamingMessage,
-    finaliseStreamingMessage,
-    replaceStreamingWithFallback,
-  };
+  // Stable identity between renders: consumers depend on this object in effect
+  // and callback dep arrays. It changes only when chatMessages changes — every
+  // function is a useCallback with stable deps, so listing `chatHistory` in a
+  // dep array means "re-run when the messages actually change".
+  return useMemo(
+    () => ({
+      chatMessages,
+      scrollRef,
+      handleScroll,
+      scrollToBottom,
+      loadHistory,
+      addPlayerMessage,
+      addAssistantMessage,
+      startStreamingMessage,
+      updateStreamingMessage,
+      finaliseStreamingMessage,
+      replaceStreamingWithFallback,
+    }),
+    [
+      chatMessages,
+      handleScroll,
+      scrollToBottom,
+      loadHistory,
+      addPlayerMessage,
+      addAssistantMessage,
+      startStreamingMessage,
+      updateStreamingMessage,
+      finaliseStreamingMessage,
+      replaceStreamingWithFallback,
+    ]
+  );
 }


### PR DESCRIPTION
## The bug the linter was pointing at

`useChatHistory()` returned a **fresh object literal every render**. Consumers couldn't list it in dep arrays without re-running effects on every render — so they omitted it, and memoised callbacks/effects silently read stale `chatMessages`.

## Fixes

- **Root cause**: the hook returns a `useMemo`'d object; identity changes only when `chatMessages` changes (all members are stable `useCallback`s).
- **Real bug**: `UnifiedDialogueBox` renders without a `key`, so it stays mounted across NPC switches — `loadHistory` ran only on mount, leaving NPC B staring at NPC A's transcript. Now reloads per `npc.id`.
- `UnifiedDialogueBox` destructures the hook so dep arrays name the stable functions directly (react-hooks v7 rejects property-chain deps).
- `getGameContext`, `switchToAI`, `contributeConversationSummary` hoisted above their first use — dep arrays evaluate during render; referencing a later-declared `const` would throw (tsc caught this mid-refactor).
- `AIDialogueBox` (pre-unified UI, currently unmounted) keeps its mount-only greeting effect with a written reason.

## Verification

`npm run verify`: tsc clean, 874/874 tests. Dialogue-cluster exhaustive-deps warnings: **8 → 0**. Part of the ongoing 40-warning triage; the remaining ~32 sites are separate, lower-risk files.