### PR TITLE
Stop a picked-up bench duplicating, show whole messages, talk with space

### DIFF
--- a/components/ChatPanel.tsx
+++ b/components/ChatPanel.tsx
@@ -96,7 +96,7 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
           }`}
         >
           <span aria-hidden="true">💬</span>
-          <span>Say something</span>
+          <span>Say something (space)</span>
         </button>
       )}
     </div>

--- a/firebase/safe.ts
+++ b/firebase/safe.ts
@@ -159,7 +159,7 @@ const stubChatService = {
 const stubSharedPlacedItemsService = {
   isAvailable: () => false,
   getListeningMap: () => null as string | null,
-  onChange: (_cb: () => void) => () => {},
+  onChange: (_cb: (removedIds: string[]) => void) => () => {},
   startListening: (_mapId: string) => false,
   stopListening: () => {},
   getPublishedIds: () => [] as string[],

--- a/firebase/sharedPlacedItemsService.ts
+++ b/firebase/sharedPlacedItemsService.ts
@@ -31,7 +31,7 @@ const PLACED_ITEMS_COLLECTION = 'shared/world/placedItems';
 class SharedPlacedItemsService {
   private unsubscribe: Unsubscribe | null = null;
   private listeningMapId: string | null = null;
-  private listeners = new Set<() => void>();
+  private listeners = new Set<(removedIds: string[]) => void>();
   private reportedWriteFailure = false;
   /**
    * Ids Firestore actually holds, straight from the snapshots and never touched
@@ -50,18 +50,27 @@ class SharedPlacedItemsService {
     return this.listeningMapId;
   }
 
-  /** Notified whenever the mirrored set changes, so the renderer can refresh. */
-  onChange(callback: () => void): () => void {
+  /**
+   * Notified whenever the mirrored set changes, so the renderer can refresh.
+   *
+   * Receives the ids Firestore dropped in this batch. The caller needs them:
+   * an item another player picked up is gone from the world, but it may still
+   * sit in *our* local save, and local state wins in getPlacedItems(). Without
+   * following the deletion the item stays on screen and is republished on our
+   * next reconcile — so picking up somebody's bench duplicated it instead of
+   * moving it.
+   */
+  onChange(callback: (removedIds: string[]) => void): () => void {
     this.listeners.add(callback);
     return () => {
       this.listeners.delete(callback);
     };
   }
 
-  #emit(): void {
+  #emit(removedIds: string[]): void {
     for (const listener of this.listeners) {
       try {
-        listener();
+        listener(removedIds);
       } catch (error) {
         console.warn('[SharedItems] Listener threw:', error);
       }
@@ -90,8 +99,10 @@ class SharedPlacedItemsService {
       this.unsubscribe = onSnapshot(
         collection(db, PLACED_ITEMS_COLLECTION),
         (snapshot) => {
+          const removedIds: string[] = [];
           for (const change of snapshot.docChanges()) {
             if (change.type === 'removed') {
+              removedIds.push(change.doc.id);
               this.publishedIds.delete(change.doc.id);
               sharedPlacedItemsManager.remove(change.doc.id);
               continue;
@@ -117,7 +128,7 @@ class SharedPlacedItemsService {
             this.publishedIds.add(change.doc.id);
             sharedPlacedItemsManager.apply(item);
           }
-          this.#emit();
+          this.#emit(removedIds);
         },
         (error) => {
           console.warn('[SharedItems] Listener failed:', error);

--- a/hooks/useKeyboardControls.ts
+++ b/hooks/useKeyboardControls.ts
@@ -260,10 +260,19 @@ export function useKeyboardControls(config: KeyboardControlsConfig) {
       return;
     }
 
-    // M key to start typing a chat message. The composer is an <input>, and the
-    // guard at the top of this handler ignores keys while one has focus, so the
-    // player types instead of walking.
-    if ((e.key === 'm' || e.key === 'M') && onStartChat && !showMiniGameRef.current) {
+    // Space (or M) to start typing a chat message. The composer is an <input>,
+    // and the guard at the top of this handler ignores keys while one has focus,
+    // so the player types instead of walking.
+    //
+    // Space rather than Enter: Enter is half of the action key (E/Enter) and
+    // taking it would break every prompt and dialogue. Space was unbound, and
+    // "press space to talk" is a shorter thing to remember than a letter.
+    // preventDefault matters here — space scrolls the page otherwise.
+    if (
+      (e.key === ' ' || e.key === 'm' || e.key === 'M') &&
+      onStartChat &&
+      !showMiniGameRef.current
+    ) {
       e.preventDefault();
       onStartChat();
       return;

--- a/hooks/useSharedPlacedItemsController.ts
+++ b/hooks/useSharedPlacedItemsController.ts
@@ -107,6 +107,26 @@ export function useSharedPlacedItemsController(
       });
     };
 
+    /**
+     * Someone picked up an item that is also in our own save.
+     *
+     * Local state wins in getPlacedItems(), and it is what the outbound
+     * reconcile publishes — so an item deleted by another player stayed on our
+     * screen *and* was republished on our next placement. Picking up somebody's
+     * bench therefore duplicated it rather than moving it, and a bench they
+     * removed came back. Following the deletion into local state is what keeps
+     * the two stores telling the same story.
+     */
+    const followRemovals = (removedIds: string[]) => {
+      for (const id of removedIds) {
+        if (!gameState.getAllPlacedItems().some((item) => item.id === id)) continue;
+        if (DEBUG.MULTIPLAYER) console.log(`[SharedItems] ${id} was picked up by someone else`);
+        // Safe against a loop: the document is already gone from publishedIds,
+        // so the reconcile this triggers has nothing left to delete.
+        gameState.removePlacedItem(id);
+      }
+    };
+
     const hydratePaintings = () => {
       const mapId = sharedPlacedItemsManager.getMapId();
       if (!mapId) return;
@@ -132,7 +152,8 @@ export function useSharedPlacedItemsController(
       const loaded = await whenFirebaseSettled();
       if (cancelled || !loaded) return;
 
-      unsubscribe = getSharedPlacedItemsService().onChange(() => {
+      unsubscribe = getSharedPlacedItemsService().onChange((removedIds) => {
+        followRemovals(removedIds);
         hydratePaintings();
         announce();
       });

--- a/multiplayer/chat.ts
+++ b/multiplayer/chat.ts
@@ -31,11 +31,19 @@ export const CHAT_MAX_AGE_MS = 10 * 60 * 1000;
 export const CHAT_BUBBLE_DURATION_MS = 8000;
 
 /**
- * Longest text a bubble shows before eliding. A bubble that grows to 140
- * characters covers the map it is floating over; the full text stays readable
- * in the chat history.
+ * Longest text a bubble shows before eliding.
+ *
+ * Deliberately the same as MAX_CHAT_LENGTH: anything a player is allowed to
+ * send, they are allowed to see. This used to be 64 while messages could be
+ * 140 characters long, so a bubble silently ate the back half of a sentence and
+ * no amount of expanding would show it. The bubble wraps instead, which costs a
+ * couple of lines of sky and reads properly.
+ *
+ * It stays as a cap rather than being deleted because inbound records come from
+ * other clients: the rules enforce 140 server-side, and a bubble should elide
+ * rather than paint over the map if that ever changes.
  */
-export const MAX_BUBBLE_CHARS = 64;
+export const MAX_BUBBLE_CHARS = MAX_CHAT_LENGTH;
 
 /** Text as it appears in a speech bubble. */
 export function truncateForBubble(text: string): string {

--- a/tests/chatProximity.test.ts
+++ b/tests/chatProximity.test.ts
@@ -19,7 +19,12 @@ vi.mock('../constants', async () => {
 
 import { MULTIPLAYER } from '../constants';
 import { remotePlayerManager } from '../multiplayer/RemotePlayerManager';
-import { CHAT_BUBBLE_DURATION_MS, truncateForBubble, MAX_BUBBLE_CHARS } from '../multiplayer/chat';
+import {
+  CHAT_BUBBLE_DURATION_MS,
+  truncateForBubble,
+  MAX_BUBBLE_CHARS,
+  MAX_CHAT_LENGTH,
+} from '../multiplayer/chat';
 import {
   setLocalChatBubble,
   getLocalChatBubble,
@@ -100,9 +105,18 @@ describe('truncateForBubble', () => {
     expect(truncateForBubble('come and see my farm')).toBe('come and see my farm');
   });
 
-  it('elides a wall of text rather than covering the map with it', () => {
-    const long = 'a'.repeat(MAX_BUBBLE_CHARS + 40);
-    const shown = truncateForBubble(long);
+  it('shows a whole message, because anything sendable is readable', () => {
+    // The cap used to be 64 while MAX_CHAT_LENGTH was 140, so the back half of a
+    // sentence vanished into an ellipsis and the bubble could never grow to show
+    // it. Whatever a player may send, the bubble must be willing to display.
+    const longest = 'a'.repeat(MAX_CHAT_LENGTH);
+    expect(truncateForBubble(longest)).toBe(longest);
+    expect(MAX_BUBBLE_CHARS).toBeGreaterThanOrEqual(MAX_CHAT_LENGTH);
+  });
+
+  it('still elides something longer than a client is allowed to send', () => {
+    const overlong = 'a'.repeat(MAX_BUBBLE_CHARS + 40);
+    const shown = truncateForBubble(overlong);
     expect(shown).toHaveLength(MAX_BUBBLE_CHARS);
     expect(shown.endsWith('…')).toBe(true);
   });


### PR DESCRIPTION
Three things reported while playing.

## Picking up another player's furniture duplicated it

A real design flaw in the shared-placement work: **local state and the shared collection were two sources of truth for the same object.**

Picking up Sanne's bench deleted the document, but her save still held it — and local state wins in `getPlacedItems()`, so it stayed on her screen *and* was republished on her next placement. Put the picked-up one down and there are two. The same flaw made an item she removed come back a moment later.

Deletions now travel into local state: the service reports which ids Firestore dropped in a batch, and the controller removes any of ours among them. No loop — the document is already out of `publishedIds` by then, so the reconcile that follows has nothing left to delete.

## A bubble could not show a whole message

`MAX_CHAT_LENGTH` was 140; `MAX_BUBBLE_CHARS` was 64. The back half of a sentence went into an ellipsis and no amount of expanding would reveal it. Anything a player may send, they may read — the cap is now the send limit and the bubble wraps.

**This may not be the whole story.** One player could see her own text in full while the other saw it cut short, and both screens truncate through the same code — so there is likely a second cause on the rendering side. I'd rather wait to hear whether the cut text ends in an ellipsis than ship a speculative scale fix on top of a real one.

## Space to talk

Not Enter: Enter is half the action key (E/Enter) and taking it would break every prompt and dialogue. Space was unbound, and "press space to talk" is less for a child to remember. `M` still works.

886 tests pass; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh8xj7NRhaxSGEMCunnqLY