### PR TITLE
Drop RecipeContent prop bindings orphaned by the deps triage

### DIFF
--- a/components/book/RecipeContent.tsx
+++ b/components/book/RecipeContent.tsx
@@ -38,11 +38,7 @@ const RECIPE_CHAPTERS: BookChapter<RecipeCategory | 'all'>[] = [
  */
 const RecipeContent: React.FC<RecipeContentProps> = ({
   theme,
-  playerPosition,
-  currentMapId,
-  cookingPosition,
   nearbyNPCs = [],
-  onItemPlaced,
 }) => {
   const [cookingResult, setCookingResult] = useState<CookingResult | null>(null);
   const [showResult, setShowResult] = useState(false);


### PR DESCRIPTION
Follow-up to #78: removing the four unused entries from the cook callback's dependency array left the same four destructured-but-unread in the component body. Removes the bindings.

tsc clean, 874/874 tests, eslint 51 → 47 warnings.