### PR TITLE
Restore the item preview + quantity picker on a normal shop click

### DIFF
--- a/components/ShopUI.tsx
+++ b/components/ShopUI.tsx
@@ -177,16 +177,18 @@ const ShopUI: React.FC<ShopUIProps> = ({
   };
 
   /**
-   * Left-click a slot: trade exactly one.
+   * Left-click a slot: open the trade. Single-stock items buy one immediately;
+   * stacks open the item preview + quantity picker.
    *
-   * The quantity slider used to appear for any stack of more than one, which taxed the
-   * common case — buying a single packet of seeds meant a slider, a plus button and a
-   * confirm. Buying several is the rarer, more deliberate act, so it moved to right-click
-   * (long-press on touch), where every other "more options" gesture in the game lives.
+   * This is the confirmation step on purpose: the picker shows what you are
+   * buying and lets you choose how many before any money moves. A previous
+   * experiment made left-click buy one instantly (quantity moved to right-click
+   * / long-press) — it was reverted because silently spending gold on a single
+   * click skipped exactly that "what am I buying, how many" moment.
    */
   const handleSlotClick = (itemId: string, fromShop: boolean, maxQuantity: number) => {
     if (maxQuantity < 1) return;
-    executeTransaction(itemId, 1, fromShop);
+    initiateTrade(itemId, fromShop, maxQuantity);
   };
 
   /** Right-click / long-press a slot: choose how many. */
@@ -594,7 +596,8 @@ const ShopUI: React.FC<ShopUIProps> = ({
                 </div>
               </div>
               <div className="mt-2 text-xs text-slate-400">
-                Click to buy one • hold or right-click for more • {filteredShopInventory.length}
+                Click to buy • hold or right-click to choose how many •{' '}
+                {filteredShopInventory.length}
                 {shopFilter !== 'all' ? ` / ${shopInventory.length}` : ''} items available
               </div>
             </div>
@@ -624,7 +627,8 @@ const ShopUI: React.FC<ShopUIProps> = ({
                 </div>
               </div>
               <div className="mt-2 text-xs text-slate-400">
-                Click to sell one • hold or right-click for more • {playerInventory.length} items
+                Click to sell • hold or right-click to choose how many • {playerInventory.length}{' '}
+                items
               </div>
             </div>
           </div>

--- a/hooks/useSharedPlacedItemsController.ts
+++ b/hooks/useSharedPlacedItemsController.ts
@@ -120,7 +120,7 @@ export function useSharedPlacedItemsController(
     const followRemovals = (removedIds: string[]) => {
       for (const id of removedIds) {
         if (!gameState.getAllPlacedItems().some((item) => item.id === id)) continue;
-        if (DEBUG.MULTIPLAYER) console.log(`[SharedItems] ${id} was picked up by someone else`);
+        if (DEBUG.MULTIPLAYER) debugLog('SharedItems', `${id} was picked up by someone else`);
         // Safe against a loop: the document is already gone from publishedIds,
         // so the reconcile this triggers has nothing left to delete.
         gameState.removePlacedItem(id);

--- a/tests/shopClickQuantity.test.tsx
+++ b/tests/shopClickQuantity.test.tsx
@@ -1,17 +1,18 @@
 /**
  * @vitest-environment jsdom
  *
- * Buying one thing should cost one click.
+ * The quantity picker is the confirmation step for a shop trade.
  *
- * The shop used to open a quantity slider for any stack of more than one, so buying a
- * single packet of seeds meant a slider, a plus button and a confirm — while buying one
- * of something you could only afford one of went straight through. The common case paid
- * for the rare one.
+ * Clicking a slot shows what you are buying — the item preview card — and lets
+ * you choose how many before any money moves; single-stock items buy one
+ * immediately because there is nothing to choose. Right-click / long-press
+ * opens the same picker directly.
  *
- * Now left-click trades exactly one and right-click (long-press on touch) opens the
- * picker, matching every other "more options" gesture in the game. This is real money
- * moving on a single click, so both halves are pinned: a click must never silently buy
- * more than one, and the picker must still be reachable.
+ * (A previous experiment made left-click buy exactly one instantly and moved
+ * the picker to right-click only. It was reverted at the owner's request: real
+ * money moving on a single click skipped the "what am I buying, how many"
+ * moment entirely.) Both halves are pinned here: a click must never silently
+ * buy more than one, and the picker must still be reachable.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
@@ -23,10 +24,12 @@ const executeBuyTransaction = vi.fn((..._args: unknown[]) => ({
   result: { message: 'Bought 1x Radish Seeds' },
 }));
 
+const maxBuyQuantity = vi.fn((_itemId: string, _gold: number) => 9);
+
 vi.mock('../utils/ShopManager', () => ({
   shopManager: {
     getInventoryForShop: () => [{ itemId: 'seed_radish', buyPrice: 10, stock: 99 }],
-    getMaxBuyQuantity: () => 9,
+    getMaxBuyQuantity: (itemId: string, gold: number) => maxBuyQuantity(itemId, gold),
     getItemSellPrice: () => 5,
     executeBuyTransaction: (...args: unknown[]) => executeBuyTransaction(...args),
     executeSellTransaction: () => ({
@@ -75,11 +78,25 @@ function shopSlot(): HTMLElement {
 
 const quantityPickerOpen = () => screen.queryByText(/confirm/i) !== null;
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  maxBuyQuantity.mockReturnValue(9);
+});
 afterEach(cleanup);
 
 describe('shop slot: click vs right-click', () => {
-  it('buys exactly one on a left-click, with no picker in the way', () => {
+  it('opens the item preview + quantity picker on left-click, and buys nothing yet', () => {
+    renderShop();
+    fireEvent.click(shopSlot());
+
+    expect(executeBuyTransaction).not.toHaveBeenCalled();
+    expect(quantityPickerOpen()).toBe(true);
+    // The picker names what is being bought.
+    expect(screen.getByText('Radish Seeds')).toBeTruthy();
+  });
+
+  it('buys exactly one immediately when only one is affordable', () => {
+    maxBuyQuantity.mockReturnValue(1);
     renderShop();
     fireEvent.click(shopSlot());
 


### PR DESCRIPTION
## Summary

The owner reported that the shop "used to say something about the item to purchase, and then we could say how many we wanted — that seems to be gone". Investigated and found the exact commit: `ca1b502` (Sep 2) made left-click buy exactly one instantly and moved the "Buy How Many?" picker (item preview card + stepper) to right-click/long-press only. The flow wasn't deleted — it was demoted to a hidden gesture, which reads as gone.

**Restored:** left-click opens the trade again.
- Single-stock items: buy one immediately (unchanged from before `ca1b502` — there's nothing to choose)
- Stacks: item preview card (image, name, max) + quantity stepper + total cost, for **both buying and selling**
- Right-click / long-press: still opens the same picker — both gestures lead to one modal

**Kept from the experiment:** the long-press wiring (touch accessibility) — only the click handler changes.

**Pinned by tests** (`tests/shopClickQuantity.test.tsx` rewritten): stack click opens the picker and buys *nothing*; single-stock click still executes immediately with quantity 1; right-click opens the picker; browser context menu stays suppressed.

Also folds in one missed site from the logging sweep: a live `DEBUG.MULTIPLAYER`-guarded `console.log` in `useSharedPlacedItemsController` → `debugLog`, matching its siblings in the same file.

## Verification

- `npm run verify`: tsc clean, 903/903 tests
- `npx eslint .`: 0 errors, 0 warnings