### PR TITLE
Gate farmManager, FriendshipManager and actionHandlers logging behind debugLog

### DIFF
--- a/GameState.ts
+++ b/GameState.ts
@@ -18,6 +18,7 @@ import { eventBus, GameEvent } from './utils/EventBus';
 import { sharedPlacedItemsManager } from './multiplayer/sharedPlacedItems';
 import { eventChainManager } from './utils/EventChainManager';
 import { loadPersistedState, SAVE_VERSION } from './GameStatePersistence';
+import { debugLog } from './utils/debugLog';
 export { runSaveMigrations, SAVE_VERSION } from './GameStatePersistence';
 
 export interface CharacterCustomization {
@@ -327,7 +328,7 @@ class GameStateManager {
 
   selectCharacter(character: CharacterCustomization): void {
     this.state.selectedCharacter = character;
-    console.log(`[GameState] Character selected: ${character.name}`);
+    debugLog('GameState', `Character selected: ${character.name}`);
     this.notify();
   }
 
@@ -343,14 +344,14 @@ class GameStateManager {
 
   addGold(amount: number): void {
     this.state.gold += amount;
-    console.log(`[GameState] +${amount} gold (total: ${this.state.gold})`);
+    debugLog('GameState', `+${amount} gold (total: ${this.state.gold})`);
     this.notify();
   }
 
   spendGold(amount: number): boolean {
     if (this.state.gold >= amount) {
       this.state.gold -= amount;
-      console.log(`[GameState] -${amount} gold (total: ${this.state.gold})`);
+      debugLog('GameState', `-${amount} gold (total: ${this.state.gold})`);
       this.notify();
       return true;
     }
@@ -361,28 +362,28 @@ class GameStateManager {
 
   enterForest(): void {
     this.state.forestDepth += 1;
-    console.log(`[GameState] Entered forest depth ${this.state.forestDepth}`);
+    debugLog('GameState', `Entered forest depth ${this.state.forestDepth}`);
     this.notify();
   }
 
   exitForest(): void {
     if (this.state.forestDepth > 0) {
       this.state.forestDepth -= 1;
-      console.log(`[GameState] Exited forest, now at depth ${this.state.forestDepth}`);
+      debugLog('GameState', `Exited forest, now at depth ${this.state.forestDepth}`);
       this.notify();
     }
   }
 
   enterCave(): void {
     this.state.caveDepth += 1;
-    console.log(`[GameState] Entered cave depth ${this.state.caveDepth}`);
+    debugLog('GameState', `Entered cave depth ${this.state.caveDepth}`);
     this.notify();
   }
 
   exitCave(): void {
     if (this.state.caveDepth > 0) {
       this.state.caveDepth -= 1;
-      console.log(`[GameState] Exited cave, now at depth ${this.state.caveDepth}`);
+      debugLog('GameState', `Exited cave, now at depth ${this.state.caveDepth}`);
       this.notify();
     }
   }
@@ -407,14 +408,14 @@ class GameStateManager {
 
   enterLava(): void {
     this.state.lavaDepth += 1;
-    console.log(`[GameState] Entered lava depth ${this.state.lavaDepth}`);
+    debugLog('GameState', `Entered lava depth ${this.state.lavaDepth}`);
     this.notify();
   }
 
   exitLava(): void {
     if (this.state.lavaDepth > 0) {
       this.state.lavaDepth -= 1;
-      console.log(`[GameState] Exited lava, now at depth ${this.state.lavaDepth}`);
+      debugLog('GameState', `Exited lava, now at depth ${this.state.lavaDepth}`);
       this.notify();
     }
   }
@@ -430,8 +431,9 @@ class GameStateManager {
 
   revealLavaEntrance(caveMapId: string, position: { x: number; y: number }): void {
     this.state.revealedLavaEntrances[caveMapId] = position;
-    console.log(
-      `[GameState] Revealed lava entrance on ${caveMapId} at (${position.x}, ${position.y})`
+    debugLog(
+      'GameState',
+      `Revealed lava entrance on ${caveMapId} at (${position.x}, ${position.y})`
     );
     this.notify();
   }
@@ -463,7 +465,7 @@ class GameStateManager {
     this.state.player.position = { x: 15, y: 25 };
     this.state.forestDepth = 0;
     this.state.caveDepth = 0;
-    console.log('[GameState] Player respawned at village');
+    debugLog('GameState', 'Player respawned at village');
     this.notify();
   }
 
@@ -497,7 +499,7 @@ class GameStateManager {
     this.state.inventory.items = [];
     this.state.inventory.tools = [];
     this.notify();
-    console.log('[GameState] Inventory cleared - will reload starter items on next refresh');
+    debugLog('GameState', 'Inventory cleared - will reload starter items on next refresh');
   }
 
   // === Crafting Methods ===
@@ -505,7 +507,7 @@ class GameStateManager {
   unlockRecipe(recipeId: string): void {
     if (!this.state.crafting.unlockedRecipes.includes(recipeId)) {
       this.state.crafting.unlockedRecipes.push(recipeId);
-      console.log(`[GameState] Unlocked recipe: ${recipeId}`);
+      debugLog('GameState', `Unlocked recipe: ${recipeId}`);
       this.notify();
     }
   }
@@ -517,7 +519,7 @@ class GameStateManager {
   addMaterial(materialId: string, quantity: number): void {
     this.state.crafting.materials[materialId] =
       (this.state.crafting.materials[materialId] || 0) + quantity;
-    console.log(`[GameState] +${quantity} ${materialId} material`);
+    debugLog('GameState', `+${quantity} ${materialId} material`);
     this.notify();
   }
 
@@ -534,7 +536,7 @@ class GameStateManager {
 
   setFarmingTool(tool: 'hoe' | 'seeds' | 'wateringCan' | 'hand'): void {
     this.state.farming.currentTool = tool;
-    console.log(`[GameState] Switched to ${tool}`);
+    debugLog('GameState', `Switched to ${tool}`);
     this.notify();
   }
 
@@ -545,7 +547,7 @@ class GameStateManager {
   setSelectedSeed(seedId: string | null): void {
     this.state.farming.selectedSeed = seedId;
     if (seedId) {
-      console.log(`[GameState] Selected seed: ${seedId}`);
+      debugLog('GameState', `Selected seed: ${seedId}`);
     }
     this.notify();
   }
@@ -567,7 +569,7 @@ class GameStateManager {
   saveCustomColors(colors: Record<string, string>): void {
     this.state.customColors = colors;
     this.notify();
-    console.log('[GameState] Custom colors saved:', Object.keys(colors).length, 'colors');
+    debugLog('GameState', 'Custom colors saved:', Object.keys(colors).length, 'colors');
   }
 
   loadCustomColors(): Record<string, string> | undefined {
@@ -581,7 +583,7 @@ class GameStateManager {
   clearCustomColors(): void {
     this.state.customColors = undefined;
     this.notify();
-    console.log('[GameState] Custom colors cleared');
+    debugLog('GameState', 'Custom colors cleared');
   }
 
   // Color scheme management
@@ -591,7 +593,7 @@ class GameStateManager {
     }
     this.state.customColorSchemes[scheme.name] = scheme;
     this.notify();
-    console.log('[GameState] Color scheme saved:', scheme.name);
+    debugLog('GameState', 'Color scheme saved:', scheme.name);
   }
 
   loadColorSchemes(): Record<string, ColorScheme> | undefined {
@@ -601,14 +603,14 @@ class GameStateManager {
   clearColorSchemes(): void {
     this.state.customColorSchemes = undefined;
     this.notify();
-    console.log('[GameState] Color schemes cleared');
+    debugLog('GameState', 'Color schemes cleared');
   }
 
   clearColorScheme(schemeName: string): void {
     if (this.state.customColorSchemes && this.state.customColorSchemes[schemeName]) {
       delete this.state.customColorSchemes[schemeName];
       this.notify();
-      console.log('[GameState] Color scheme cleared:', schemeName);
+      debugLog('GameState', 'Color scheme cleared:', schemeName);
     }
   }
 
@@ -656,7 +658,7 @@ class GameStateManager {
     if (!this.state.cutscenes.completed.includes(cutsceneId)) {
       this.state.cutscenes.completed.push(cutsceneId);
       this.notify();
-      console.log(`[GameState] Cutscene completed: ${cutsceneId}`);
+      debugLog('GameState', `Cutscene completed: ${cutsceneId}`);
     }
   }
 
@@ -1005,7 +1007,7 @@ class GameStateManager {
       return false;
     }
     this.state.wateringCan.currentLevel -= 1;
-    console.log(`[GameState] Water used, ${this.state.wateringCan.currentLevel} remaining`);
+    debugLog('GameState', `Water used, ${this.state.wateringCan.currentLevel} remaining`);
     this.notify();
     return true;
   }
@@ -1019,7 +1021,7 @@ class GameStateManager {
     } else {
       this.state.wateringCan.currentLevel = WATERING_CAN.CAPACITY;
     }
-    console.log('[GameState] Watering can refilled');
+    debugLog('GameState', 'Watering can refilled');
     this.notify();
   }
 
@@ -1060,7 +1062,7 @@ class GameStateManager {
       mode,
       expiresAt: Date.now() + durationMs,
     };
-    console.log(`[GameState] Movement effect set: ${mode} for ${durationMs}ms`);
+    debugLog('GameState', `Movement effect set: ${mode} for ${durationMs}ms`);
     this.saveState();
     this.notify();
   }
@@ -1070,7 +1072,7 @@ class GameStateManager {
    */
   clearMovementEffect(): void {
     if (this.state.movementEffect) {
-      console.log('[GameState] Movement effect cleared');
+      debugLog('GameState', 'Movement effect cleared');
       this.state.movementEffect = null;
       this.saveState();
       this.notify();
@@ -1140,8 +1142,9 @@ class GameStateManager {
     this.state.transformations.fairyFormExpiresAt =
       active && durationMs ? Date.now() + durationMs : null;
 
-    console.log(
-      `[GameState] Fairy form ${active ? 'activated' : 'deactivated'}${durationMs ? ` for ${durationMs}ms` : ''}`
+    debugLog(
+      'GameState',
+      `Fairy form ${active ? 'activated' : 'deactivated'}${durationMs ? ` for ${durationMs}ms` : ''}`
     );
     this.saveState();
     this.notify();
@@ -1152,7 +1155,7 @@ class GameStateManager {
    */
   clearFairyForm(): void {
     if (this.state.transformations?.isFairyForm) {
-      console.log('[GameState] Fairy form cleared');
+      debugLog('GameState', 'Fairy form cleared');
       this.state.transformations.isFairyForm = false;
       this.state.transformations.fairyFormExpiresAt = null;
       this.saveState();
@@ -1216,7 +1219,7 @@ class GameStateManager {
       playerDisguise: null,
       appliedWallpapers: {},
     };
-    console.log('[GameState] State reset');
+    debugLog('GameState', 'State reset');
     this.notify();
   }
 
@@ -1300,7 +1303,7 @@ class GameStateManager {
 
     if (removedCount > 0) {
       this.notify();
-      console.log(`[GameState] Removed ${removedCount} decayed item(s)`);
+      debugLog('GameState', `Removed ${removedCount} decayed item(s)`);
       // Emit generic update event (items could be from any map)
       eventBus.emit(GameEvent.PLACED_ITEMS_CHANGED, { mapId: '*', action: 'remove' });
     }
@@ -1528,7 +1531,7 @@ class GameStateManager {
         delete this.state.forageCooldowns[key];
       }
       this.saveState();
-      console.log(`[GameState] Cleaned up ${keysToRemove.length} expired forage cooldowns`);
+      debugLog('GameState', `Cleaned up ${keysToRemove.length} expired forage cooldowns`);
     }
   }
 
@@ -1556,7 +1559,7 @@ class GameStateManager {
         delete this.state.forageCooldowns[key];
       }
       this.saveState();
-      console.log(`[GameState] Cleared ${keysToRemove.length} forage cooldowns on map ${mapId}`);
+      debugLog('GameState', `Cleared ${keysToRemove.length} forage cooldowns on map ${mapId}`);
     }
 
     return keysToRemove.length;
@@ -1571,7 +1574,7 @@ class GameStateManager {
       const newState = JSON.parse(jsonState);
       this.state = newState;
       this.notify();
-      console.log('[GameState] State imported successfully');
+      debugLog('GameState', 'State imported successfully');
       return true;
     } catch (error) {
       console.error('[GameState] Failed to import state:', error);
@@ -1617,7 +1620,7 @@ class GameStateManager {
         stage: 0,
         data: initialData,
       };
-      console.log(`[GameState] Quest started: ${questId}`);
+      debugLog('GameState', `Quest started: ${questId}`);
       this.notify();
       eventBus.emit(GameEvent.QUEST_STARTED, { questId });
     }
@@ -1651,7 +1654,7 @@ class GameStateManager {
 
     if (this.state.quests[questId]) {
       this.state.quests[questId].completed = true;
-      console.log(`[GameState] Quest completed: ${questId}`);
+      debugLog('GameState', `Quest completed: ${questId}`);
       this.notify();
       eventBus.emit(GameEvent.QUEST_COMPLETED, { questId });
     }
@@ -1683,7 +1686,7 @@ class GameStateManager {
     if (this.state.quests[questId]) {
       const previousStage = this.state.quests[questId].stage;
       this.state.quests[questId].stage = stage;
-      console.log(`[GameState] Quest ${questId} stage set to ${stage}`);
+      debugLog('GameState', `Quest ${questId} stage set to ${stage}`);
       this.notify();
       eventBus.emit(GameEvent.QUEST_STAGE_CHANGED, { questId, stage, previousStage });
     }
@@ -1813,7 +1816,7 @@ class GameStateManager {
       expiresAt: now + durationMs,
     };
 
-    console.log(`[GameState] Potion effect activated: ${effectType} for ${durationMs}ms`);
+    debugLog('GameState', `Potion effect activated: ${effectType} for ${durationMs}ms`);
     this.saveState();
     this.notify();
   }
@@ -1853,7 +1856,7 @@ class GameStateManager {
 
     if (this.state.activePotionEffects[effectType]) {
       delete this.state.activePotionEffects[effectType];
-      console.log(`[GameState] Potion effect cleared: ${effectType}`);
+      debugLog('GameState', `Potion effect cleared: ${effectType}`);
       this.saveState();
       this.notify();
     }
@@ -1920,7 +1923,7 @@ class GameStateManager {
       for (const effectType of expiredEffects) {
         delete this.state.activePotionEffects[effectType];
       }
-      console.log(`[GameState] Cleaned up ${expiredEffects.length} expired potion effect(s)`);
+      debugLog('GameState', `Cleaned up ${expiredEffects.length} expired potion effect(s)`);
       this.saveState();
       this.notify();
     }
@@ -1943,7 +1946,7 @@ class GameStateManager {
       expiresAt: Date.now() + durationMs,
     };
 
-    console.log(`[GameState] Player disguised as ${npcName} for ${durationMs}ms`);
+    debugLog('GameState', `Player disguised as ${npcName} for ${durationMs}ms`);
     this.saveState();
     this.notify();
   }
@@ -1976,7 +1979,7 @@ class GameStateManager {
    */
   clearPlayerDisguise(): void {
     if (this.state.playerDisguise) {
-      console.log('[GameState] Player disguise cleared');
+      debugLog('GameState', 'Player disguise cleared');
       this.state.playerDisguise = null;
       this.saveState();
       this.notify();
@@ -2020,7 +2023,7 @@ class GameStateManager {
    * Replaces the current state with cloud data
    */
   loadFromCloud(cloudState: GameState): void {
-    console.log('[GameState] Loading state from cloud');
+    debugLog('GameState', 'Loading state from cloud');
 
     // Merge cloud state with any migration defaults
     this.state = {
@@ -2041,7 +2044,7 @@ class GameStateManager {
     this.saveState();
     this.notify();
 
-    console.log('[GameState] Cloud state loaded and saved to localStorage');
+    debugLog('GameState', 'Cloud state loaded and saved to localStorage');
   }
 }
 

--- a/GameStatePersistence.ts
+++ b/GameStatePersistence.ts
@@ -13,6 +13,7 @@
 import type { GameState } from './GameState';
 import { TimeManager } from './utils/TimeManager';
 import { STAMINA, WATERING_CAN } from './constants';
+import { debugLog } from './utils/debugLog';
 
 /**
  * Save schema version.
@@ -68,7 +69,7 @@ export function loadPersistedState(storageKey: string): GameState {
 
       // Migrate old save data that doesn't have player location
       if (!parsed.player) {
-        console.log('[GameState] Migrating old save data - adding player location');
+        debugLog('GameState', 'Migrating old save data - adding player location');
         parsed.player = {
           currentMapId: 'village',
           position: { x: 15, y: 25 },
@@ -77,7 +78,7 @@ export function loadPersistedState(storageKey: string): GameState {
 
       // Migrate old save data that doesn't have character customization
       if (!parsed.selectedCharacter) {
-        console.log('[GameState] No character found - will show character creator');
+        debugLog('GameState', 'No character found - will show character creator');
         parsed.selectedCharacter = null;
       }
 
@@ -102,21 +103,21 @@ export function loadPersistedState(storageKey: string): GameState {
         );
 
         if (!hasAllFields) {
-          console.log('[GameState] Character data incomplete - resetting to force re-creation');
+          debugLog('GameState', 'Character data incomplete - resetting to force re-creation');
           parsed.selectedCharacter = null;
         }
       }
 
       // Migrate old farming data structure
       if (!parsed.farming.currentTool) {
-        console.log('[GameState] Migrating old save data - adding farming tools');
+        debugLog('GameState', 'Migrating old save data - adding farming tools');
         parsed.farming.currentTool = 'hand';
         parsed.farming.selectedSeed = 'radish';
       }
 
       // Migrate old inventory structure (object to new format)
       if (parsed.inventory && !Array.isArray(parsed.inventory.items)) {
-        console.log('[GameState] Migrating old inventory format');
+        debugLog('GameState', 'Migrating old inventory format');
         const oldInventory = parsed.inventory as Record<string, number>;
         parsed.inventory = {
           items: Object.entries(oldInventory).map(([itemId, quantity]) => ({
@@ -139,7 +140,7 @@ export function loadPersistedState(storageKey: string): GameState {
       const hasHoe = parsed.inventory.tools.includes('tool_hoe');
       const hasWateringCan = parsed.inventory.tools.includes('tool_watering_can');
       if (!hasHoe || !hasWateringCan) {
-        console.log('[GameState] Migrating old save data - adding missing starter tools');
+        debugLog('GameState', 'Migrating old save data - adding missing starter tools');
         if (!hasHoe) {
           parsed.inventory.tools.push('tool_hoe');
         }
@@ -160,7 +161,7 @@ export function loadPersistedState(storageKey: string): GameState {
       );
 
       if (!hasRadishSeeds || !hasTeaLeaves || !hasWater) {
-        console.log('[GameState] Migrating old save data - adding starter items');
+        debugLog('GameState', 'Migrating old save data - adding starter items');
         if (!hasRadishSeeds) {
           parsed.inventory.items.push({ itemId: 'seed_radish', quantity: 10 });
         }
@@ -174,14 +175,14 @@ export function loadPersistedState(storageKey: string): GameState {
 
       // Migrate old save data that doesn't have weather
       if (!parsed.weather) {
-        console.log('[GameState] Migrating old save data - adding weather system');
+        debugLog('GameState', 'Migrating old save data - adding weather system');
         parsed.weather = 'clear';
       }
 
       // Migrate old save data that doesn't have automatic weather
       // Also force-enable for users who had it disabled from previous defaults
       if (parsed.automaticWeather === undefined || parsed.automaticWeather === false) {
-        console.log('[GameState] Migrating save data - enabling automatic weather');
+        debugLog('GameState', 'Migrating save data - enabling automatic weather');
         parsed.automaticWeather = true;
       }
       if (!parsed.nextWeatherCheckTime) {
@@ -190,25 +191,25 @@ export function loadPersistedState(storageKey: string): GameState {
 
       // Migrate old save data that doesn't have cutscene tracking
       if (!parsed.cutscenes) {
-        console.log('[GameState] Migrating old save data - adding cutscene tracking');
+        debugLog('GameState', 'Migrating old save data - adding cutscene tracking');
         parsed.cutscenes = { completed: [] };
       }
 
       // Migrate old save data that doesn't have weather drift speed
       if (parsed.weatherDriftSpeed === undefined) {
-        console.log('[GameState] Migrating old save data - adding weather drift speed');
+        debugLog('GameState', 'Migrating old save data - adding weather drift speed');
         parsed.weatherDriftSpeed = 1.0; // Default normal speed
       }
 
       // Migrate old save data that doesn't have relationships
       if (!parsed.relationships) {
-        console.log('[GameState] Migrating old save data - adding relationships');
+        debugLog('GameState', 'Migrating old save data - adding relationships');
         parsed.relationships = { npcFriendships: [] };
       }
 
       // Migrate old save data that doesn't have cooking
       if (!parsed.cooking) {
-        console.log('[GameState] Migrating old save data - adding cooking');
+        debugLog('GameState', 'Migrating old save data - adding cooking');
         parsed.cooking = {
           recipeBookUnlocked: false,
           unlockedRecipes: ['tea'],
@@ -217,19 +218,19 @@ export function loadPersistedState(storageKey: string): GameState {
       } else {
         // Migrate old cooking data that doesn't have recipeBookUnlocked
         if (parsed.cooking.recipeBookUnlocked === undefined) {
-          console.log('[GameState] Migrating old save data - adding recipeBookUnlocked');
+          debugLog('GameState', 'Migrating old save data - adding recipeBookUnlocked');
           parsed.cooking.recipeBookUnlocked = false;
         }
         // Ensure tea is always unlocked, even in existing saves
         if (!parsed.cooking.unlockedRecipes.includes('tea')) {
-          console.log('[GameState] Migrating old save data - ensuring tea is unlocked');
+          debugLog('GameState', 'Migrating old save data - ensuring tea is unlocked');
           parsed.cooking.unlockedRecipes.push('tea');
         }
       }
 
       // Migrate old save data that doesn't have status effects
       if (!parsed.statusEffects) {
-        console.log('[GameState] Migrating old save data - adding status effects');
+        debugLog('GameState', 'Migrating old save data - adding status effects');
         parsed.statusEffects = {
           feelingSick: false,
           stamina: STAMINA.MAX,
@@ -240,8 +241,9 @@ export function loadPersistedState(storageKey: string): GameState {
 
       // Migrate old status effects to include stamina (new session = full stamina)
       if (parsed.statusEffects.stamina === undefined) {
-        console.log(
-          '[GameState] Migrating old save data - adding stamina (full restore on session start)'
+        debugLog(
+          'GameState',
+          'Migrating old save data - adding stamina (full restore on session start)'
         );
         parsed.statusEffects.stamina = STAMINA.MAX;
         parsed.statusEffects.maxStamina = STAMINA.MAX;
@@ -251,47 +253,47 @@ export function loadPersistedState(storageKey: string): GameState {
         const timeSinceLastUpdate = Date.now() - (parsed.statusEffects.lastStaminaUpdate || 0);
 
         if (timeSinceLastUpdate >= TimeManager.MS_PER_GAME_DAY) {
-          console.log('[GameState] Offline for 2+ hours - restoring stamina to full (slept well!)');
+          debugLog('GameState', 'Offline for 2+ hours - restoring stamina to full (slept well!)');
           parsed.statusEffects.stamina = parsed.statusEffects.maxStamina || STAMINA.MAX;
         } else {
-          console.log('[GameState] Quick session resume - stamina unchanged');
+          debugLog('GameState', 'Quick session resume - stamina unchanged');
         }
         parsed.statusEffects.lastStaminaUpdate = Date.now();
       }
 
       // Migrate old save data that doesn't have placed items
       if (!parsed.placedItems) {
-        console.log('[GameState] Migrating old save data - adding placed items');
+        debugLog('GameState', 'Migrating old save data - adding placed items');
         parsed.placedItems = [];
       }
 
       // Migrate old save data that doesn't have desk contents
       if (!parsed.deskContents) {
-        console.log('[GameState] Migrating old save data - adding desk contents');
+        debugLog('GameState', 'Migrating old save data - adding desk contents');
         parsed.deskContents = [];
       }
 
       // Migrate old save data that doesn't have watering can state
       if (!parsed.wateringCan) {
-        console.log('[GameState] Migrating old save data - adding watering can');
+        debugLog('GameState', 'Migrating old save data - adding watering can');
         parsed.wateringCan = { currentLevel: WATERING_CAN.CAPACITY }; // Start with full water can
       }
 
       // Migrate old save data that doesn't have forage cooldowns
       if (!parsed.forageCooldowns) {
-        console.log('[GameState] Migrating old save data - adding forage cooldowns');
+        debugLog('GameState', 'Migrating old save data - adding forage cooldowns');
         parsed.forageCooldowns = {};
       }
 
       // Migrate old save data that doesn't have movement effect
       if (parsed.movementEffect === undefined) {
-        console.log('[GameState] Migrating old save data - adding movement effect');
+        debugLog('GameState', 'Migrating old save data - adding movement effect');
         parsed.movementEffect = null;
       }
 
       // Migrate old save data that doesn't have transformations
       if (!parsed.transformations) {
-        console.log('[GameState] Migrating old save data - adding transformations');
+        debugLog('GameState', 'Migrating old save data - adding transformations');
         parsed.transformations = {
           isFairyForm: false,
           fairyFormExpiresAt: null,
@@ -304,26 +306,26 @@ export function loadPersistedState(storageKey: string): GameState {
         parsed.transformations.fairyFormExpiresAt &&
         parsed.transformations.fairyFormExpiresAt <= Date.now()
       ) {
-        console.log('[GameState] Clearing expired fairy form on load');
+        debugLog('GameState', 'Clearing expired fairy form on load');
         parsed.transformations.isFairyForm = false;
         parsed.transformations.fairyFormExpiresAt = null;
       }
 
       // Clear expired movement effects on load
       if (parsed.movementEffect && parsed.movementEffect.expiresAt <= Date.now()) {
-        console.log('[GameState] Clearing expired movement effect on load');
+        debugLog('GameState', 'Clearing expired movement effect on load');
         parsed.movementEffect = null;
       }
 
       // Migrate old save data that doesn't have quest tracking
       if (!parsed.quests) {
-        console.log('[GameState] Migrating old save data - adding quest tracking');
+        debugLog('GameState', 'Migrating old save data - adding quest tracking');
         parsed.quests = {};
       }
 
       // Migrate old save data that doesn't have active potion effects
       if (!parsed.activePotionEffects) {
-        console.log('[GameState] Migrating old save data - adding active potion effects');
+        debugLog('GameState', 'Migrating old save data - adding active potion effects');
         parsed.activePotionEffects = {};
       }
 
@@ -331,20 +333,20 @@ export function loadPersistedState(storageKey: string): GameState {
       const now = Date.now();
       for (const effectType of Object.keys(parsed.activePotionEffects)) {
         if (parsed.activePotionEffects[effectType].expiresAt <= now) {
-          console.log(`[GameState] Clearing expired potion effect: ${effectType}`);
+          debugLog('GameState', `Clearing expired potion effect: ${effectType}`);
           delete parsed.activePotionEffects[effectType];
         }
       }
 
       // Migrate old save data that doesn't have player disguise
       if (parsed.playerDisguise === undefined) {
-        console.log('[GameState] Migrating old save data - adding player disguise');
+        debugLog('GameState', 'Migrating old save data - adding player disguise');
         parsed.playerDisguise = null;
       }
 
       // Clear expired disguise on load
       if (parsed.playerDisguise && parsed.playerDisguise.expiresAt <= now) {
-        console.log('[GameState] Clearing expired player disguise on load');
+        debugLog('GameState', 'Clearing expired player disguise on load');
         parsed.playerDisguise = null;
       }
 

--- a/docs/PENDING_CLEANUP.md
+++ b/docs/PENDING_CLEANUP.md
@@ -71,14 +71,16 @@ count honest afterwards.
 **Migration recipe** (see `utils/dialogueHandlers.ts` for the worked example —
 39 sites, one codemod + hand-fixed multi-line forms):
 
-1. Per file: `console.log('[Prefix] ...')` → `debugLog('Prefix', ...)` (prefix
-   moves out of the string into the first argument; output looks identical).
-2. Drop any `if (DEBUG.X)` guards wrapping the logs — `DEBUG.QUEST`-style flags
-   are hardcoded `import.meta.env.DEV && false` (never on); the category flag
-   revives these diagnostics behind `?debug=<category>`.
+1. Run `node scripts/convert-debug-log.mjs <files...>` — it rewrites
+   `console.log('[Tag] ...')` → `debugLog('Tag', ...)` (prefix moves out of the
+   string into the first argument; output looks identical), handles multi-line
+   calls, and unwraps dead `if (DEBUG.X)` guards. Live `DEBUG.MULTIPLAYER`
+   guards are kept by default (extend via `--keep-guards=`). Anything needing
+   judgement is reported as `MANUAL file:line` and left untouched.
+2. Review the diff — promote anything a player genuinely needs to
+   `console.warn` (ungated); routine traces stay gated `debugLog`.
 3. Add the file to the eslint `no-console` override list.
-4. Per category, sanity-check intent: diagnostics → gated `debugLog`; anything
-   a player genuinely needs → keep/convert to `console.warn` (ungated).
+4. `npm run verify` + prettier, then commit.
 
 **Remaining inventory** (console.log counts on main after the merge): GameState.ts ~43,
 GameStatePersistence.ts ~32, farmManager.ts ~31, FriendshipManager.ts ~30,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,7 +66,12 @@ export default tseslint.config(
   // console.error stay permitted everywhere — they carry player-relevant
   // failure diagnostics and are deliberately ungated.
   {
-    files: ['utils/debugLog.ts', 'utils/dialogueHandlers.ts'],
+    files: [
+      'utils/debugLog.ts',
+      'utils/dialogueHandlers.ts',
+      'GameState.ts',
+      'GameStatePersistence.ts',
+    ],
     rules: {
       'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -71,6 +71,9 @@ export default tseslint.config(
       'utils/dialogueHandlers.ts',
       'GameState.ts',
       'GameStatePersistence.ts',
+      'utils/farmManager.ts',
+      'utils/FriendshipManager.ts',
+      'utils/actionHandlers.ts',
     ],
     rules: {
       'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],

--- a/scripts/convert-debug-log.mjs
+++ b/scripts/convert-debug-log.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * Codemod for §2 of docs/PENDING_CLEANUP.md: convert bare console.log calls
+ * to the category-gated debugLog helper (utils/debugLog.ts).
+ *
+ *   node scripts/convert-debug-log.mjs <file...> [--keep-guards=FLAG,FLAG]
+ *
+ * What it does per call site:
+ *   console.log('[Tag] msg', extra)      → debugLog('Tag', 'msg', extra)
+ *   console.log(`[Tag] msg ${x}`)        → debugLog('Tag', `msg ${x}`)
+ *   console.log(                         → debugLog(
+ *     '[Tag] msg',                             'Tag',
+ *     extra                                    'msg',
+ *   );                                         extra,
+ *                                            );
+ *   if (DEBUG.X) console.log(...)        → debugLog(...)   (dead guards only)
+ *
+ * Dead-guard unwrapping: DEBUG.* flags in constants.ts are hardcoded
+ * `import.meta.env.DEV && false` — those logs are unreachable, and the
+ * category flag revives them behind ?debug=<tag>. Live flags (default:
+ * DEBUG.MULTIPLAYER, which uses runtimeDebug) keep their guards; only the
+ * inner call is converted.
+ *
+ * Deliberately left for manual triage (reported with line numbers):
+ *   - calls whose first argument is not a string/template literal
+ *   - calls where the [Tag] prefix is not at the very start of the message
+ *   - calls with no [Tag] prefix at all
+ *   - `if (DEBUG.X) { ... }` blocks (may contain more than the log)
+ *
+ * The script never edits console.warn / console.error / console.debug.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const argv = process.argv.slice(2);
+const keepGuardFlags = new Set(['MULTIPLAYER']);
+const files = [];
+
+for (const a of argv) {
+  if (a.startsWith('--keep-guards=')) {
+    for (const f of a.slice('--keep-guards='.length).split(',')) {
+      if (f) keepGuardFlags.add(f.trim().toUpperCase());
+    }
+  } else {
+    files.push(a);
+  }
+}
+
+if (files.length === 0) {
+  console.error('usage: node scripts/convert-debug-log.mjs <file...> [--keep-guards=FLAG,FLAG]');
+  process.exit(1);
+}
+
+const CALL_RE = /\bconsole\.(?:log|info)\(/g;
+
+/** Walk from an opening paren to its matching close, respecting strings,
+ *  template literals (incl. nested ${}), comments and nesting. */
+function findMatchingParen(text, openIdx) {
+  let depth = 0;
+  let i = openIdx;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === '/' && text[i + 1] === '/') {
+      while (i < text.length && text[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '/' && text[i + 1] === '*') {
+      const end = text.indexOf('*/', i + 2);
+      i = end === -1 ? text.length : end + 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipString(text, i, ch);
+      continue;
+    }
+    if (ch === '`') {
+      i = skipTemplate(text, i);
+      continue;
+    }
+    if (ch === '(') depth++;
+    if (ch === ')') {
+      depth--;
+      if (depth === 0) return i;
+    }
+    i++;
+  }
+  return -1;
+}
+
+function skipString(text, start, quote) {
+  let i = start + 1;
+  while (i < text.length) {
+    if (text[i] === '\\') {
+      i += 2;
+      continue;
+    }
+    if (text[i] === quote) return i + 1;
+    if (text[i] === '\n') return i; // unterminated; bail
+    i++;
+  }
+  return i;
+}
+
+function skipTemplate(text, start) {
+  let i = start + 1;
+  while (i < text.length) {
+    if (text[i] === '\\') {
+      i += 2;
+      continue;
+    }
+    if (text[i] === '`') return i + 1;
+    if (text[i] === '$' && text[i + 1] === '{') {
+      let braceDepth = 1;
+      i += 2;
+      while (i < text.length && braceDepth > 0) {
+        if (text[i] === '{') braceDepth++;
+        else if (text[i] === '}') braceDepth--;
+        else if (text[i] === '"' || text[i] === "'") {
+          i = skipString(text, i, text[i]);
+          continue;
+        } else if (text[i] === '`') {
+          i = skipTemplate(text, i);
+          continue;
+        }
+        i++;
+      }
+      continue;
+    }
+    i++;
+  }
+  return i;
+}
+
+/** Split text[from..to) on top-level commas. */
+function splitArgs(text, from, to) {
+  const parts = [];
+  let depth = 0;
+  let start = from;
+  let i = from;
+  while (i < to) {
+    const ch = text[i];
+    if (ch === '/' && text[i + 1] === '/') {
+      while (i < to && text[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '/' && text[i + 1] === '*') {
+      const end = text.indexOf('*/', i + 2);
+      i = end === -1 ? to : end + 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipString(text, i, ch);
+      continue;
+    }
+    if (ch === '`') {
+      i = skipTemplate(text, i);
+      continue;
+    }
+    if ('([{'.includes(ch)) depth++;
+    else if (')]}'.includes(ch)) depth--;
+    else if (ch === ',' && depth === 0) {
+      parts.push({ start, end: i });
+      start = i + 1;
+    }
+    i++;
+  }
+  parts.push({ start, end: to });
+  return parts;
+}
+
+const PREFIX_RE = /^\s*\[([A-Za-z0-9 _-]+)\]\s*:?\s*/;
+
+/** Build the debugLog(...) replacement for one call, or null if the site
+ *  needs manual attention. */
+function buildReplacement(text, nameStart, closeIdx) {
+  const openIdx = text.indexOf('(', nameStart);
+  const args = splitArgs(text, openIdx + 1, closeIdx);
+  if (args.length === 0) return null;
+
+  const first = args[0];
+  const argText = text.slice(first.start, first.end).trim();
+
+  const quote = argText[0];
+  if (quote !== "'" && quote !== '"' && quote !== '`') return null;
+  if (!argText.endsWith(quote)) return null;
+  const inner = argText.slice(1, -1);
+  const m = inner.match(PREFIX_RE);
+  if (!m) return null;
+
+  const tag = m[1];
+  const rest = inner.slice(m[0].length);
+
+  const pieces = [];
+  if (rest.length > 0) pieces.push(quote + rest + quote);
+  for (const a of args.slice(1)) {
+    const t = text.slice(a.start, a.end).trim();
+    if (t.length > 0) pieces.push(t);
+  }
+
+  return pieces.length === 0 ? `debugLog('${tag}')` : `debugLog('${tag}', ${pieces.join(', ')})`;
+}
+
+function lineOf(text, idx) {
+  return text.slice(0, idx).split('\n').length;
+}
+
+function insertDebugLogImport(text, file) {
+  if (/import\s*\{[^}]*debugLog[^}]*\}\s*from/.test(text)) return text;
+  const rel =
+    path.relative(path.dirname(file), path.resolve('utils/debugLog.ts')).replace(/\.ts$/, '') ||
+    './debugLog';
+  const importLine = `import { debugLog } from '${rel.startsWith('.') ? rel : './' + rel}';`;
+
+  const lines = text.split('\n');
+  let insertAt = -1; // index of the END of the last import statement
+  let i = 0;
+  while (i < lines.length) {
+    if (/^import\s/.test(lines[i])) {
+      // advance to the line that closes this import
+      while (i < lines.length && !/from\s+'[^']*';/.test(lines[i])) i++;
+      if (i >= lines.length) break;
+      insertAt = i;
+    } else if (/^\S/.test(lines[i]) && !lines[i].startsWith('//') && !lines[i].startsWith('/*')) {
+      if (insertAt !== -1) break; // first non-import code line: stop
+    }
+    i++;
+  }
+  lines.splice(insertAt + 1, 0, importLine);
+  return lines.join('\n');
+}
+
+let totalConverted = 0;
+let totalGuards = 0;
+
+for (const file of files) {
+  let text = fs.readFileSync(file, 'utf8');
+
+  // --- Pass 1: unwrap dead `if (DEBUG.X)` guards. ---
+  let guards = 0;
+  text = text.replace(
+    /^[ \t]*if \(DEBUG\.([A-Za-z0-9_]+)\)[ \t]*\n[ \t]*console\.(log|info)\(/gm,
+    (match, flag, call) => {
+      if (keepGuardFlags.has(flag.toUpperCase())) return match;
+      guards++;
+      return `console.${call}(`;
+    }
+  );
+  text = text.replace(/if \(DEBUG\.([A-Za-z0-9_]+)\) console\.(log|info)\(/g, (match, flag, call) => {
+    if (keepGuardFlags.has(flag.toUpperCase())) return match;
+    guards++;
+    return `console.${call}(`;
+  });
+
+  // --- Pass 2: rewrite calls right-to-left so offsets stay stable. ---
+  const manual = [];
+  let converted = 0;
+  for (;;) {
+    // find the last convertible call site in the current text
+    let best = -1;
+    let m;
+    CALL_RE.lastIndex = 0;
+    while ((m = CALL_RE.exec(text)) !== null) {
+      const lineStart = text.lastIndexOf('\n', m.index) + 1;
+      const before = text.slice(lineStart, m.index);
+      if (before.includes('//') || before.includes('*')) continue; // comment line
+      best = m.index;
+    }
+    if (best === -1) break;
+
+    const openIdx = text.indexOf('(', best);
+    const closeIdx = findMatchingParen(text, openIdx);
+    if (closeIdx === -1) {
+      manual.push({ line: lineOf(text, best), reason: 'unbalanced paren', snippet: '' });
+      text = text.slice(0, best) + 'c0ns0le' + text.slice(best + 'console'.length);
+      continue;
+    }
+
+    const replacement = buildReplacement(text, best, closeIdx);
+    if (!replacement) {
+      const firstArg = text
+        .slice(openIdx + 1, closeIdx)
+        .trim()
+        .split('\n')[0]
+        .slice(0, 70);
+      manual.push({ line: lineOf(text, best), reason: 'manual', snippet: firstArg });
+      text = text.slice(0, best) + 'c0ns0le' + text.slice(best + 'console'.length);
+      continue;
+    }
+
+    text = text.slice(0, best) + replacement + text.slice(closeIdx + 1);
+    converted++;
+  }
+  text = text.replace(/c0ns0le/g, 'console');
+
+  if (converted === 0 && guards === 0) {
+    console.log(`${file}: nothing to do`);
+    continue;
+  }
+
+  if (converted > 0) text = insertDebugLogImport(text, file);
+
+  fs.writeFileSync(file, text);
+
+  console.log(`${file}: ${converted} converted, ${guards} guards unwrapped`);
+  totalConverted += converted;
+  totalGuards += guards;
+  for (const mm of manual) {
+    console.log(`  MANUAL ${file}:${mm.line} ${mm.reason} :: ${mm.snippet}`);
+  }
+}
+
+console.log(`\ntotal: ${totalConverted} converted, ${totalGuards} guards unwrapped`);

--- a/utils/FriendshipManager.ts
+++ b/utils/FriendshipManager.ts
@@ -53,7 +53,6 @@ import {
 } from '../data/questHandlers/altheaChoresHandler';
 import { magicManager } from './MagicManager';
 import { decorationManager } from './DecorationManager';
-import { DEBUG } from '../constants';
 import {
   getEstrangedSistersStage,
   deliverLetterToJuniper,
@@ -65,6 +64,7 @@ import {
   isGhostQuestActive,
   advanceGhostQuestToHasBook,
 } from '../data/questHandlers/ghostQueenHandler';
+import { debugLog } from './debugLog';
 
 // Tier reward definitions - items given when reaching a tier with certain NPCs
 // Format: { npcId: { tier: [{ itemId, quantity }] } }
@@ -187,8 +187,7 @@ class FriendshipManagerClass {
     }
 
     this.initialised = true;
-    if (DEBUG.FRIENDSHIP)
-      console.log(`[FriendshipManager] Initialised with ${this.friendships.size} friendships`);
+    debugLog('FriendshipManager', `Initialised with ${this.friendships.size} friendships`);
   }
 
   /**
@@ -289,20 +288,19 @@ class FriendshipManagerClass {
     const newLevel = this.getFriendshipLevel(npcId);
     const newTier = this.getFriendshipTier(npcId);
 
-    if (DEBUG.FRIENDSHIP)
-      console.log(
-        `[FriendshipManager] ${npcId}: +${amount} points (${reason}). Now ${friendship.points} points, level ${newLevel}, tier: ${newTier}`
-      );
+    debugLog(
+      'FriendshipManager',
+      `${npcId}: +${amount} points (${reason}). Now ${friendship.points} points, level ${newLevel}, tier: ${newTier}`
+    );
 
     // Announce level up
     if (newLevel > oldLevel) {
-      if (DEBUG.FRIENDSHIP)
-        console.log(`[FriendshipManager] 🎉 ${npcId} friendship increased to level ${newLevel}!`);
+      debugLog('FriendshipManager', `🎉 ${npcId} friendship increased to level ${newLevel}!`);
     }
 
     // Check for tier change and give rewards
     if (newTier !== oldTier) {
-      if (DEBUG.FRIENDSHIP) console.log(`[FriendshipManager] 🌟 ${npcId} is now a ${newTier}!`);
+      debugLog('FriendshipManager', `🌟 ${npcId} is now a ${newTier}!`);
       this.giveTierReward(npcId, newTier, friendship);
     }
 
@@ -322,18 +320,17 @@ class FriendshipManagerClass {
     // Check if already received this tier's reward
     const rewardKey = `${npcId}_${tier}`;
     if (friendship.rewardsReceived?.includes(rewardKey)) {
-      if (DEBUG.FRIENDSHIP)
-        console.log(`[FriendshipManager] Already received ${tier} reward from ${npcId}`);
+      debugLog('FriendshipManager', `Already received ${tier} reward from ${npcId}`);
       return;
     }
 
     // Give the rewards
     for (const reward of rewards) {
       inventoryManager.addItem(reward.itemId, reward.quantity);
-      if (DEBUG.FRIENDSHIP)
-        console.log(
-          `[FriendshipManager] 🎁 Received ${reward.quantity}x ${reward.itemId} from ${npcId}!`
-        );
+      debugLog(
+        'FriendshipManager',
+        `🎁 Received ${reward.quantity}x ${reward.itemId} from ${npcId}!`
+      );
 
       // Special handling for Easel - track in DecorationManager
       if (reward.itemId === 'easel') {
@@ -364,8 +361,7 @@ class FriendshipManagerClass {
       })),
     });
 
-    if (DEBUG.FRIENDSHIP)
-      console.log(`[FriendshipManager] 🎁 ${npcId} gave you a gift for becoming their ${tier}!`);
+    debugLog('FriendshipManager', `🎁 ${npcId} gave you a gift for becoming their ${tier}!`);
   }
 
   /**
@@ -378,7 +374,7 @@ class FriendshipManagerClass {
 
     // Check if already talked today
     if (friendship.lastTalkedDay === currentDay) {
-      if (DEBUG.FRIENDSHIP) console.log(`[FriendshipManager] Already talked to ${npcId} today`);
+      debugLog('FriendshipManager', `Already talked to ${npcId} today`);
       return false;
     }
 
@@ -445,8 +441,7 @@ class FriendshipManagerClass {
     if (itemId === 'potion_friendship') {
       const points = 300;
       this.addPoints(npcId, points, 'friendship elixir');
-      if (DEBUG.FRIENDSHIP)
-        console.log(`[FriendshipManager] 💖 ${npcId} drinks the Friendship Elixir! (+${points})`);
+      debugLog('FriendshipManager', `💖 ${npcId} drinks the Friendship Elixir! (+${points})`);
       return { points, reaction: 'loved' };
     }
 
@@ -454,8 +449,7 @@ class FriendshipManagerClass {
     if (itemId === 'potion_bitter_grudge') {
       const points = -300;
       this.addPoints(npcId, points, 'bitter grudge potion');
-      if (DEBUG.FRIENDSHIP)
-        console.log(`[FriendshipManager] 💔 ${npcId} drinks the Bitter Grudge... (${points})`);
+      debugLog('FriendshipManager', `💔 ${npcId} drinks the Bitter Grudge... (${points})`);
       return { points, reaction: 'disliked' };
     }
 
@@ -466,19 +460,16 @@ class FriendshipManagerClass {
 
       if (isSpecial) {
         // Special Friends are understanding and don't lose friendship
-        if (DEBUG.FRIENDSHIP)
-          console.log(
-            `[FriendshipManager] 😅 ${npcId} (Special Friend) tries your terrible food but doesn't mind`
-          );
+        debugLog(
+          'FriendshipManager',
+          `😅 ${npcId} (Special Friend) tries your terrible food but doesn't mind`
+        );
         return { points: 0, reaction: 'neutral' };
       } else {
         // Regular NPCs lose 1 friendship point
         const points = -1;
         this.addPoints(npcId, points, `terrible food gift: ${item.displayName}`);
-        if (DEBUG.FRIENDSHIP)
-          console.log(
-            `[FriendshipManager] 😖 ${npcId} is disgusted by your terrible food (-1 point)`
-          );
+        debugLog('FriendshipManager', `😖 ${npcId} is disgusted by your terrible food (-1 point)`);
         return { points, reaction: 'disliked' };
       }
     }
@@ -493,27 +484,23 @@ class FriendshipManagerClass {
       case 'loved':
         points = LIKED_GIFT_POINTS; // +300 points
         this.addPoints(npcId, points, `loved gift: ${item.displayName}`);
-        if (DEBUG.FRIENDSHIP)
-          console.log(`[FriendshipManager] 💕 ${npcId} loves ${item.displayName}! (+${points})`);
+        debugLog('FriendshipManager', `💕 ${npcId} loves ${item.displayName}! (+${points})`);
         break;
       case 'liked':
         points = GIFT_POINTS; // +100 points
         this.addPoints(npcId, points, `liked gift: ${item.displayName}`);
-        if (DEBUG.FRIENDSHIP)
-          console.log(`[FriendshipManager] 😊 ${npcId} likes ${item.displayName}. (+${points})`);
+        debugLog('FriendshipManager', `😊 ${npcId} likes ${item.displayName}. (+${points})`);
         break;
       case 'disliked':
         points = -100; // -100 points for disliked items
         this.addPoints(npcId, points, `disliked gift: ${item.displayName}`);
-        if (DEBUG.FRIENDSHIP)
-          console.log(`[FriendshipManager] 😟 ${npcId} dislikes ${item.displayName}. (${points})`);
+        debugLog('FriendshipManager', `😟 ${npcId} dislikes ${item.displayName}. (${points})`);
         break;
       case 'neutral':
       default:
         points = GIFT_POINTS; // +100 points
         this.addPoints(npcId, points, `gift: ${item.displayName}`);
-        if (DEBUG.FRIENDSHIP)
-          console.log(`[FriendshipManager] 🙂 ${npcId} accepts ${item.displayName}. (+${points})`);
+        debugLog('FriendshipManager', `🙂 ${npcId} accepts ${item.displayName}. (+${points})`);
         break;
     }
 
@@ -556,8 +543,7 @@ class FriendshipManagerClass {
       getEstrangedSistersStage() === SISTERS_STAGES.LETTER_GIVEN
     ) {
       const nodeId = deliverLetterToJuniper();
-      if (DEBUG.FRIENDSHIP)
-        console.log("[FriendshipManager] Witch receives Althea's letter via gift.");
+      debugLog('FriendshipManager', "Witch receives Althea's letter via gift.");
       return { points: 0, reaction: 'neutral', dialogueNodeId: nodeId };
     }
 
@@ -567,7 +553,7 @@ class FriendshipManagerClass {
       getEstrangedSistersStage() === SISTERS_STAGES.PHOTO_NEEDED
     ) {
       const nodeId = deliverPhotoToJuniper();
-      if (DEBUG.FRIENDSHIP) console.log('[FriendshipManager] Witch receives photograph via gift.');
+      debugLog('FriendshipManager', 'Witch receives photograph via gift.');
       return { points: 0, reaction: 'neutral', dialogueNodeId: nodeId };
     }
 
@@ -583,8 +569,7 @@ class FriendshipManagerClass {
       magicManager.unlockMagicBook();
       const points = 300;
       this.addPoints('witch', points, 'witch garden quest: pickled onions delivered');
-      if (DEBUG.FRIENDSHIP)
-        console.log(`[FriendshipManager] Witch accepts your pickled onions! (+${points})`);
+      debugLog('FriendshipManager', `Witch accepts your pickled onions! (+${points})`);
       return {
         points,
         reaction: 'loved',
@@ -611,7 +596,7 @@ class FriendshipManagerClass {
     if (!isGhostQuestActive()) return null;
 
     advanceGhostQuestToHasBook();
-    if (DEBUG.FRIENDSHIP) console.log('[FriendshipManager] Ghost Queen receives the history book.');
+    debugLog('FriendshipManager', 'Ghost Queen receives the history book.');
     return { points: 0, reaction: 'neutral', dialogueNodeId: 'ghost_deliver' };
   }
 
@@ -632,7 +617,7 @@ class FriendshipManagerClass {
       markTeaDelivered();
       const points = 100;
       this.addPoints('old_woman_knitting', points, 'althea chores: tea delivered');
-      if (DEBUG.FRIENDSHIP) console.log('[FriendshipManager] Althea receives tea! (+${points})');
+      debugLog('FriendshipManager', 'Althea receives tea! (+${points})');
       return { points, reaction: 'loved', dialogueNodeId: 'chores_tea_accepted' };
     }
 
@@ -640,8 +625,7 @@ class FriendshipManagerClass {
       markCookiesDelivered();
       const points = 100;
       this.addPoints('old_woman_knitting', points, 'althea chores: cookies delivered');
-      if (DEBUG.FRIENDSHIP)
-        console.log('[FriendshipManager] Althea receives cookies! (+${points})');
+      debugLog('FriendshipManager', 'Althea receives cookies! (+${points})');
       return { points, reaction: 'loved', dialogueNodeId: 'chores_cookies_accepted' };
     }
 
@@ -671,8 +655,7 @@ class FriendshipManagerClass {
         markSeasonCompleted(task);
         const points = 100;
         this.addPoints('village_elder', points, `gardening quest: ${task} crop delivered`);
-        if (DEBUG.FRIENDSHIP)
-          console.log(`[FriendshipManager] 🌱 Elias accepts your ${task} harvest! (+${points})`);
+        debugLog('FriendshipManager', `🌱 Elias accepts your ${task} harvest! (+${points})`);
         return { points, reaction: 'loved', dialogueNodeId: 'garden_task_complete' };
       }
 
@@ -681,8 +664,7 @@ class FriendshipManagerClass {
         markSeasonCompleted('autumn');
         const points = 100;
         this.addPoints('village_elder', points, 'gardening quest: autumn honey delivered');
-        if (DEBUG.FRIENDSHIP)
-          console.log(`[FriendshipManager] 🍯 Elias is delighted with the honey! (+${points})`);
+        debugLog('FriendshipManager', `🍯 Elias is delighted with the honey! (+${points})`);
         return { points, reaction: 'loved', dialogueNodeId: 'garden_task_complete' };
       }
     }
@@ -708,10 +690,10 @@ class FriendshipManagerClass {
 
             const points = 150;
             this.addPoints('village_elder', points, 'fairy bluebells quest completed');
-            if (DEBUG.FRIENDSHIP)
-              console.log(
-                `[FriendshipManager] 🔔 Fairy Bluebells quest complete! Received fairy bluebell seed! (+${points})`
-              );
+            debugLog(
+              'FriendshipManager',
+              `🔔 Fairy Bluebells quest complete! Received fairy bluebell seed! (+${points})`
+            );
             return {
               points,
               reaction: 'loved',
@@ -719,10 +701,10 @@ class FriendshipManagerClass {
               dialogueNodeId: 'fairy_bluebells_complete',
             };
           } else {
-            if (DEBUG.FRIENDSHIP)
-              console.log(
-                `[FriendshipManager] 🔔 Elias accepts your ${questItemType} for the Fairy Bluebells quest!`
-              );
+            debugLog(
+              'FriendshipManager',
+              `🔔 Elias accepts your ${questItemType} for the Fairy Bluebells quest!`
+            );
             return {
               points: 0,
               reaction: 'loved',
@@ -731,8 +713,7 @@ class FriendshipManagerClass {
           }
         } else {
           // Already delivered this item
-          if (DEBUG.FRIENDSHIP)
-            console.log(`[FriendshipManager] Elias already received ${questItemType}`);
+          debugLog('FriendshipManager', `Elias already received ${questItemType}`);
           // Fall through to normal gift handling
         }
       }
@@ -757,8 +738,7 @@ class FriendshipManagerClass {
     friendship.isSpecialFriend = true;
     friendship.crisisCompleted = crisisId;
 
-    if (DEBUG.FRIENDSHIP)
-      console.log(`[FriendshipManager] 💫 ${npcId} is now a Special Friend! (crisis: ${crisisId})`);
+    debugLog('FriendshipManager', `💫 ${npcId} is now a Special Friend! (crisis: ${crisisId})`);
     this.save();
   }
 
@@ -799,8 +779,7 @@ class FriendshipManagerClass {
           const inventoryData = inventoryManager.getInventoryData();
           characterData.saveInventory(inventoryData.items, inventoryData.tools);
 
-          if (DEBUG.FRIENDSHIP)
-            console.log(`[FriendshipManager] 🎁 ${npcId} gave player ${item.displayName}!`);
+          debugLog('FriendshipManager', `🎁 ${npcId} gave player ${item.displayName}!`);
 
           return {
             itemId: gift.itemId,
@@ -882,7 +861,7 @@ class FriendshipManagerClass {
   reset(): void {
     this.friendships.clear();
     this.initialised = false;
-    if (DEBUG.FRIENDSHIP) console.log('[FriendshipManager] Reset all friendships');
+    debugLog('FriendshipManager', 'Reset all friendships');
   }
 }
 

--- a/utils/actionHandlers.ts
+++ b/utils/actionHandlers.ts
@@ -15,12 +15,13 @@ import { characterData } from './CharacterData';
 import { getCrop } from '../data/crops';
 import { getCropIdFromSeed } from '../data/items';
 
-import { WATER_CAN, DEBUG } from '../constants';
+import { WATER_CAN } from '../constants';
 import { staminaManager } from './StaminaManager';
 
 import { getTierName } from './MagicEffects';
 
 import { cookingManager, CookingResult } from './CookingManager';
+import { debugLog } from './debugLog';
 
 // Re-export forage types and handlers for consumers importing from actionHandlers
 export type { ForageResult } from './forageHandlers';
@@ -95,11 +96,11 @@ export function checkDeskInteraction(playerPos: Position, mapId: string): DeskIn
   }
 
   if (closestDesk.found) {
-    if (DEBUG.NPC)
-      console.log(
-        `[Action] Found desk at (${closestDesk.position?.x}, ${closestDesk.position?.y}), ` +
-          `hasItems: ${closestDesk.hasItems}, hasSpace: ${closestDesk.hasSpace}`
-      );
+    debugLog(
+      'Action',
+      `Found desk at (${closestDesk.position?.x}, ${closestDesk.position?.y}), ` +
+        `hasItems: ${closestDesk.hasItems}, hasSpace: ${closestDesk.hasSpace}`
+    );
   }
 
   return closestDesk;
@@ -113,7 +114,7 @@ export function checkStoveInteraction(playerPos: Position): boolean {
   for (const tile of getAdjacentTiles(playerPos)) {
     const tileData = getTileData(tile.x, tile.y);
     if (tileData && tileData.type === TileType.STOVE) {
-      if (DEBUG.NPC) console.log(`[Action] Found stove at (${tile.x}, ${tile.y})`);
+      debugLog('Action', `Found stove at (${tile.x}, ${tile.y})`);
       return true;
     }
   }
@@ -129,7 +130,7 @@ export function checkMirrorInteraction(playerPos: Position): boolean {
   for (const tile of getAdjacentTiles(playerPos)) {
     const tileData = getTileData(tile.x, tile.y);
     if (tileData && tileData.type === TileType.MIRROR) {
-      if (DEBUG.NPC) console.log(`[Action] Found mirror at (${tile.x}, ${tile.y})`);
+      debugLog('Action', `Found mirror at (${tile.x}, ${tile.y})`);
       return true;
     }
   }
@@ -145,7 +146,7 @@ export function checkNPCInteraction(playerPos: Position): string | null {
   const nearbyNPC = npcManager.getNPCAtPosition(playerPos);
 
   if (nearbyNPC) {
-    if (DEBUG.NPC) console.log(`[Action] Interacting with NPC: ${nearbyNPC.name}`);
+    debugLog('Action', `Interacting with NPC: ${nearbyNPC.name}`);
 
     // Trigger NPC event if it has animated states
     if (nearbyNPC.animatedStates) {
@@ -198,7 +199,7 @@ export function checkTransition(
   const transitionData = mapManager.getTransitionAt(playerPos);
 
   if (!transitionData) {
-    if (DEBUG.MAP) console.log(`[Action] No transition found near player position`);
+    debugLog('Action', `No transition found near player position`);
     return { success: false };
   }
 
@@ -211,10 +212,10 @@ export function checkTransition(
     const requiredStage = transition.requiresQuestStage ?? 1; // Default to stage 1 if not specified
 
     if (!questStarted || questStage < requiredStage) {
-      if (DEBUG.MAP)
-        console.log(
-          `[Action] Transition blocked: requires quest '${transition.requiresQuest}' stage ${requiredStage} (current: ${questStage})`
-        );
+      debugLog(
+        'Action',
+        `Transition blocked: requires quest '${transition.requiresQuest}' stage ${requiredStage} (current: ${questStage})`
+      );
       return {
         success: false,
         blocked: true,
@@ -230,10 +231,10 @@ export function checkTransition(
   if (transition.minSizeTier !== undefined && playerSizeTier < transition.minSizeTier) {
     const requiredSize = getTierName(transition.minSizeTier);
     const currentSize = getTierName(playerSizeTier);
-    if (DEBUG.MAP)
-      console.log(
-        `[Action] Transition blocked: player too small (${currentSize}, needs at least ${requiredSize})`
-      );
+    debugLog(
+      'Action',
+      `Transition blocked: player too small (${currentSize}, needs at least ${requiredSize})`
+    );
     return {
       success: false,
       blocked: true,
@@ -244,10 +245,10 @@ export function checkTransition(
   if (playerSizeTier > effectiveMaxSize) {
     const maxSize = getTierName(effectiveMaxSize as SizeTier);
     const currentSize = getTierName(playerSizeTier);
-    if (DEBUG.MAP)
-      console.log(
-        `[Action] Transition blocked: player too big (${currentSize}, max allowed ${maxSize})`
-      );
+    debugLog(
+      'Action',
+      `Transition blocked: player too big (${currentSize}, max allowed ${maxSize})`
+    );
     return {
       success: false,
       blocked: true,
@@ -255,19 +256,16 @@ export function checkTransition(
     };
   }
 
-  if (DEBUG.MAP)
-    console.log(
-      `[Action] Found transition at (${transition.fromPosition.x}, ${transition.fromPosition.y})`
-    );
-  if (DEBUG.MAP)
-    console.log(
-      `[Action] Transitioning from ${mapManager.getCurrentMapId()} to ${transition.toMapId}`
-    );
+  debugLog(
+    'Action',
+    `Found transition at (${transition.fromPosition.x}, ${transition.fromPosition.y})`
+  );
+  debugLog('Action', `Transitioning from ${mapManager.getCurrentMapId()} to ${transition.toMapId}`);
 
   try {
     // Transition to new map (pass current map ID for depth tracking)
     const { map, spawn } = transitionToMap(transition.toMapId, transition.toPosition);
-    if (DEBUG.MAP) console.log(`[Action] Successfully loaded map: ${map.id} (${map.name})`);
+    debugLog('Action', `Successfully loaded map: ${map.id} (${map.name})`);
 
     return {
       success: true,
@@ -309,10 +307,10 @@ export function handleFarmAction(
   const plot = farmManager.getPlot(currentMapId, position);
   const plotTileType = plot ? farmManager.getTileTypeForPlot(plot) : tileData?.type;
 
-  if (DEBUG.FARM)
-    console.log(
-      `[Action] Tile at (${position.x}, ${position.y}): visual type=${tileData?.type}, plot type=${plotTileType}, currentTool=${currentTool}`
-    );
+  debugLog(
+    'Action',
+    `Tile at (${position.x}, ${position.y}): visual type=${tileData?.type}, plot type=${plotTileType}, currentTool=${currentTool}`
+  );
 
   // Check for wild strawberry harvesting with hand tool
   // Check if this is a farm tile or farm action (check both visual tile and plot state)
@@ -322,10 +320,10 @@ export function handleFarmAction(
       plotTileType >= TileType.SOIL_FALLOW &&
       plotTileType <= TileType.SOIL_DEAD)
   ) {
-    if (DEBUG.FARM)
-      console.log(
-        `[Action] Farm tile detected! Visual: ${tileData?.type}, Plot state: ${plotTileType}`
-      );
+    debugLog(
+      'Action',
+      `Farm tile detected! Visual: ${tileData?.type}, Plot state: ${plotTileType}`
+    );
 
     let farmActionTaken = false;
 
@@ -334,10 +332,9 @@ export function handleFarmAction(
       if (!staminaManager.performActivity('till')) {
         return { handled: false };
       }
-      if (DEBUG.FARM)
-        console.log(`[Action] Attempting to till soil at (${position.x}, ${position.y})`);
+      debugLog('Action', `Attempting to till soil at (${position.x}, ${position.y})`);
       if (farmManager.tillSoil(currentMapId, position)) {
-        if (DEBUG.FARM) console.log('[Action] Tilled soil');
+        debugLog('Action', 'Tilled soil');
         onAnimationTrigger?.('till');
         farmActionTaken = true;
       }
@@ -357,17 +354,17 @@ export function handleFarmAction(
           messageType: 'warning',
         };
       }
-      if (DEBUG.FARM) console.log(`[Action] Attempting to plant: ${currentTool} (crop: ${cropId})`);
+      debugLog('Action', `Attempting to plant: ${currentTool} (crop: ${cropId})`);
       const plantResult = farmManager.plantSeed(currentMapId, position, cropId, currentTool);
       if (plantResult.success) {
         // FarmManager consumed seed from inventory, save it
         const inventoryData = inventoryManager.getInventoryData();
         characterData.saveInventory(inventoryData.items, inventoryData.tools);
-        if (DEBUG.FARM) console.log(`[Action] Planted ${cropId}`);
+        debugLog('Action', `Planted ${cropId}`);
         onAnimationTrigger?.('plant');
         farmActionTaken = true;
       } else {
-        if (DEBUG.FARM) console.log(`[Action] Failed to plant: ${plantResult.reason}`);
+        debugLog('Action', `Failed to plant: ${plantResult.reason}`);
         // Return the failure reason to show to user
         return {
           handled: false,
@@ -412,7 +409,7 @@ export function handleFarmAction(
         };
       }
       if (farmManager.waterPlot(currentMapId, position)) {
-        if (DEBUG.FARM) console.log('[Action] Watered crop');
+        debugLog('Action', 'Watered crop');
         gameState.useWater(); // Consume water
         onAnimationTrigger?.('water', position);
         farmActionTaken = true;
@@ -451,10 +448,10 @@ export function handleFarmAction(
             result.quality !== 'normal'
               ? ` (${result.quality} quality, ${qualityMultiplier}x gold!)`
               : '';
-          if (DEBUG.FARM)
-            console.log(
-              `[Action] Harvested ${result.yield}x ${crop.displayName}${qualityStr} for ${totalGold} gold`
-            );
+          debugLog(
+            'Action',
+            `Harvested ${result.yield}x ${crop.displayName}${qualityStr} for ${totalGold} gold`
+          );
         }
         onAnimationTrigger?.('harvest', position);
         farmActionTaken = true;
@@ -462,7 +459,7 @@ export function handleFarmAction(
     } else if (plotTileType === TileType.SOIL_DEAD) {
       // Clear dead crop (works with any tool - no need to switch)
       if (farmManager.clearDeadCrop(currentMapId, position)) {
-        if (DEBUG.FARM) console.log('[Action] Cleared dead crop');
+        debugLog('Action', 'Cleared dead crop');
         onAnimationTrigger?.('clear');
         farmActionTaken = true;
       }
@@ -615,7 +612,7 @@ export function checkWellInteraction(playerPos: Position): boolean {
   for (const tile of tilesToCheck) {
     const tileData = getTileData(tile.x, tile.y);
     if (tileData && tileData.type === TileType.WELL) {
-      if (DEBUG.FARM) console.log(`[Action] Found well at (${tile.x}, ${tile.y})`);
+      debugLog('Action', `Found well at (${tile.x}, ${tile.y})`);
       return true;
     }
   }
@@ -682,7 +679,7 @@ export function handleRefillWaterCan(): { success: boolean; message: string } {
   // Refill the can
   gameState.refillWaterCan();
   const message = 'Refilled watering can!';
-  if (DEBUG.FARM) console.log(`[Action] ${message}`);
+  debugLog('Action', `${message}`);
 
   return {
     success: true,
@@ -704,7 +701,7 @@ export function handleCollectWater(): { success: boolean; message: string } {
   characterData.saveInventory(inventoryData.items, inventoryData.tools);
 
   const message = `Collected ${waterAmount} water from the well!`;
-  if (DEBUG.FARM) console.log(`[Action] ${message}`);
+  debugLog('Action', `${message}`);
 
   return {
     success: true,
@@ -733,7 +730,7 @@ export function checkCookingLocation(playerPos: Position): CookingLocationResult
     if (!tileData) continue;
 
     if (tileData.type === TileType.STOVE) {
-      if (DEBUG.NPC) console.log(`[Action] Found stove at (${tile.x}, ${tile.y})`);
+      debugLog('Action', `Found stove at (${tile.x}, ${tile.y})`);
       return {
         found: true,
         locationType: 'stove',
@@ -742,7 +739,7 @@ export function checkCookingLocation(playerPos: Position): CookingLocationResult
     }
 
     if (tileData.type === TileType.CAMPFIRE) {
-      if (DEBUG.NPC) console.log(`[Action] Found campfire at (${tile.x}, ${tile.y})`);
+      debugLog('Action', `Found campfire at (${tile.x}, ${tile.y})`);
       return {
         found: true,
         locationType: 'campfire',
@@ -751,7 +748,7 @@ export function checkCookingLocation(playerPos: Position): CookingLocationResult
     }
 
     if (tileData.type === TileType.CAULDRON) {
-      if (DEBUG.NPC) console.log(`[Action] Found cauldron at (${tile.x}, ${tile.y})`);
+      debugLog('Action', `Found cauldron at (${tile.x}, ${tile.y})`);
       return {
         found: true,
         locationType: 'cauldron',

--- a/utils/farmManager.ts
+++ b/utils/farmManager.ts
@@ -14,10 +14,11 @@ import { TimeManager, Season } from './TimeManager';
 import { inventoryManager } from './inventoryManager';
 import { getSeedItemId, getCropItemId } from '../data/items';
 import { getTileCoords } from './mapUtils';
-import { GROWTH_THRESHOLDS, DEBUG, SHARED_FARM_MAP_IDS } from '../constants';
+import { GROWTH_THRESHOLDS, SHARED_FARM_MAP_IDS } from '../constants';
 import { getWeatherZone } from '../data/weatherConfig';
 import { eventBus, GameEvent } from './EventBus';
 import { reportMessage } from './errorReporting';
+import { debugLog, isDebugLogEnabled } from './debugLog';
 
 /** Interval for batch-flushing dirty shared plots to Firestore */
 const SHARED_SYNC_INTERVAL_MS = 10_000;
@@ -126,9 +127,7 @@ class FarmManager {
     }
 
     if (updated.length > 0) {
-      if (DEBUG.FARM) {
-        console.log(`[FarmManager] Updated ${updated.length} plots`);
-      }
+      debugLog('FarmManager', `Updated ${updated.length} plots`);
       // Emit a single event for all crop growth updates
       eventBus.emit(GameEvent.FARM_PLOT_CHANGED, {});
     }
@@ -229,8 +228,7 @@ class FarmManager {
     if (plot.state === FarmPlotState.WILTING) {
       const msSinceStateChange = now - plot.stateChangedAtTimestamp;
       if (msSinceStateChange >= crop.deathGracePeriod) {
-        if (DEBUG.FARM)
-          console.log(`[FarmManager] Crop died at ${plot.position.x},${plot.position.y}`);
+        debugLog('FarmManager', `Crop died at ${plot.position.x},${plot.position.y}`);
         return {
           ...plot,
           state: FarmPlotState.DEAD,
@@ -247,8 +245,7 @@ class FarmManager {
       if (needsWater) {
         const msSinceNeeded = msSinceWatered - crop.waterNeededInterval;
         if (msSinceNeeded >= crop.wiltingGracePeriod) {
-          if (DEBUG.FARM)
-            console.log(`[FarmManager] Crop wilting at ${plot.position.x},${plot.position.y}`);
+          debugLog('FarmManager', `Crop wilting at ${plot.position.x},${plot.position.y}`);
           return {
             ...plot,
             state: FarmPlotState.WILTING,
@@ -274,8 +271,7 @@ class FarmManager {
       const growthTime = isWatered ? crop.growthTimeWatered : crop.growthTime;
 
       if (msSincePlanted >= growthTime) {
-        if (DEBUG.FARM)
-          console.log(`[FarmManager] Crop ready at ${plot.position.x},${plot.position.y}`);
+        debugLog('FarmManager', `Crop ready at ${plot.position.x},${plot.position.y}`);
         return {
           ...plot,
           state: FarmPlotState.READY,
@@ -296,10 +292,10 @@ class FarmManager {
     const key = this.getPlotKey(mapId, position);
     const existing = this.plots.get(key);
 
-    if (DEBUG.FARM)
-      console.log(
-        `[FarmManager] tillSoil called: mapId=${mapId}, position=(${position.x},${position.y}), existing=${existing ? `state=${FarmPlotState[existing.state]}` : 'none'}`
-      );
+    debugLog(
+      'FarmManager',
+      `tillSoil called: mapId=${mapId}, position=(${position.x},${position.y}), existing=${existing ? `state=${FarmPlotState[existing.state]}` : 'none'}`
+    );
 
     // Can only till fallow soil or create new plots
     if (existing && existing.state !== FarmPlotState.FALLOW) {
@@ -331,7 +327,7 @@ class FarmManager {
     };
 
     this.registerPlot(plot);
-    if (DEBUG.FARM) console.log(`[FarmManager] Tilled soil at ${position.x},${position.y}`);
+    debugLog('FarmManager', `Tilled soil at ${position.x},${position.y}`);
     eventBus.emit(GameEvent.FARM_PLOT_CHANGED, { position: tile, action: 'till' });
     this.syncSharedPlot(mapId, position);
     return true;
@@ -403,10 +399,10 @@ class FarmManager {
     };
 
     this.registerPlot(updatedPlot);
-    if (DEBUG.FARM)
-      console.log(
-        `[FarmManager] Planted ${cropId} at ${position.x},${position.y} in ${gameTime.season} (used 1 seed)`
-      );
+    debugLog(
+      'FarmManager',
+      `Planted ${cropId} at ${position.x},${position.y} in ${gameTime.season} (used 1 seed)`
+    );
     eventBus.emit(GameEvent.FARM_PLOT_CHANGED, { position: plot.position, action: 'plant' });
     this.syncSharedPlot(mapId, position);
     return { success: true };
@@ -469,7 +465,7 @@ class FarmManager {
     };
 
     this.registerPlot(updatedPlot);
-    if (DEBUG.FARM) console.log(`[FarmManager] Watered crop at ${position.x},${position.y}`);
+    debugLog('FarmManager', `Watered crop at ${position.x},${position.y}`);
     eventBus.emit(GameEvent.FARM_PLOT_CHANGED, { position: plot.position, action: 'water' });
     this.syncSharedPlot(mapId, position);
     return true;
@@ -502,7 +498,7 @@ class FarmManager {
     };
 
     this.registerPlot(updatedPlot);
-    if (DEBUG.FARM) console.log(`[FarmManager] Revived crop at ${position.x},${position.y}`);
+    debugLog('FarmManager', `Revived crop at ${position.x},${position.y}`);
     eventBus.emit(GameEvent.FARM_PLOT_CHANGED, { position: plot.position, action: 'revive' });
     this.syncSharedPlot(mapId, position);
     return true;
@@ -553,10 +549,10 @@ class FarmManager {
     };
 
     this.registerPlot(updatedPlot);
-    if (DEBUG.FARM)
-      console.log(
-        `[FarmManager] Applied fertiliser at ${position.x},${position.y}, quality now ${newQuality}`
-      );
+    debugLog(
+      'FarmManager',
+      `Applied fertiliser at ${position.x},${position.y}, quality now ${newQuality}`
+    );
     return { success: true };
   }
 
@@ -653,12 +649,13 @@ class FarmManager {
     }
 
     this.registerPlot(updatedPlot);
-    if (DEBUG.FARM) {
+    if (isDebugLogEnabled('FarmManager')) {
       const qualityStr = quality !== 'normal' ? ` (${quality} quality)` : '';
       const seedsInfo = seedsDropped > 0 ? ` + ${seedsDropped}x seeds` : '';
       const herbInfo = crop.isHerb ? ' (herb — plot persists, in cooldown)' : '';
-      console.log(
-        `[FarmManager] Harvested ${crop.harvestYield}x ${crop.displayName}${qualityStr}${seedsInfo}${herbInfo} at ${position.x},${position.y}`
+      debugLog(
+        'FarmManager',
+        `Harvested ${crop.harvestYield}x ${crop.displayName}${qualityStr}${seedsInfo}${herbInfo} at ${position.x},${position.y}`
       );
     }
     eventBus.emit(GameEvent.FARM_PLOT_CHANGED, { position: plot.position, action: 'harvest' });
@@ -746,7 +743,7 @@ class FarmManager {
         this.registerPlot({ ...plotBefore });
         this.dirtySharedPlots.delete(plotId);
 
-        console.log(`[SharedFarm] Lost the race for ${plotId} — harvest rolled back`);
+        debugLog('SharedFarm', `Lost the race for ${plotId} — harvest rolled back`);
         eventBus.emit(GameEvent.FARM_PLOT_CHANGED, { position, action: 'harvest' });
         eventBus.emit(GameEvent.FARM_HARVEST_CONTESTED, {
           mapId,
@@ -803,7 +800,7 @@ class FarmManager {
     };
 
     this.registerPlot(updatedPlot);
-    if (DEBUG.FARM) console.log(`[FarmManager] Removed herb at ${position.x},${position.y}`);
+    debugLog('FarmManager', `Removed herb at ${position.x},${position.y}`);
     eventBus.emit(GameEvent.FARM_PLOT_CHANGED, { position: plot.position, action: 'clear' });
     this.syncSharedPlot(mapId, position);
     return true;
@@ -885,10 +882,11 @@ class FarmManager {
     };
 
     this.registerPlot(updatedPlot);
-    if (DEBUG.FARM) {
+    if (isDebugLogEnabled('FarmManager')) {
       const qualityStr = quality !== 'normal' ? ` (${quality} quality)` : '';
-      console.log(
-        `[FarmManager] Dual-harvest (${mode}): ${cropYield}x ${crop.displayName} + ${seedsDropped}x seeds${qualityStr} at ${position.x},${position.y}`
+      debugLog(
+        'FarmManager',
+        `Dual-harvest (${mode}): ${cropYield}x ${crop.displayName} + ${seedsDropped}x seeds${qualityStr} at ${position.x},${position.y}`
       );
     }
     eventBus.emit(GameEvent.FARM_PLOT_CHANGED, { position: plot.position, action: 'harvest' });
@@ -936,7 +934,7 @@ class FarmManager {
     };
 
     this.registerPlot(updatedPlot);
-    if (DEBUG.FARM) console.log(`[FarmManager] Cleared dead crop at ${position.x},${position.y}`);
+    debugLog('FarmManager', `Cleared dead crop at ${position.x},${position.y}`);
     eventBus.emit(GameEvent.FARM_PLOT_CHANGED, { position: plot.position, action: 'clear' });
     this.syncSharedPlot(mapId, position);
     return true;
@@ -1123,9 +1121,7 @@ class FarmManager {
       }
     }
 
-    if (affectedCount > 0 && DEBUG.FARM) {
-      console.log(`[FarmManager] Set ${affectedCount} crops to ${quality} quality`);
-    }
+    debugLog('FarmManager', `Set ${affectedCount} crops to ${quality} quality`);
 
     return affectedCount;
   }
@@ -1160,9 +1156,7 @@ class FarmManager {
       }
     }
 
-    if (affectedCount > 0 && DEBUG.FARM) {
-      console.log(`[FarmManager] Applied abundant harvest blessing to ${affectedCount} crops`);
-    }
+    debugLog('FarmManager', `Applied abundant harvest blessing to ${affectedCount} crops`);
 
     return affectedCount;
   }
@@ -1215,9 +1209,7 @@ class FarmManager {
     }
 
     if (wateredCount > 0) {
-      if (DEBUG.FARM) {
-        console.log(`[FarmManager] Rain watered ${wateredCount} outdoor plots`);
-      }
+      debugLog('FarmManager', `Rain watered ${wateredCount} outdoor plots`);
       eventBus.emit(GameEvent.FARM_PLOT_CHANGED, { action: 'water' });
     }
 
@@ -1259,12 +1251,12 @@ class FarmManager {
         this.plots.set(key, fallenPlot);
         this.dirtySharedPlots.add(key);
         purgedCount++;
-        if (DEBUG.FARM) console.log(`[SharedFarm] Orphaned local plot queued for deletion: ${key}`);
+        debugLog('SharedFarm', `Orphaned local plot queued for deletion: ${key}`);
       }
     }
 
     if (purgedCount > 0) {
-      console.log(`[SharedFarm] Purged ${purgedCount} orphaned local plots from ${mapId}`);
+      debugLog('SharedFarm', `Purged ${purgedCount} orphaned local plots from ${mapId}`);
       eventBus.emit(GameEvent.FARM_PLOT_CHANGED, {});
     }
   }
@@ -1277,7 +1269,7 @@ class FarmManager {
     if (!SHARED_FARM_MAP_IDS.has(mapId)) return;
     const key = this.getPlotKey(mapId, position);
     this.dirtySharedPlots.add(key);
-    if (DEBUG.FARM) console.log(`[SharedFarm] Marked dirty: ${key}`);
+    debugLog('SharedFarm', `Marked dirty: ${key}`);
   }
 
   /**
@@ -1297,7 +1289,7 @@ class FarmManager {
 
     // Start the flush interval
     this.flushInterval = setInterval(() => this.flushDirtyPlots(), SHARED_SYNC_INTERVAL_MS);
-    console.log(`[SharedFarm] Started batch sync (${SHARED_SYNC_INTERVAL_MS / 1000}s interval)`);
+    debugLog('SharedFarm', `Started batch sync (${SHARED_SYNC_INTERVAL_MS / 1000}s interval)`);
 
     // Start real-time listener for remote changes
     try {
@@ -1328,7 +1320,7 @@ class FarmManager {
             if (baseTile !== TileType.SOIL_FALLOW) {
               this.dirtySharedPlots.add(plotId);
               purged++;
-              if (DEBUG.FARM) console.log(`[SharedFarm] Rejecting orphaned remote plot: ${plotId}`);
+              debugLog('SharedFarm', `Rejecting orphaned remote plot: ${plotId}`);
               continue;
             }
           }
@@ -1344,8 +1336,9 @@ class FarmManager {
         }
 
         if (purged > 0) {
-          console.log(
-            `[SharedFarm] Rejected ${purged} orphaned remote plots — queued for Firestore deletion`
+          debugLog(
+            'SharedFarm',
+            `Rejected ${purged} orphaned remote plots — queued for Firestore deletion`
           );
         }
 
@@ -1368,12 +1361,12 @@ class FarmManager {
         }
 
         if (applied > 0) {
-          console.log(`[SharedFarm] Applied ${applied} remote updates from other players`);
+          debugLog('SharedFarm', `Applied ${applied} remote updates from other players`);
           eventBus.emit(GameEvent.FARM_PLOT_CHANGED, { action: 'water' });
         }
       });
     } catch {
-      console.log('[SharedFarm] Firebase not available — local-only mode');
+      debugLog('SharedFarm', 'Firebase not available — local-only mode');
     }
   }
 
@@ -1404,7 +1397,7 @@ class FarmManager {
       // Firebase not available
     }
 
-    console.log('[SharedFarm] Stopped batch sync');
+    debugLog('SharedFarm', 'Stopped batch sync');
   }
 
   /**
@@ -1461,7 +1454,7 @@ class FarmManager {
       }
 
       if (written > 0 || cleared > 0) {
-        console.log(`[SharedFarm] Flushed ${written} writes, ${cleared} clears to Firestore`);
+        debugLog('SharedFarm', `Flushed ${written} writes, ${cleared} clears to Firestore`);
       }
       if (failed > 0) {
         console.warn(`[SharedFarm] ${failed} plot write(s) failed and will be retried`);
@@ -1475,7 +1468,7 @@ class FarmManager {
         });
       }
     } catch {
-      console.log('[SharedFarm] Flush failed — Firebase not available');
+      debugLog('SharedFarm', 'Flush failed — Firebase not available');
     }
   }
 
@@ -1534,8 +1527,9 @@ class FarmManager {
    * map, as debug tooling intends.
    */
   debugAdvanceTime(milliseconds: number, mapId?: string): void {
-    console.log(
-      `[FarmManager DEBUG] Advancing time by ${milliseconds}ms${mapId ? ` (map: ${mapId})` : ''}`
+    debugLog(
+      'FarmManager',
+      `Advancing time by ${milliseconds}ms${mapId ? ` (map: ${mapId})` : ''}`
     );
 
     for (const plot of this.plots.values()) {
@@ -1558,7 +1552,7 @@ class FarmManager {
 
     // Trigger update to recalculate states
     this.updateAllPlots();
-    console.log(`[FarmManager DEBUG] Time advanced, plots updated`);
+    debugLog('FarmManager', `Time advanced, plots updated`);
   }
 }
 


### PR DESCRIPTION
## Summary

88 more §2 sites (stacks on #85): farmManager 31, FriendshipManager 30, actionHandlers 27 — all routine traces (farm ops, friendship levels, action handling), gated under `farmmanager`/`friendshipmanager`/`action`/`sharedfarm` etc. by their existing prefixes.

- farmManager's 18 dead `DEBUG.FARM` guards unwrapped: log-only blocks collapse to plain `debugLog` calls; the two string-building harvest blocks become `if (isDebugLogEnabled('FarmManager'))` so assembly stays lazy and the diagnostics become reachable via `?debug=farmmanager`
- The two `[FarmManager DEBUG]`-prefixed sites in `debugAdvanceTime` normalise to the `FarmManager` category
- Two failure-flavoured traces reviewed by hand and kept gated: plant-failure reasons already reach the player as a warning toast (the handler returns `messageType: 'warning'`), and the shared-farm flush catch is the normal offline path
- No `DEBUG` usage remains in these three files — their constants imports drop `DEBUG`

## Verification

- `npm run verify`: tsc clean, 885/885 tests
- `npx eslint .`: 0 errors, 0 warnings