### PR TITLE
Triage all remaining exhaustive-deps warnings: fix real bugs, document intent

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -798,7 +798,7 @@ const App: React.FC = () => {
     });
 
     return unsubscribe;
-  }, [isLoadingCutscene]);
+  }, [isLoadingCutscene, closeAllUI, setRadialMenuVisible]);
 
   // Subscribe to EventBus for inventory updates (only triggers when inventory actually changes)
   useEffect(() => {
@@ -916,6 +916,7 @@ const App: React.FC = () => {
         return cutsceneStarted;
       },
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- handleMapTransition is a plain function read through currentMapIdRef precisely so it can be captured once here; re-initialising the stamina manager per render would reset its state
   }, [showToast]);
 
   // Track hostile NPC that initiated combat (for post-combat cleanup)
@@ -949,7 +950,7 @@ const App: React.FC = () => {
       setActiveNPC(null);
       openUI('shopUI', { activeShopId: 'mushras_shop' });
     }
-  }, [activeNPC]);
+  }, [activeNPC, openUI]);
 
   // Setup keyboard controls
   useKeyboardControls({
@@ -1196,6 +1197,7 @@ const App: React.FC = () => {
     );
 
     animationFrameId.current = requestAnimationFrame(gameLoop);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- updateAnimations is a stable useCallback destructured from usePixiRenderer below this line
   }, [
     updateMovement,
     activeNPC,
@@ -1205,6 +1207,8 @@ const App: React.FC = () => {
     currentMapId,
     ui.miniGame,
     tickMultiplayer,
+    isMovingRef,
+    playerPosRef,
   ]);
 
   // Disabled automatic transitions - now using action key (E or Enter)
@@ -1261,6 +1265,7 @@ const App: React.FC = () => {
     };
 
     initAssets();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only by design: initAssets reads currentMapId once to load/regenerate the saved map; the effect must not re-run when the player changes maps
   }, []); // Only run once on mount
 
   // Debug logging for DevTools state
@@ -1293,6 +1298,7 @@ const App: React.FC = () => {
       clearInterval(farmUpdateInterval);
       farmManager.stopSharedSync(); // Flush and stop shared farm sync on unmount
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- the belt-and-braces startSharedSync for loading a save straight onto a shared map; the map-transition handler owns the shared-sync lifecycle, and re-running this per map change would cancel/restart the rAF loop and flush shared sync on every transition
   }, [isMapInitialized, gameLoop]);
 
   // Freeze/unfreeze NPC movement during dialogue
@@ -1415,7 +1421,7 @@ const App: React.FC = () => {
       x: (viewportSize.width - artworkWidth) / 2 + backgroundRoomPan.x,
       y: (viewportSize.height - artworkHeight) / 2 + backgroundRoomPan.y,
     };
-  }, [currentMap, currentMapId, viewportScale, viewportSize, zoom, backgroundRoomPan]);
+  }, [currentMap, viewportScale, viewportSize, zoom, backgroundRoomPan]);
 
   // Calculate effective tile size for background-image rooms (scaled)
   // Must include both viewport scale AND layer scale to match the room artwork
@@ -1636,6 +1642,7 @@ const App: React.FC = () => {
         }
       },
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- the callbacks read refs, singletons and the mount-captured handleMapTransition (which reads currentMapIdRef by design); currentMapId/playerPos/playerScale/playerSizeTier are the real invalidation triggers
     [currentMapId, playerPos, playerScale, playerSizeTier, triggerVFX]
   );
 
@@ -1666,7 +1673,7 @@ const App: React.FC = () => {
 
       return false;
     },
-    [magicEffectCallbacks]
+    [magicEffectCallbacks, showToast]
   );
 
   // Handle eating food directly from inventory
@@ -1854,6 +1861,7 @@ const App: React.FC = () => {
     // Deduplicate NPCs by ID (layer NPCs take precedence over map NPCs)
     const uniqueNPCs = Array.from(new Map(npcs.map((npc) => [npc.id, npc])).values());
     return uniqueNPCs;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- npcUpdateTrigger is a version counter: the NPCs read manager singletons, so the counter is the invalidation mechanism
   }, [currentMapId, npcUpdateTrigger, backgroundImageLayerRef]);
 
   // Keep NPCs ref in sync for collision detection

--- a/components/BasketModal.tsx
+++ b/components/BasketModal.tsx
@@ -51,12 +51,14 @@ const BasketModal: React.FC<BasketModalProps> = ({ onClose, onResult }) => {
           alreadyInBasket: basketContents.includes(item.itemId),
         };
       });
-  }, []);
+  }, [basketContents]);
 
   const displaySlots = Math.max(MIN_ROWS * COLS, Math.ceil(foodItems.length / COLS) * COLS);
   const slots = useMemo(() => {
     const arr: ((typeof foodItems)[0] | null)[] = Array(displaySlots).fill(null);
-    foodItems.forEach((item, i) => { if (i < displaySlots) arr[i] = item; });
+    foodItems.forEach((item, i) => {
+      if (i < displaySlots) arr[i] = item;
+    });
     return arr;
   }, [foodItems, displaySlots]);
 
@@ -116,7 +118,12 @@ const BasketModal: React.FC<BasketModalProps> = ({ onClose, onResult }) => {
                 const alreadyAdded = item?.alreadyInBasket ?? false;
 
                 const tooltipContent: TooltipContent | null = item
-                  ? { name: item.name, description: item.description, image: item.icon, quantity: item.quantity }
+                  ? {
+                      name: item.name,
+                      description: item.description,
+                      image: item.icon,
+                      quantity: item.quantity,
+                    }
                   : null;
 
                 const slotButton = (
@@ -126,13 +133,14 @@ const BasketModal: React.FC<BasketModalProps> = ({ onClose, onResult }) => {
                     onClick={() => !isEmpty && !alreadyAdded && setSelectedItemId(item!.id)}
                     className={`
                       aspect-square rounded border-2 flex flex-col items-center justify-center p-1 transition-all
-                      ${isEmpty
-                        ? 'border-amber-800 bg-amber-900/30 cursor-default'
-                        : alreadyAdded
-                          ? 'border-amber-700 bg-amber-800/40 cursor-not-allowed opacity-50'
-                          : isSelected
-                            ? 'border-amber-400 bg-amber-700 scale-105 shadow-lg'
-                            : 'border-amber-700 bg-amber-800/60 hover:border-amber-500 hover:bg-amber-700/60 cursor-pointer'
+                      ${
+                        isEmpty
+                          ? 'border-amber-800 bg-amber-900/30 cursor-default'
+                          : alreadyAdded
+                            ? 'border-amber-700 bg-amber-800/40 cursor-not-allowed opacity-50'
+                            : isSelected
+                              ? 'border-amber-400 bg-amber-700 scale-105 shadow-lg'
+                              : 'border-amber-700 bg-amber-800/60 hover:border-amber-500 hover:bg-amber-700/60 cursor-pointer'
                       }
                     `}
                   >
@@ -165,30 +173,31 @@ const BasketModal: React.FC<BasketModalProps> = ({ onClose, onResult }) => {
         </div>
 
         {/* Selected item info + confirm */}
-        {selectedItemId && (() => {
-          const item = foodItems.find((i) => i.id === selectedItemId);
-          if (!item) return null;
-          return (
-            <div className="mt-4 pt-4 border-t border-amber-700">
-              <div className="flex items-center gap-3 mb-3">
-                <img src={item.icon} alt={item.name} className="w-10 h-10 object-contain" />
-                <div>
-                  <p className="text-amber-200 font-semibold">{item.name}</p>
-                  {item.description && (
-                    <p className="text-amber-400 text-xs italic">{item.description}</p>
-                  )}
+        {selectedItemId &&
+          (() => {
+            const item = foodItems.find((i) => i.id === selectedItemId);
+            if (!item) return null;
+            return (
+              <div className="mt-4 pt-4 border-t border-amber-700">
+                <div className="flex items-center gap-3 mb-3">
+                  <img src={item.icon} alt={item.name} className="w-10 h-10 object-contain" />
+                  <div>
+                    <p className="text-amber-200 font-semibold">{item.name}</p>
+                    {item.description && (
+                      <p className="text-amber-400 text-xs italic">{item.description}</p>
+                    )}
+                  </div>
                 </div>
+                <button
+                  onClick={handleAddToBasket}
+                  disabled={remaining <= 0}
+                  className="w-full py-2 bg-amber-600 hover:bg-amber-500 disabled:bg-amber-800 disabled:opacity-50 text-white font-bold rounded transition-colors"
+                >
+                  Add to basket
+                </button>
               </div>
-              <button
-                onClick={handleAddToBasket}
-                disabled={remaining <= 0}
-                className="w-full py-2 bg-amber-600 hover:bg-amber-500 disabled:bg-amber-800 disabled:opacity-50 text-white font-bold rounded transition-colors"
-              >
-                Add to basket
-              </button>
-            </div>
-          );
-        })()}
+            );
+          })()}
       </div>
     </div>
   );

--- a/components/CutscenePlayer.tsx
+++ b/components/CutscenePlayer.tsx
@@ -146,10 +146,28 @@ const CutscenePlayer: React.FC<CutscenePlayerProps> = ({ onComplete }) => {
     if (currentScene?.soundEffect) {
       audioManager.playSfx(currentScene.soundEffect);
     }
-  }, [currentScene?.id]);
+  }, [currentScene?.id, currentScene?.soundEffect]);
 
   // Track cutscene ID for natural ending detection
   const cutsceneIdRef = useRef<string | undefined>(cutsceneManager.getState().currentCutscene?.id);
+
+  // Handle scene transitions
+  const handleSceneTransition = useCallback(
+    (newScene: CutsceneScene) => {
+      setIsTransitioning(true);
+      setShowDialogue(false);
+
+      const transitionDuration = currentScene?.transitionOut?.duration || 500;
+
+      setTimeout(() => {
+        setCurrentScene(newScene);
+        setIsTransitioning(false);
+        const delay = newScene.letterboxReveal ? 1500 : 300;
+        setTimeout(() => setShowDialogue(true), delay);
+      }, transitionDuration);
+    },
+    [currentScene]
+  );
 
   // Subscribe to cutscene manager state changes
   useEffect(() => {
@@ -176,22 +194,7 @@ const CutscenePlayer: React.FC<CutscenePlayerProps> = ({ onComplete }) => {
     });
 
     return unsubscribe;
-  }, [currentScene, onComplete]);
-
-  // Handle scene transitions
-  const handleSceneTransition = (newScene: CutsceneScene) => {
-    setIsTransitioning(true);
-    setShowDialogue(false);
-
-    const transitionDuration = currentScene?.transitionOut?.duration || 500;
-
-    setTimeout(() => {
-      setCurrentScene(newScene);
-      setIsTransitioning(false);
-      const delay = newScene.letterboxReveal ? 1500 : 300;
-      setTimeout(() => setShowDialogue(true), delay);
-    }, transitionDuration);
-  };
+  }, [currentScene, onComplete, handleSceneTransition]);
 
   // Advance to next scene
   const handleAdvance = useCallback((nextSceneIndex?: number) => {
@@ -222,7 +225,7 @@ const CutscenePlayer: React.FC<CutscenePlayerProps> = ({ onComplete }) => {
       // Advance to specified scene or next scene
       handleAdvance(choice.nextSceneIndex);
     },
-    [currentScene, handleAdvance, onComplete]
+    [currentScene, handleAdvance]
   );
 
   // Keyboard controls

--- a/components/FarmActionAnimation.tsx
+++ b/components/FarmActionAnimation.tsx
@@ -39,7 +39,8 @@ const FarmActionAnimation: React.FC<FarmActionAnimationProps> = ({
       console.log('[FarmActionAnimation] Unmounting');
       clearTimeout(timer);
     };
-  }, [onComplete]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mounted per action via key; the position is only logged at mount, and adding it as a dep would restart the completion timer whenever the player moves during the 1-second animation
+  }, [action, onComplete]);
 
   if (!action) return null;
 

--- a/components/ForegroundParallax.tsx
+++ b/components/ForegroundParallax.tsx
@@ -195,6 +195,7 @@ const ForegroundParallax: React.FC<ForegroundParallaxProps> = ({
       assets[tree.id] = getSeasonalTree(tree.treeType);
     }
     return assets;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- season is the invalidation trigger: getSeasonalTree reads the season from TimeManager internally
   }, [season]);
 
   const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1200;

--- a/components/FurnitureCatalogueUI.tsx
+++ b/components/FurnitureCatalogueUI.tsx
@@ -4,7 +4,15 @@ import { getItem } from '../data/items';
 import { inventoryManager } from '../utils/inventoryManager';
 import { FALLBACK_ITEM_ICON } from '../utils/iconMap';
 
-const CATALOGUE_ITEM_IDS = ['furniture_bookshelf', 'furniture_armchair', 'furniture_cozy_rug', 'furniture_cozy_rug_blue', 'furniture_cozy_rug_green', 'furniture_strawberry_wallpaper', 'furniture_stripey_curtains'];
+const CATALOGUE_ITEM_IDS = [
+  'furniture_bookshelf',
+  'furniture_armchair',
+  'furniture_cozy_rug',
+  'furniture_cozy_rug_blue',
+  'furniture_cozy_rug_green',
+  'furniture_strawberry_wallpaper',
+  'furniture_stripey_curtains',
+];
 
 interface FurnitureCatalogueUIProps {
   isOpen: boolean;
@@ -55,7 +63,7 @@ export default function FurnitureCatalogueUI({
       onTransaction(playerGold - price, newInventory);
       onClose();
     },
-    [playerGold, onTransaction, onClose]
+    [playerGold, onTransaction, onClose, showFeedback]
   );
 
   if (!isOpen) return null;

--- a/components/MiniGameHost.tsx
+++ b/components/MiniGameHost.tsx
@@ -127,7 +127,7 @@ const MiniGameHost: React.FC<MiniGameHostProps> = ({
         },
       },
     }),
-    [gameStateSnapshot, actions, storage, triggerData]
+    [gameStateSnapshot, actions, storage, triggerData, activeMiniGameId]
   );
 
   // Handle mini-game completion

--- a/components/book/JournalContent.tsx
+++ b/components/book/JournalContent.tsx
@@ -151,6 +151,7 @@ const JournalContent: React.FC<JournalContentProps> = ({ theme }) => {
       completed: completedQuests,
       conversations,
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- diaryRefreshKey is a version counter: the entries read manager singletons, not React state, so the counter is the invalidation mechanism
   }, [diaryRefreshKey]);
 
   const pagination = useBookPagination(JOURNAL_CHAPTERS, entriesByChapter, 6);

--- a/components/book/PotionContent.tsx
+++ b/components/book/PotionContent.tsx
@@ -62,10 +62,12 @@ const PotionContent: React.FC<PotionContentProps> = ({ theme }) => {
       },
       { id: 'encyclopaedia', label: 'Encyclopaedia', icon: '🌿', locked: false },
     ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- magicUpdateTrigger is a version counter invalidating this list when the magic level changes
     [magicUpdateTrigger]
   );
 
   // Get all unlocked recipes (re-evaluate when level changes to include new recipes)
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- same version-counter pattern as above
   const unlockedRecipes = useMemo(() => magicManager.getUnlockedRecipes(), [magicUpdateTrigger]);
 
   // Group recipes by level (plus encyclopaedia entries)

--- a/components/book/RecipeContent.tsx
+++ b/components/book/RecipeContent.tsx
@@ -130,7 +130,7 @@ const RecipeContent: React.FC<RecipeContentProps> = ({
 
       // Popup handles its own auto-dismiss via CookingResultPopup
     },
-    [nearbyNPCs, currentMapId, cookingPosition, playerPosition, onItemPlaced]
+    [nearbyNPCs]
   );
 
   // Get selected recipe details

--- a/hooks/useInteractionController.ts
+++ b/hooks/useInteractionController.ts
@@ -546,6 +546,7 @@ export function useInteractionController(
     onEmote,
     onOpenEmoteWheel,
     onStartChat,
+    setActiveNPC,
   ]);
 
   // -------------------------------------------------------------------------

--- a/hooks/useMouseHover.ts
+++ b/hooks/useMouseHover.ts
@@ -302,5 +302,5 @@ export function useMouseHover(config: UseMouseHoverConfig): void {
     };
     // Only depend on stable values — everything else read from refs
     // containerReady triggers re-run when the game container mounts after loading
-  }, [containerRef, isTouchDevice, containerReady]);
+  }, [containerRef, isTouchDevice, containerReady, playerPosRef]);
 }

--- a/hooks/usePaintingLayers.ts
+++ b/hooks/usePaintingLayers.ts
@@ -472,12 +472,16 @@ export function usePaintingLayers(config: UsePaintingLayersConfig): UsePaintingL
   // ─── Cleanup on unmount ──────────────────────────────────────────
 
   useEffect(() => {
+    // Snapshot the maps now: the cleanup must destroy the atrament instances
+    // that exist for this hook instance, not whatever the refs hold later.
+    const drawingStatesMap = drawingStates.current;
+    const imageStatesMap = imageStates.current;
     return () => {
-      for (const [, ds] of drawingStates.current) {
+      for (const [, ds] of drawingStatesMap) {
         ds.atrament?.destroy();
       }
-      drawingStates.current.clear();
-      imageStates.current.clear();
+      drawingStatesMap.clear();
+      imageStatesMap.clear();
     };
   }, []);
 

--- a/hooks/usePixiRenderer.ts
+++ b/hooks/usePixiRenderer.ts
@@ -618,6 +618,7 @@ export function usePixiRenderer(props: UsePixiRendererProps): UsePixiRendererRet
         darknessLayerRef.current = null;
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- init-once by design: the twelve flagged values are per-frame/per-render inputs consumed through refs and the game loop; re-initialising the whole PixiJS renderer when they change would tear down and rebuild the GPU context every frame
   }, [enabled, isMapInitialized]); // Only initialize once when map is ready
 
   // =========================================================================

--- a/minigames/combat-encounter/CombatEncounter.tsx
+++ b/minigames/combat-encounter/CombatEncounter.tsx
@@ -311,12 +311,11 @@ const CombatEncounterInner: React.FC<
   );
 
   const currentEnemySprite = useMemo(() => {
-    const { phase, telegraphedMove, actualMove } = state;
-    if (phase === 'telegraph' && telegraphedMove) {
-      return config.actionSprites?.[telegraphedMove] ?? npcSprite;
+    if (state.phase === 'telegraph' && state.telegraphedMove) {
+      return config.actionSprites?.[state.telegraphedMove] ?? npcSprite;
     }
-    if ((phase === 'reveal' || phase === 'result') && actualMove) {
-      return config.actionSprites?.[actualMove] ?? npcSprite;
+    if ((state.phase === 'reveal' || state.phase === 'result') && state.actualMove) {
+      return config.actionSprites?.[state.actualMove] ?? npcSprite;
     }
     return npcSprite;
   }, [state.phase, state.telegraphedMove, state.actualMove, config, npcSprite]);

--- a/minigames/combat-encounter/useCombatLogic.ts
+++ b/minigames/combat-encounter/useCombatLogic.ts
@@ -131,7 +131,7 @@ export function useCombatLogic(
     }));
 
     timerRef.current = setTimeout(startTelegraph, COMBAT.STANDOFF_MS);
-  }, [config, startTelegraph]);
+  }, [startTelegraph]);
 
   // Keep ref in sync
   startStandoffRef.current = startStandoff;

--- a/minigames/painting-easel/PaintingEaselGame.tsx
+++ b/minigames/painting-easel/PaintingEaselGame.tsx
@@ -144,7 +144,15 @@ const PaintingEaselGame: React.FC<MiniGameComponentProps> = ({ onClose }) => {
     } else {
       showMessage(result.message);
     }
-  }, [painting, paintingName, selectedFramePaints, showMessage, onClose]);
+  }, [
+    painting,
+    paintingName,
+    selectedFramePaints,
+    selectedScale,
+    transparentBg,
+    showMessage,
+    onClose,
+  ]);
 
   const handleToggleFramePaint = useCallback((paintId: string) => {
     setSelectedFramePaints((prev) =>

--- a/minigames/pumpkin-carving/PumpkinCarvingGame.tsx
+++ b/minigames/pumpkin-carving/PumpkinCarvingGame.tsx
@@ -98,8 +98,6 @@ export const PumpkinCarvingGame: React.FC<MiniGameComponentProps> = ({
   const [imageLoaded, setImageLoaded] = useState(false);
   const [carvePercent, setCarvePercent] = useState(0);
 
-  const getKnifeRadius = () => KNIFE_SIZES.find((k) => k.id === knifeSize)!.radius;
-
   // ─── Load pumpkin asset image ────────────────────────────────────────────
   useEffect(() => {
     let cancelled = false;
@@ -226,7 +224,7 @@ export const PumpkinCarvingGame: React.FC<MiniGameComponentProps> = ({
       const ctx = surface.getContext('2d');
       if (!ctx) return;
 
-      const r = getKnifeRadius();
+      const r = KNIFE_SIZES.find((k) => k.id === knifeSize)!.radius;
 
       // Erase a circle from the surface (reveals interior)
       ctx.save();
@@ -354,7 +352,7 @@ export const PumpkinCarvingGame: React.FC<MiniGameComponentProps> = ({
 
     const pct = pumpkinPixels > 0 ? Math.round((carvedPixels / pumpkinPixels) * 100) : 0;
     setCarvePercent(pct);
-  }, [imageLoaded]);
+  }, []);
 
   // ─── Finish carving ─────────────────────────────────────────────────────
   const handleFinish = useCallback(() => {


### PR DESCRIPTION
Completes the `react-hooks/exhaustive-deps` triage for everything outside the dialogue cluster (that's #77). Every site was read and classified — real bug, safe dep addition, or intentional pattern — never silenced blind.

## Real bugs fixed

- **`BasketModal`**: `alreadyInBasket` computed from a mount-stale `basketContents` (deps were `[]`) — items never showed as already-packed
- **`PaintingEaselGame`**: export captured stale `selectedScale`/`transparentBg` — changing settings after mount then saving used the old ones
- **`MiniGameHost`**: memoised trigger data baked a stale `activeMiniGameId`
- **`CombatEncounter`**: enemy-sprite memo destructured `state` inside the body; now reads fields directly against the same precise deps

## Safe additions (stable identities, zero behaviour change)

`closeAllUI`, `setRadialMenuVisible`, `openUI`, `showToast`, `setActiveNPC`, `playerPosRef`, `handleSceneTransition` (converted to `useCallback`), the cutscene sound-effect key, and the refs in `gameLoop`.

## Intentional patterns, now documented with reasons

- **Init-once effects** (App bootstrap, PixiJS renderer init): flagged values are per-frame inputs consumed through refs — re-running would tear down the GPU context or reload the map
- **Game-loop `startSharedSync`**: belt-and-braces for loading a save onto a shared map; the transition handler owns that lifecycle
- **Version-counter deps** (`diaryRefreshKey`, `magicUpdateTrigger`, `npcUpdateTrigger`): they read manager singletons, so the counter *is* the invalidation mechanism
- **Stamina manager** captures `handleMapTransition` at mount through `currentMapIdRef` by design
- **`FarmActionAnimation`** remounts per action (keyed) — the mount-time position must not restart its completion timer

## Cleanup

Removed deps the linter proved unreferenced; moved `getKnifeRadius` inline in PumpkinCarving, which surfaced `knifeSize` as the real dep.

`npm run verify`: tsc clean, 874/874 tests. **exhaustive-deps: 40 → 0** once #77 merges (the 8 remaining here are the dialogue files it fixes).