### PR TITLE
Gate GameState and GameStatePersistence console logging behind debugLog

### DIFF
--- a/GameState.ts
+++ b/GameState.ts
@@ -18,6 +18,7 @@ import { eventBus, GameEvent } from './utils/EventBus';
 import { sharedPlacedItemsManager } from './multiplayer/sharedPlacedItems';
 import { eventChainManager } from './utils/EventChainManager';
 import { loadPersistedState, SAVE_VERSION } from './GameStatePersistence';
+import { debugLog } from './utils/debugLog';
 export { runSaveMigrations, SAVE_VERSION } from './GameStatePersistence';
 
 export interface CharacterCustomization {
@@ -327,7 +328,7 @@ class GameStateManager {
 
   selectCharacter(character: CharacterCustomization): void {
     this.state.selectedCharacter = character;
-    console.log(`[GameState] Character selected: ${character.name}`);
+    debugLog('GameState', `Character selected: ${character.name}`);
     this.notify();
   }
 
@@ -343,14 +344,14 @@ class GameStateManager {
 
   addGold(amount: number): void {
     this.state.gold += amount;
-    console.log(`[GameState] +${amount} gold (total: ${this.state.gold})`);
+    debugLog('GameState', `+${amount} gold (total: ${this.state.gold})`);
     this.notify();
   }
 
   spendGold(amount: number): boolean {
     if (this.state.gold >= amount) {
       this.state.gold -= amount;
-      console.log(`[GameState] -${amount} gold (total: ${this.state.gold})`);
+      debugLog('GameState', `-${amount} gold (total: ${this.state.gold})`);
       this.notify();
       return true;
     }
@@ -361,28 +362,28 @@ class GameStateManager {
 
   enterForest(): void {
     this.state.forestDepth += 1;
-    console.log(`[GameState] Entered forest depth ${this.state.forestDepth}`);
+    debugLog('GameState', `Entered forest depth ${this.state.forestDepth}`);
     this.notify();
   }
 
   exitForest(): void {
     if (this.state.forestDepth > 0) {
       this.state.forestDepth -= 1;
-      console.log(`[GameState] Exited forest, now at depth ${this.state.forestDepth}`);
+      debugLog('GameState', `Exited forest, now at depth ${this.state.forestDepth}`);
       this.notify();
     }
   }
 
   enterCave(): void {
     this.state.caveDepth += 1;
-    console.log(`[GameState] Entered cave depth ${this.state.caveDepth}`);
+    debugLog('GameState', `Entered cave depth ${this.state.caveDepth}`);
     this.notify();
   }
 
   exitCave(): void {
     if (this.state.caveDepth > 0) {
       this.state.caveDepth -= 1;
-      console.log(`[GameState] Exited cave, now at depth ${this.state.caveDepth}`);
+      debugLog('GameState', `Exited cave, now at depth ${this.state.caveDepth}`);
       this.notify();
     }
   }
@@ -407,14 +408,14 @@ class GameStateManager {
 
   enterLava(): void {
     this.state.lavaDepth += 1;
-    console.log(`[GameState] Entered lava depth ${this.state.lavaDepth}`);
+    debugLog('GameState', `Entered lava depth ${this.state.lavaDepth}`);
     this.notify();
   }
 
   exitLava(): void {
     if (this.state.lavaDepth > 0) {
       this.state.lavaDepth -= 1;
-      console.log(`[GameState] Exited lava, now at depth ${this.state.lavaDepth}`);
+      debugLog('GameState', `Exited lava, now at depth ${this.state.lavaDepth}`);
       this.notify();
     }
   }
@@ -430,8 +431,9 @@ class GameStateManager {
 
   revealLavaEntrance(caveMapId: string, position: { x: number; y: number }): void {
     this.state.revealedLavaEntrances[caveMapId] = position;
-    console.log(
-      `[GameState] Revealed lava entrance on ${caveMapId} at (${position.x}, ${position.y})`
+    debugLog(
+      'GameState',
+      `Revealed lava entrance on ${caveMapId} at (${position.x}, ${position.y})`
     );
     this.notify();
   }
@@ -463,7 +465,7 @@ class GameStateManager {
     this.state.player.position = { x: 15, y: 25 };
     this.state.forestDepth = 0;
     this.state.caveDepth = 0;
-    console.log('[GameState] Player respawned at village');
+    debugLog('GameState', 'Player respawned at village');
     this.notify();
   }
 
@@ -497,7 +499,7 @@ class GameStateManager {
     this.state.inventory.items = [];
     this.state.inventory.tools = [];
     this.notify();
-    console.log('[GameState] Inventory cleared - will reload starter items on next refresh');
+    debugLog('GameState', 'Inventory cleared - will reload starter items on next refresh');
   }
 
   // === Crafting Methods ===
@@ -505,7 +507,7 @@ class GameStateManager {
   unlockRecipe(recipeId: string): void {
     if (!this.state.crafting.unlockedRecipes.includes(recipeId)) {
       this.state.crafting.unlockedRecipes.push(recipeId);
-      console.log(`[GameState] Unlocked recipe: ${recipeId}`);
+      debugLog('GameState', `Unlocked recipe: ${recipeId}`);
       this.notify();
     }
   }
@@ -517,7 +519,7 @@ class GameStateManager {
   addMaterial(materialId: string, quantity: number): void {
     this.state.crafting.materials[materialId] =
       (this.state.crafting.materials[materialId] || 0) + quantity;
-    console.log(`[GameState] +${quantity} ${materialId} material`);
+    debugLog('GameState', `+${quantity} ${materialId} material`);
     this.notify();
   }
 
@@ -534,7 +536,7 @@ class GameStateManager {
 
   setFarmingTool(tool: 'hoe' | 'seeds' | 'wateringCan' | 'hand'): void {
     this.state.farming.currentTool = tool;
-    console.log(`[GameState] Switched to ${tool}`);
+    debugLog('GameState', `Switched to ${tool}`);
     this.notify();
   }
 
@@ -545,7 +547,7 @@ class GameStateManager {
   setSelectedSeed(seedId: string | null): void {
     this.state.farming.selectedSeed = seedId;
     if (seedId) {
-      console.log(`[GameState] Selected seed: ${seedId}`);
+      debugLog('GameState', `Selected seed: ${seedId}`);
     }
     this.notify();
   }
@@ -567,7 +569,7 @@ class GameStateManager {
   saveCustomColors(colors: Record<string, string>): void {
     this.state.customColors = colors;
     this.notify();
-    console.log('[GameState] Custom colors saved:', Object.keys(colors).length, 'colors');
+    debugLog('GameState', 'Custom colors saved:', Object.keys(colors).length, 'colors');
   }
 
   loadCustomColors(): Record<string, string> | undefined {
@@ -581,7 +583,7 @@ class GameStateManager {
   clearCustomColors(): void {
     this.state.customColors = undefined;
     this.notify();
-    console.log('[GameState] Custom colors cleared');
+    debugLog('GameState', 'Custom colors cleared');
   }
 
   // Color scheme management
@@ -591,7 +593,7 @@ class GameStateManager {
     }
     this.state.customColorSchemes[scheme.name] = scheme;
     this.notify();
-    console.log('[GameState] Color scheme saved:', scheme.name);
+    debugLog('GameState', 'Color scheme saved:', scheme.name);
   }
 
   loadColorSchemes(): Record<string, ColorScheme> | undefined {
@@ -601,14 +603,14 @@ class GameStateManager {
   clearColorSchemes(): void {
     this.state.customColorSchemes = undefined;
     this.notify();
-    console.log('[GameState] Color schemes cleared');
+    debugLog('GameState', 'Color schemes cleared');
   }
 
   clearColorScheme(schemeName: string): void {
     if (this.state.customColorSchemes && this.state.customColorSchemes[schemeName]) {
       delete this.state.customColorSchemes[schemeName];
       this.notify();
-      console.log('[GameState] Color scheme cleared:', schemeName);
+      debugLog('GameState', 'Color scheme cleared:', schemeName);
     }
   }
 
@@ -656,7 +658,7 @@ class GameStateManager {
     if (!this.state.cutscenes.completed.includes(cutsceneId)) {
       this.state.cutscenes.completed.push(cutsceneId);
       this.notify();
-      console.log(`[GameState] Cutscene completed: ${cutsceneId}`);
+      debugLog('GameState', `Cutscene completed: ${cutsceneId}`);
     }
   }
 
@@ -1005,7 +1007,7 @@ class GameStateManager {
       return false;
     }
     this.state.wateringCan.currentLevel -= 1;
-    console.log(`[GameState] Water used, ${this.state.wateringCan.currentLevel} remaining`);
+    debugLog('GameState', `Water used, ${this.state.wateringCan.currentLevel} remaining`);
     this.notify();
     return true;
   }
@@ -1019,7 +1021,7 @@ class GameStateManager {
     } else {
       this.state.wateringCan.currentLevel = WATERING_CAN.CAPACITY;
     }
-    console.log('[GameState] Watering can refilled');
+    debugLog('GameState', 'Watering can refilled');
     this.notify();
   }
 
@@ -1060,7 +1062,7 @@ class GameStateManager {
       mode,
       expiresAt: Date.now() + durationMs,
     };
-    console.log(`[GameState] Movement effect set: ${mode} for ${durationMs}ms`);
+    debugLog('GameState', `Movement effect set: ${mode} for ${durationMs}ms`);
     this.saveState();
     this.notify();
   }
@@ -1070,7 +1072,7 @@ class GameStateManager {
    */
   clearMovementEffect(): void {
     if (this.state.movementEffect) {
-      console.log('[GameState] Movement effect cleared');
+      debugLog('GameState', 'Movement effect cleared');
       this.state.movementEffect = null;
       this.saveState();
       this.notify();
@@ -1140,8 +1142,9 @@ class GameStateManager {
     this.state.transformations.fairyFormExpiresAt =
       active && durationMs ? Date.now() + durationMs : null;
 
-    console.log(
-      `[GameState] Fairy form ${active ? 'activated' : 'deactivated'}${durationMs ? ` for ${durationMs}ms` : ''}`
+    debugLog(
+      'GameState',
+      `Fairy form ${active ? 'activated' : 'deactivated'}${durationMs ? ` for ${durationMs}ms` : ''}`
     );
     this.saveState();
     this.notify();
@@ -1152,7 +1155,7 @@ class GameStateManager {
    */
   clearFairyForm(): void {
     if (this.state.transformations?.isFairyForm) {
-      console.log('[GameState] Fairy form cleared');
+      debugLog('GameState', 'Fairy form cleared');
       this.state.transformations.isFairyForm = false;
       this.state.transformations.fairyFormExpiresAt = null;
       this.saveState();
@@ -1216,7 +1219,7 @@ class GameStateManager {
       playerDisguise: null,
       appliedWallpapers: {},
     };
-    console.log('[GameState] State reset');
+    debugLog('GameState', 'State reset');
     this.notify();
   }
 
@@ -1300,7 +1303,7 @@ class GameStateManager {
 
     if (removedCount > 0) {
       this.notify();
-      console.log(`[GameState] Removed ${removedCount} decayed item(s)`);
+      debugLog('GameState', `Removed ${removedCount} decayed item(s)`);
       // Emit generic update event (items could be from any map)
       eventBus.emit(GameEvent.PLACED_ITEMS_CHANGED, { mapId: '*', action: 'remove' });
     }
@@ -1528,7 +1531,7 @@ class GameStateManager {
         delete this.state.forageCooldowns[key];
       }
       this.saveState();
-      console.log(`[GameState] Cleaned up ${keysToRemove.length} expired forage cooldowns`);
+      debugLog('GameState', `Cleaned up ${keysToRemove.length} expired forage cooldowns`);
     }
   }
 
@@ -1556,7 +1559,7 @@ class GameStateManager {
         delete this.state.forageCooldowns[key];
       }
       this.saveState();
-      console.log(`[GameState] Cleared ${keysToRemove.length} forage cooldowns on map ${mapId}`);
+      debugLog('GameState', `Cleared ${keysToRemove.length} forage cooldowns on map ${mapId}`);
     }
 
     return keysToRemove.length;
@@ -1571,7 +1574,7 @@ class GameStateManager {
       const newState = JSON.parse(jsonState);
       this.state = newState;
       this.notify();
-      console.log('[GameState] State imported successfully');
+      debugLog('GameState', 'State imported successfully');
       return true;
     } catch (error) {
       console.error('[GameState] Failed to import state:', error);
@@ -1617,7 +1620,7 @@ class GameStateManager {
         stage: 0,
         data: initialData,
       };
-      console.log(`[GameState] Quest started: ${questId}`);
+      debugLog('GameState', `Quest started: ${questId}`);
       this.notify();
       eventBus.emit(GameEvent.QUEST_STARTED, { questId });
     }
@@ -1651,7 +1654,7 @@ class GameStateManager {
 
     if (this.state.quests[questId]) {
       this.state.quests[questId].completed = true;
-      console.log(`[GameState] Quest completed: ${questId}`);
+      debugLog('GameState', `Quest completed: ${questId}`);
       this.notify();
       eventBus.emit(GameEvent.QUEST_COMPLETED, { questId });
     }
@@ -1683,7 +1686,7 @@ class GameStateManager {
     if (this.state.quests[questId]) {
       const previousStage = this.state.quests[questId].stage;
       this.state.quests[questId].stage = stage;
-      console.log(`[GameState] Quest ${questId} stage set to ${stage}`);
+      debugLog('GameState', `Quest ${questId} stage set to ${stage}`);
       this.notify();
       eventBus.emit(GameEvent.QUEST_STAGE_CHANGED, { questId, stage, previousStage });
     }
@@ -1813,7 +1816,7 @@ class GameStateManager {
       expiresAt: now + durationMs,
     };
 
-    console.log(`[GameState] Potion effect activated: ${effectType} for ${durationMs}ms`);
+    debugLog('GameState', `Potion effect activated: ${effectType} for ${durationMs}ms`);
     this.saveState();
     this.notify();
   }
@@ -1853,7 +1856,7 @@ class GameStateManager {
 
     if (this.state.activePotionEffects[effectType]) {
       delete this.state.activePotionEffects[effectType];
-      console.log(`[GameState] Potion effect cleared: ${effectType}`);
+      debugLog('GameState', `Potion effect cleared: ${effectType}`);
       this.saveState();
       this.notify();
     }
@@ -1920,7 +1923,7 @@ class GameStateManager {
       for (const effectType of expiredEffects) {
         delete this.state.activePotionEffects[effectType];
       }
-      console.log(`[GameState] Cleaned up ${expiredEffects.length} expired potion effect(s)`);
+      debugLog('GameState', `Cleaned up ${expiredEffects.length} expired potion effect(s)`);
       this.saveState();
       this.notify();
     }
@@ -1943,7 +1946,7 @@ class GameStateManager {
       expiresAt: Date.now() + durationMs,
     };
 
-    console.log(`[GameState] Player disguised as ${npcName} for ${durationMs}ms`);
+    debugLog('GameState', `Player disguised as ${npcName} for ${durationMs}ms`);
     this.saveState();
     this.notify();
   }
@@ -1976,7 +1979,7 @@ class GameStateManager {
    */
   clearPlayerDisguise(): void {
     if (this.state.playerDisguise) {
-      console.log('[GameState] Player disguise cleared');
+      debugLog('GameState', 'Player disguise cleared');
       this.state.playerDisguise = null;
       this.saveState();
       this.notify();
@@ -2020,7 +2023,7 @@ class GameStateManager {
    * Replaces the current state with cloud data
    */
   loadFromCloud(cloudState: GameState): void {
-    console.log('[GameState] Loading state from cloud');
+    debugLog('GameState', 'Loading state from cloud');
 
     // Merge cloud state with any migration defaults
     this.state = {
@@ -2041,7 +2044,7 @@ class GameStateManager {
     this.saveState();
     this.notify();
 
-    console.log('[GameState] Cloud state loaded and saved to localStorage');
+    debugLog('GameState', 'Cloud state loaded and saved to localStorage');
   }
 }
 

--- a/GameStatePersistence.ts
+++ b/GameStatePersistence.ts
@@ -13,6 +13,7 @@
 import type { GameState } from './GameState';
 import { TimeManager } from './utils/TimeManager';
 import { STAMINA, WATERING_CAN } from './constants';
+import { debugLog } from './utils/debugLog';
 
 /**
  * Save schema version.
@@ -68,7 +69,7 @@ export function loadPersistedState(storageKey: string): GameState {
 
       // Migrate old save data that doesn't have player location
       if (!parsed.player) {
-        console.log('[GameState] Migrating old save data - adding player location');
+        debugLog('GameState', 'Migrating old save data - adding player location');
         parsed.player = {
           currentMapId: 'village',
           position: { x: 15, y: 25 },
@@ -77,7 +78,7 @@ export function loadPersistedState(storageKey: string): GameState {
 
       // Migrate old save data that doesn't have character customization
       if (!parsed.selectedCharacter) {
-        console.log('[GameState] No character found - will show character creator');
+        debugLog('GameState', 'No character found - will show character creator');
         parsed.selectedCharacter = null;
       }
 
@@ -102,21 +103,21 @@ export function loadPersistedState(storageKey: string): GameState {
         );
 
         if (!hasAllFields) {
-          console.log('[GameState] Character data incomplete - resetting to force re-creation');
+          debugLog('GameState', 'Character data incomplete - resetting to force re-creation');
           parsed.selectedCharacter = null;
         }
       }
 
       // Migrate old farming data structure
       if (!parsed.farming.currentTool) {
-        console.log('[GameState] Migrating old save data - adding farming tools');
+        debugLog('GameState', 'Migrating old save data - adding farming tools');
         parsed.farming.currentTool = 'hand';
         parsed.farming.selectedSeed = 'radish';
       }
 
       // Migrate old inventory structure (object to new format)
       if (parsed.inventory && !Array.isArray(parsed.inventory.items)) {
-        console.log('[GameState] Migrating old inventory format');
+        debugLog('GameState', 'Migrating old inventory format');
         const oldInventory = parsed.inventory as Record<string, number>;
         parsed.inventory = {
           items: Object.entries(oldInventory).map(([itemId, quantity]) => ({
@@ -139,7 +140,7 @@ export function loadPersistedState(storageKey: string): GameState {
       const hasHoe = parsed.inventory.tools.includes('tool_hoe');
       const hasWateringCan = parsed.inventory.tools.includes('tool_watering_can');
       if (!hasHoe || !hasWateringCan) {
-        console.log('[GameState] Migrating old save data - adding missing starter tools');
+        debugLog('GameState', 'Migrating old save data - adding missing starter tools');
         if (!hasHoe) {
           parsed.inventory.tools.push('tool_hoe');
         }
@@ -160,7 +161,7 @@ export function loadPersistedState(storageKey: string): GameState {
       );
 
       if (!hasRadishSeeds || !hasTeaLeaves || !hasWater) {
-        console.log('[GameState] Migrating old save data - adding starter items');
+        debugLog('GameState', 'Migrating old save data - adding starter items');
         if (!hasRadishSeeds) {
           parsed.inventory.items.push({ itemId: 'seed_radish', quantity: 10 });
         }
@@ -174,14 +175,14 @@ export function loadPersistedState(storageKey: string): GameState {
 
       // Migrate old save data that doesn't have weather
       if (!parsed.weather) {
-        console.log('[GameState] Migrating old save data - adding weather system');
+        debugLog('GameState', 'Migrating old save data - adding weather system');
         parsed.weather = 'clear';
       }
 
       // Migrate old save data that doesn't have automatic weather
       // Also force-enable for users who had it disabled from previous defaults
       if (parsed.automaticWeather === undefined || parsed.automaticWeather === false) {
-        console.log('[GameState] Migrating save data - enabling automatic weather');
+        debugLog('GameState', 'Migrating save data - enabling automatic weather');
         parsed.automaticWeather = true;
       }
       if (!parsed.nextWeatherCheckTime) {
@@ -190,25 +191,25 @@ export function loadPersistedState(storageKey: string): GameState {
 
       // Migrate old save data that doesn't have cutscene tracking
       if (!parsed.cutscenes) {
-        console.log('[GameState] Migrating old save data - adding cutscene tracking');
+        debugLog('GameState', 'Migrating old save data - adding cutscene tracking');
         parsed.cutscenes = { completed: [] };
       }
 
       // Migrate old save data that doesn't have weather drift speed
       if (parsed.weatherDriftSpeed === undefined) {
-        console.log('[GameState] Migrating old save data - adding weather drift speed');
+        debugLog('GameState', 'Migrating old save data - adding weather drift speed');
         parsed.weatherDriftSpeed = 1.0; // Default normal speed
       }
 
       // Migrate old save data that doesn't have relationships
       if (!parsed.relationships) {
-        console.log('[GameState] Migrating old save data - adding relationships');
+        debugLog('GameState', 'Migrating old save data - adding relationships');
         parsed.relationships = { npcFriendships: [] };
       }
 
       // Migrate old save data that doesn't have cooking
       if (!parsed.cooking) {
-        console.log('[GameState] Migrating old save data - adding cooking');
+        debugLog('GameState', 'Migrating old save data - adding cooking');
         parsed.cooking = {
           recipeBookUnlocked: false,
           unlockedRecipes: ['tea'],
@@ -217,19 +218,19 @@ export function loadPersistedState(storageKey: string): GameState {
       } else {
         // Migrate old cooking data that doesn't have recipeBookUnlocked
         if (parsed.cooking.recipeBookUnlocked === undefined) {
-          console.log('[GameState] Migrating old save data - adding recipeBookUnlocked');
+          debugLog('GameState', 'Migrating old save data - adding recipeBookUnlocked');
           parsed.cooking.recipeBookUnlocked = false;
         }
         // Ensure tea is always unlocked, even in existing saves
         if (!parsed.cooking.unlockedRecipes.includes('tea')) {
-          console.log('[GameState] Migrating old save data - ensuring tea is unlocked');
+          debugLog('GameState', 'Migrating old save data - ensuring tea is unlocked');
           parsed.cooking.unlockedRecipes.push('tea');
         }
       }
 
       // Migrate old save data that doesn't have status effects
       if (!parsed.statusEffects) {
-        console.log('[GameState] Migrating old save data - adding status effects');
+        debugLog('GameState', 'Migrating old save data - adding status effects');
         parsed.statusEffects = {
           feelingSick: false,
           stamina: STAMINA.MAX,
@@ -240,8 +241,9 @@ export function loadPersistedState(storageKey: string): GameState {
 
       // Migrate old status effects to include stamina (new session = full stamina)
       if (parsed.statusEffects.stamina === undefined) {
-        console.log(
-          '[GameState] Migrating old save data - adding stamina (full restore on session start)'
+        debugLog(
+          'GameState',
+          'Migrating old save data - adding stamina (full restore on session start)'
         );
         parsed.statusEffects.stamina = STAMINA.MAX;
         parsed.statusEffects.maxStamina = STAMINA.MAX;
@@ -251,47 +253,47 @@ export function loadPersistedState(storageKey: string): GameState {
         const timeSinceLastUpdate = Date.now() - (parsed.statusEffects.lastStaminaUpdate || 0);
 
         if (timeSinceLastUpdate >= TimeManager.MS_PER_GAME_DAY) {
-          console.log('[GameState] Offline for 2+ hours - restoring stamina to full (slept well!)');
+          debugLog('GameState', 'Offline for 2+ hours - restoring stamina to full (slept well!)');
           parsed.statusEffects.stamina = parsed.statusEffects.maxStamina || STAMINA.MAX;
         } else {
-          console.log('[GameState] Quick session resume - stamina unchanged');
+          debugLog('GameState', 'Quick session resume - stamina unchanged');
         }
         parsed.statusEffects.lastStaminaUpdate = Date.now();
       }
 
       // Migrate old save data that doesn't have placed items
       if (!parsed.placedItems) {
-        console.log('[GameState] Migrating old save data - adding placed items');
+        debugLog('GameState', 'Migrating old save data - adding placed items');
         parsed.placedItems = [];
       }
 
       // Migrate old save data that doesn't have desk contents
       if (!parsed.deskContents) {
-        console.log('[GameState] Migrating old save data - adding desk contents');
+        debugLog('GameState', 'Migrating old save data - adding desk contents');
         parsed.deskContents = [];
       }
 
       // Migrate old save data that doesn't have watering can state
       if (!parsed.wateringCan) {
-        console.log('[GameState] Migrating old save data - adding watering can');
+        debugLog('GameState', 'Migrating old save data - adding watering can');
         parsed.wateringCan = { currentLevel: WATERING_CAN.CAPACITY }; // Start with full water can
       }
 
       // Migrate old save data that doesn't have forage cooldowns
       if (!parsed.forageCooldowns) {
-        console.log('[GameState] Migrating old save data - adding forage cooldowns');
+        debugLog('GameState', 'Migrating old save data - adding forage cooldowns');
         parsed.forageCooldowns = {};
       }
 
       // Migrate old save data that doesn't have movement effect
       if (parsed.movementEffect === undefined) {
-        console.log('[GameState] Migrating old save data - adding movement effect');
+        debugLog('GameState', 'Migrating old save data - adding movement effect');
         parsed.movementEffect = null;
       }
 
       // Migrate old save data that doesn't have transformations
       if (!parsed.transformations) {
-        console.log('[GameState] Migrating old save data - adding transformations');
+        debugLog('GameState', 'Migrating old save data - adding transformations');
         parsed.transformations = {
           isFairyForm: false,
           fairyFormExpiresAt: null,
@@ -304,26 +306,26 @@ export function loadPersistedState(storageKey: string): GameState {
         parsed.transformations.fairyFormExpiresAt &&
         parsed.transformations.fairyFormExpiresAt <= Date.now()
       ) {
-        console.log('[GameState] Clearing expired fairy form on load');
+        debugLog('GameState', 'Clearing expired fairy form on load');
         parsed.transformations.isFairyForm = false;
         parsed.transformations.fairyFormExpiresAt = null;
       }
 
       // Clear expired movement effects on load
       if (parsed.movementEffect && parsed.movementEffect.expiresAt <= Date.now()) {
-        console.log('[GameState] Clearing expired movement effect on load');
+        debugLog('GameState', 'Clearing expired movement effect on load');
         parsed.movementEffect = null;
       }
 
       // Migrate old save data that doesn't have quest tracking
       if (!parsed.quests) {
-        console.log('[GameState] Migrating old save data - adding quest tracking');
+        debugLog('GameState', 'Migrating old save data - adding quest tracking');
         parsed.quests = {};
       }
 
       // Migrate old save data that doesn't have active potion effects
       if (!parsed.activePotionEffects) {
-        console.log('[GameState] Migrating old save data - adding active potion effects');
+        debugLog('GameState', 'Migrating old save data - adding active potion effects');
         parsed.activePotionEffects = {};
       }
 
@@ -331,20 +333,20 @@ export function loadPersistedState(storageKey: string): GameState {
       const now = Date.now();
       for (const effectType of Object.keys(parsed.activePotionEffects)) {
         if (parsed.activePotionEffects[effectType].expiresAt <= now) {
-          console.log(`[GameState] Clearing expired potion effect: ${effectType}`);
+          debugLog('GameState', `Clearing expired potion effect: ${effectType}`);
           delete parsed.activePotionEffects[effectType];
         }
       }
 
       // Migrate old save data that doesn't have player disguise
       if (parsed.playerDisguise === undefined) {
-        console.log('[GameState] Migrating old save data - adding player disguise');
+        debugLog('GameState', 'Migrating old save data - adding player disguise');
         parsed.playerDisguise = null;
       }
 
       // Clear expired disguise on load
       if (parsed.playerDisguise && parsed.playerDisguise.expiresAt <= now) {
-        console.log('[GameState] Clearing expired player disguise on load');
+        debugLog('GameState', 'Clearing expired player disguise on load');
         parsed.playerDisguise = null;
       }
 

--- a/docs/PENDING_CLEANUP.md
+++ b/docs/PENDING_CLEANUP.md
@@ -71,14 +71,16 @@ count honest afterwards.
 **Migration recipe** (see `utils/dialogueHandlers.ts` for the worked example —
 39 sites, one codemod + hand-fixed multi-line forms):
 
-1. Per file: `console.log('[Prefix] ...')` → `debugLog('Prefix', ...)` (prefix
-   moves out of the string into the first argument; output looks identical).
-2. Drop any `if (DEBUG.X)` guards wrapping the logs — `DEBUG.QUEST`-style flags
-   are hardcoded `import.meta.env.DEV && false` (never on); the category flag
-   revives these diagnostics behind `?debug=<category>`.
+1. Run `node scripts/convert-debug-log.mjs <files...>` — it rewrites
+   `console.log('[Tag] ...')` → `debugLog('Tag', ...)` (prefix moves out of the
+   string into the first argument; output looks identical), handles multi-line
+   calls, and unwraps dead `if (DEBUG.X)` guards. Live `DEBUG.MULTIPLAYER`
+   guards are kept by default (extend via `--keep-guards=`). Anything needing
+   judgement is reported as `MANUAL file:line` and left untouched.
+2. Review the diff — promote anything a player genuinely needs to
+   `console.warn` (ungated); routine traces stay gated `debugLog`.
 3. Add the file to the eslint `no-console` override list.
-4. Per category, sanity-check intent: diagnostics → gated `debugLog`; anything
-   a player genuinely needs → keep/convert to `console.warn` (ungated).
+4. `npm run verify` + prettier, then commit.
 
 **Remaining inventory** (console.log counts on main after the merge): GameState.ts ~43,
 GameStatePersistence.ts ~32, farmManager.ts ~31, FriendshipManager.ts ~30,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,7 +66,12 @@ export default tseslint.config(
   // console.error stay permitted everywhere — they carry player-relevant
   // failure diagnostics and are deliberately ungated.
   {
-    files: ['utils/debugLog.ts', 'utils/dialogueHandlers.ts'],
+    files: [
+      'utils/debugLog.ts',
+      'utils/dialogueHandlers.ts',
+      'GameState.ts',
+      'GameStatePersistence.ts',
+    ],
     rules: {
       'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
     },

--- a/scripts/convert-debug-log.mjs
+++ b/scripts/convert-debug-log.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * Codemod for §2 of docs/PENDING_CLEANUP.md: convert bare console.log calls
+ * to the category-gated debugLog helper (utils/debugLog.ts).
+ *
+ *   node scripts/convert-debug-log.mjs <file...> [--keep-guards=FLAG,FLAG]
+ *
+ * What it does per call site:
+ *   console.log('[Tag] msg', extra)      → debugLog('Tag', 'msg', extra)
+ *   console.log(`[Tag] msg ${x}`)        → debugLog('Tag', `msg ${x}`)
+ *   console.log(                         → debugLog(
+ *     '[Tag] msg',                             'Tag',
+ *     extra                                    'msg',
+ *   );                                         extra,
+ *                                            );
+ *   if (DEBUG.X) console.log(...)        → debugLog(...)   (dead guards only)
+ *
+ * Dead-guard unwrapping: DEBUG.* flags in constants.ts are hardcoded
+ * `import.meta.env.DEV && false` — those logs are unreachable, and the
+ * category flag revives them behind ?debug=<tag>. Live flags (default:
+ * DEBUG.MULTIPLAYER, which uses runtimeDebug) keep their guards; only the
+ * inner call is converted.
+ *
+ * Deliberately left for manual triage (reported with line numbers):
+ *   - calls whose first argument is not a string/template literal
+ *   - calls where the [Tag] prefix is not at the very start of the message
+ *   - calls with no [Tag] prefix at all
+ *   - `if (DEBUG.X) { ... }` blocks (may contain more than the log)
+ *
+ * The script never edits console.warn / console.error / console.debug.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const argv = process.argv.slice(2);
+const keepGuardFlags = new Set(['MULTIPLAYER']);
+const files = [];
+
+for (const a of argv) {
+  if (a.startsWith('--keep-guards=')) {
+    for (const f of a.slice('--keep-guards='.length).split(',')) {
+      if (f) keepGuardFlags.add(f.trim().toUpperCase());
+    }
+  } else {
+    files.push(a);
+  }
+}
+
+if (files.length === 0) {
+  console.error('usage: node scripts/convert-debug-log.mjs <file...> [--keep-guards=FLAG,FLAG]');
+  process.exit(1);
+}
+
+const CALL_RE = /\bconsole\.(?:log|info)\(/g;
+
+/** Walk from an opening paren to its matching close, respecting strings,
+ *  template literals (incl. nested ${}), comments and nesting. */
+function findMatchingParen(text, openIdx) {
+  let depth = 0;
+  let i = openIdx;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === '/' && text[i + 1] === '/') {
+      while (i < text.length && text[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '/' && text[i + 1] === '*') {
+      const end = text.indexOf('*/', i + 2);
+      i = end === -1 ? text.length : end + 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipString(text, i, ch);
+      continue;
+    }
+    if (ch === '`') {
+      i = skipTemplate(text, i);
+      continue;
+    }
+    if (ch === '(') depth++;
+    if (ch === ')') {
+      depth--;
+      if (depth === 0) return i;
+    }
+    i++;
+  }
+  return -1;
+}
+
+function skipString(text, start, quote) {
+  let i = start + 1;
+  while (i < text.length) {
+    if (text[i] === '\\') {
+      i += 2;
+      continue;
+    }
+    if (text[i] === quote) return i + 1;
+    if (text[i] === '\n') return i; // unterminated; bail
+    i++;
+  }
+  return i;
+}
+
+function skipTemplate(text, start) {
+  let i = start + 1;
+  while (i < text.length) {
+    if (text[i] === '\\') {
+      i += 2;
+      continue;
+    }
+    if (text[i] === '`') return i + 1;
+    if (text[i] === '$' && text[i + 1] === '{') {
+      let braceDepth = 1;
+      i += 2;
+      while (i < text.length && braceDepth > 0) {
+        if (text[i] === '{') braceDepth++;
+        else if (text[i] === '}') braceDepth--;
+        else if (text[i] === '"' || text[i] === "'") {
+          i = skipString(text, i, text[i]);
+          continue;
+        } else if (text[i] === '`') {
+          i = skipTemplate(text, i);
+          continue;
+        }
+        i++;
+      }
+      continue;
+    }
+    i++;
+  }
+  return i;
+}
+
+/** Split text[from..to) on top-level commas. */
+function splitArgs(text, from, to) {
+  const parts = [];
+  let depth = 0;
+  let start = from;
+  let i = from;
+  while (i < to) {
+    const ch = text[i];
+    if (ch === '/' && text[i + 1] === '/') {
+      while (i < to && text[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '/' && text[i + 1] === '*') {
+      const end = text.indexOf('*/', i + 2);
+      i = end === -1 ? to : end + 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipString(text, i, ch);
+      continue;
+    }
+    if (ch === '`') {
+      i = skipTemplate(text, i);
+      continue;
+    }
+    if ('([{'.includes(ch)) depth++;
+    else if (')]}'.includes(ch)) depth--;
+    else if (ch === ',' && depth === 0) {
+      parts.push({ start, end: i });
+      start = i + 1;
+    }
+    i++;
+  }
+  parts.push({ start, end: to });
+  return parts;
+}
+
+const PREFIX_RE = /^\s*\[([A-Za-z0-9 _-]+)\]\s*:?\s*/;
+
+/** Build the debugLog(...) replacement for one call, or null if the site
+ *  needs manual attention. */
+function buildReplacement(text, nameStart, closeIdx) {
+  const openIdx = text.indexOf('(', nameStart);
+  const args = splitArgs(text, openIdx + 1, closeIdx);
+  if (args.length === 0) return null;
+
+  const first = args[0];
+  const argText = text.slice(first.start, first.end).trim();
+
+  const quote = argText[0];
+  if (quote !== "'" && quote !== '"' && quote !== '`') return null;
+  if (!argText.endsWith(quote)) return null;
+  const inner = argText.slice(1, -1);
+  const m = inner.match(PREFIX_RE);
+  if (!m) return null;
+
+  const tag = m[1];
+  const rest = inner.slice(m[0].length);
+
+  const pieces = [];
+  if (rest.length > 0) pieces.push(quote + rest + quote);
+  for (const a of args.slice(1)) {
+    const t = text.slice(a.start, a.end).trim();
+    if (t.length > 0) pieces.push(t);
+  }
+
+  return pieces.length === 0 ? `debugLog('${tag}')` : `debugLog('${tag}', ${pieces.join(', ')})`;
+}
+
+function lineOf(text, idx) {
+  return text.slice(0, idx).split('\n').length;
+}
+
+function insertDebugLogImport(text, file) {
+  if (/import\s*\{[^}]*debugLog[^}]*\}\s*from/.test(text)) return text;
+  const rel =
+    path.relative(path.dirname(file), path.resolve('utils/debugLog.ts')).replace(/\.ts$/, '') ||
+    './debugLog';
+  const importLine = `import { debugLog } from '${rel.startsWith('.') ? rel : './' + rel}';`;
+
+  const lines = text.split('\n');
+  let insertAt = -1; // index of the END of the last import statement
+  let i = 0;
+  while (i < lines.length) {
+    if (/^import\s/.test(lines[i])) {
+      // advance to the line that closes this import
+      while (i < lines.length && !/from\s+'[^']*';/.test(lines[i])) i++;
+      if (i >= lines.length) break;
+      insertAt = i;
+    } else if (/^\S/.test(lines[i]) && !lines[i].startsWith('//') && !lines[i].startsWith('/*')) {
+      if (insertAt !== -1) break; // first non-import code line: stop
+    }
+    i++;
+  }
+  lines.splice(insertAt + 1, 0, importLine);
+  return lines.join('\n');
+}
+
+let totalConverted = 0;
+let totalGuards = 0;
+
+for (const file of files) {
+  let text = fs.readFileSync(file, 'utf8');
+
+  // --- Pass 1: unwrap dead `if (DEBUG.X)` guards. ---
+  let guards = 0;
+  text = text.replace(
+    /^[ \t]*if \(DEBUG\.([A-Za-z0-9_]+)\)[ \t]*\n[ \t]*console\.(log|info)\(/gm,
+    (match, flag, call) => {
+      if (keepGuardFlags.has(flag.toUpperCase())) return match;
+      guards++;
+      return `console.${call}(`;
+    }
+  );
+  text = text.replace(/if \(DEBUG\.([A-Za-z0-9_]+)\) console\.(log|info)\(/g, (match, flag, call) => {
+    if (keepGuardFlags.has(flag.toUpperCase())) return match;
+    guards++;
+    return `console.${call}(`;
+  });
+
+  // --- Pass 2: rewrite calls right-to-left so offsets stay stable. ---
+  const manual = [];
+  let converted = 0;
+  for (;;) {
+    // find the last convertible call site in the current text
+    let best = -1;
+    let m;
+    CALL_RE.lastIndex = 0;
+    while ((m = CALL_RE.exec(text)) !== null) {
+      const lineStart = text.lastIndexOf('\n', m.index) + 1;
+      const before = text.slice(lineStart, m.index);
+      if (before.includes('//') || before.includes('*')) continue; // comment line
+      best = m.index;
+    }
+    if (best === -1) break;
+
+    const openIdx = text.indexOf('(', best);
+    const closeIdx = findMatchingParen(text, openIdx);
+    if (closeIdx === -1) {
+      manual.push({ line: lineOf(text, best), reason: 'unbalanced paren', snippet: '' });
+      text = text.slice(0, best) + 'c0ns0le' + text.slice(best + 'console'.length);
+      continue;
+    }
+
+    const replacement = buildReplacement(text, best, closeIdx);
+    if (!replacement) {
+      const firstArg = text
+        .slice(openIdx + 1, closeIdx)
+        .trim()
+        .split('\n')[0]
+        .slice(0, 70);
+      manual.push({ line: lineOf(text, best), reason: 'manual', snippet: firstArg });
+      text = text.slice(0, best) + 'c0ns0le' + text.slice(best + 'console'.length);
+      continue;
+    }
+
+    text = text.slice(0, best) + replacement + text.slice(closeIdx + 1);
+    converted++;
+  }
+  text = text.replace(/c0ns0le/g, 'console');
+
+  if (converted === 0 && guards === 0) {
+    console.log(`${file}: nothing to do`);
+    continue;
+  }
+
+  if (converted > 0) text = insertDebugLogImport(text, file);
+
+  fs.writeFileSync(file, text);
+
+  console.log(`${file}: ${converted} converted, ${guards} guards unwrapped`);
+  totalConverted += converted;
+  totalGuards += guards;
+  for (const mm of manual) {
+    console.log(`  MANUAL ${file}:${mm.line} ${mm.reason} :: ${mm.snippet}`);
+  }
+}
+
+console.log(`\ntotal: ${totalConverted} converted, ${totalGuards} guards unwrapped`);


### PR DESCRIPTION
## Summary

Continues §2 of `docs/PENDING_CLEANUP.md` with the save/state core: **75 sites** (GameState.ts 43, GameStatePersistence.ts 32) move from bare `console.log` to the category-gated helper from #84.

- All are routine traces — gold/depth changes, save migrations, state resets — so they gate under `gamestate` (GameStatePersistence keeps the existing `[GameState]` tag for its migration lines, exactly as printed today). Genuine failure paths in these modules already used `console.warn`/`error` and stay ungated.
- Both files join the eslint `no-console` override list.

### New: `scripts/convert-debug-log.mjs`

The conversion codemod, now part of the §2 recipe for the remaining ~500 sites:

- Rewrites `console.log('[Tag] ...')` → `debugLog('Tag', ...)` — single-line strings, templates, and multi-line calls, with a nesting/string/comment-aware scanner
- Unwraps dead `if (DEBUG.X)` guards (hardcoded `DEV \&\& false` flags); live `DEBUG.MULTIPLAYER` guards kept by default (`--keep-guards=` to extend)
- Reports anything needing judgement as `MANUAL file:line` and leaves it untouched (non-literal first args, missing/mid-string prefixes, concatenation forms)

Validated on a scratch file covering all shapes before touching source.

## Verification

- `npm run verify`: tsc clean, 885/885 tests
- `npx eslint .`: 0 errors, 0 warnings