### PR TITLE
Show what an NPC is saying above their head, for the other player

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -33,6 +33,7 @@ import { useEnvironmentController } from './hooks/useEnvironmentController';
 import { useMultiplayerController } from './hooks/useMultiplayerController';
 import { useChatController } from './hooks/useChatController';
 import { useSharedPlacedItemsController } from './hooks/useSharedPlacedItemsController';
+import { useNpcSpeechController } from './hooks/useNpcSpeechController';
 import { useEventChainUI } from './hooks/useEventChainUI';
 import { EventChainPopup } from './components/EventChainPopup';
 import { useAmbientVFX } from './hooks/useAmbientVFX';
@@ -456,6 +457,14 @@ const App: React.FC = () => {
   // everyone there. Nothing else needs wiring: GameState merges the shared items
   // into getPlacedItems(), which the renderer and interactions already use.
   useSharedPlacedItemsController({ currentMapId });
+
+  // What the NPCs are saying, shared: a snippet floats above the NPC for anyone
+  // standing near enough, so a conversation is something the other player can
+  // notice and wander over to rather than watching you stand still.
+  useNpcSpeechController({
+    currentMapId,
+    getLocalPosition: () => playerPosRef.current,
+  });
 
   const [isComposingChat, setIsComposingChat] = useState(false);
   const startComposingChat = useCallback(() => setIsComposingChat(true), []);

--- a/components/dialogue/UnifiedDialogueBox.tsx
+++ b/components/dialogue/UnifiedDialogueBox.tsx
@@ -28,6 +28,7 @@ import {
 import { useStreamingDialogue } from '../../hooks/useStreamingDialogue';
 import { useChatHistory } from '../../hooks/useChatHistory';
 import { TimeManager } from '../../utils/TimeManager';
+import { eventBus, GameEvent } from '../../utils/EventBus';
 import { gameState } from '../../GameState';
 import { getSharedDataService } from '../../firebase/safe';
 import { recordConversation, recordScriptedConversation } from '../../services/diaryService';
@@ -193,6 +194,21 @@ const UnifiedDialogueBox: React.FC<UnifiedDialogueBoxProps> = ({
     };
     loadDialogue();
   }, [npc, currentNodeId, mode, chatMessages, addAssistantMessage, onNodeChange]);
+
+  /**
+   * Share the NPC's latest line, so a player standing nearby sees a snippet
+   * above the NPC's head instead of watching you stand still.
+   *
+   * Watching the message list rather than hooking each addAssistantMessage
+   * call: scripted dialogue, AI replies and the offline fallback all land here,
+   * and there is exactly one place to get wrong. Streaming placeholders are
+   * skipped — publishing every token would be a write per character.
+   */
+  useEffect(() => {
+    const last = chatMessages[chatMessages.length - 1];
+    if (!last || last.role !== 'assistant' || last.isStreaming || !last.content) return;
+    eventBus.emit(GameEvent.NPC_SPOKE, { npcId: npc.id, text: last.content });
+  }, [chatMessages, npc.id]);
 
   // AI mode: game context
   // -------------------------------------------------------------------------

--- a/database.rules.json
+++ b/database.rules.json
@@ -62,6 +62,27 @@
           }
         }
       }
+    },
+    "npcSpeech": {
+      "$mapId": {
+        ".read": "auth != null",
+        "$npcId": {
+          ".write": "auth != null",
+          ".validate": "newData.hasChildren(['m','t','u'])",
+          "m": {
+            ".validate": "newData.isString() && newData.val().length > 0 && newData.val().length <= 90"
+          },
+          "t": {
+            ".validate": "newData.val() === now"
+          },
+          "u": {
+            ".validate": "newData.val() === auth.uid"
+          },
+          "$other": {
+            ".validate": false
+          }
+        }
+      }
     }
   }
 }

--- a/firebase/index.ts
+++ b/firebase/index.ts
@@ -52,6 +52,8 @@ export { presenceService } from './presenceService';
 
 export { chatService } from './chatService';
 
+export { npcSpeechService } from './npcSpeechService';
+
 export { sharedPlacedItemsService } from './sharedPlacedItemsService';
 
 export { sharedAlbumService } from './sharedAlbumService';

--- a/firebase/npcSpeechService.ts
+++ b/firebase/npcSpeechService.ts
@@ -1,0 +1,145 @@
+/**
+ * NPC speech transport — Realtime Database.
+ *
+ * A sibling of presenceService and chatService, and ephemeral for the same
+ * reason: what Mushra said forty minutes ago is not worth storing, and a room
+ * full of stale lines would be worse than none.
+ *
+ * One record per NPC (`npcSpeech/{mapId}/{npcId}`), overwritten rather than
+ * appended. An NPC only says one thing at a time, and the last line is the only
+ * one worth showing — so there is no history to page through and nothing to
+ * clean up.
+ *
+ * Nothing here throws to callers.
+ */
+
+import { ref, set, onChildAdded, onChildChanged, serverTimestamp } from 'firebase/database';
+import { getRealtimeDb } from './realtimeConfig';
+import { authService } from './authService';
+import { DEBUG } from '../constants';
+import { reportError } from '../utils/errorReporting';
+import { decodeNpcSpeech, truncateNpcSpeech } from '../multiplayer/npcSpeech';
+import type { NpcSpeechWire } from '../multiplayer/npcSpeech';
+
+const NPC_SPEECH_ROOT = 'npcSpeech';
+
+/** Minimal shape of the snapshots the RTDB child callbacks hand us. */
+interface ChildSnapshot {
+  key: string | null;
+  val: () => unknown;
+}
+
+class NpcSpeechService {
+  private roomMapId: string | null = null;
+  private unsubscribers: Array<() => void> = [];
+  private listeners = new Set<(npcId: string, wire: NpcSpeechWire) => void>();
+  private reportedSendFailure = false;
+
+  isAvailable(): boolean {
+    return getRealtimeDb() !== null && authService.isAuthenticated();
+  }
+
+  getCurrentRoom(): string | null {
+    return this.roomMapId;
+  }
+
+  onSpeech(callback: (npcId: string, wire: NpcSpeechWire) => void): () => void {
+    this.listeners.add(callback);
+    return () => {
+      this.listeners.delete(callback);
+    };
+  }
+
+  #emit(npcId: string, wire: NpcSpeechWire): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(npcId, wire);
+      } catch (error) {
+        console.warn('[NpcSpeech] Listener threw:', error);
+      }
+    }
+  }
+
+  /** Listen to what NPCs on this map are saying. */
+  async enterRoom(mapId: string): Promise<boolean> {
+    if (this.roomMapId === mapId) return true;
+    await this.leaveRoom();
+
+    const db = getRealtimeDb();
+    if (!db || !authService.isAuthenticated()) return false;
+
+    try {
+      const roomRef = ref(db, `${NPC_SPEECH_ROOT}/${mapId}`);
+      this.roomMapId = mapId;
+
+      const handle = (snapshot: ChildSnapshot) => {
+        const npcId = snapshot.key;
+        if (!npcId) return;
+        const wire = decodeNpcSpeech(snapshot.val());
+        if (!wire) return;
+        this.#emit(npcId, wire);
+      };
+
+      // Both events matter: the first line from an NPC arrives as an add, every
+      // line after it as a change to the same record.
+      this.unsubscribers.push(onChildAdded(roomRef, handle), onChildChanged(roomRef, handle));
+
+      if (DEBUG.MULTIPLAYER) console.log(`[NpcSpeech] Listening on "${mapId}"`);
+      return true;
+    } catch (error) {
+      console.warn(`[NpcSpeech] Failed to listen on "${mapId}":`, error);
+      reportError(error, 'presence', { room: mapId, transport: 'npc_speech' });
+      this.roomMapId = null;
+      return false;
+    }
+  }
+
+  async leaveRoom(): Promise<void> {
+    for (const unsubscribe of this.unsubscribers) {
+      try {
+        unsubscribe();
+      } catch {
+        /* detaching a dead listener is not worth reporting */
+      }
+    }
+    this.unsubscribers = [];
+    this.roomMapId = null;
+  }
+
+  /** Publish what an NPC just said. */
+  async publish(npcId: string, text: string): Promise<boolean> {
+    const db = getRealtimeDb();
+    const uid = authService.getUserId();
+    const mapId = this.roomMapId;
+    if (!db || !uid || !mapId) return false;
+
+    const body = truncateNpcSpeech(text);
+    if (!body) return false;
+
+    try {
+      await set(ref(db, `${NPC_SPEECH_ROOT}/${mapId}/${npcId}`), {
+        m: body,
+        t: serverTimestamp(),
+        u: uid,
+      });
+      return true;
+    } catch (error) {
+      // Losing one line is survivable — the next one is a click away — but a
+      // failure that repeats means nobody ever sees a conversation, so say so
+      // once.
+      if (!this.reportedSendFailure) {
+        this.reportedSendFailure = true;
+        console.warn('[NpcSpeech] Publish failed — others will not see this conversation:', error);
+        reportError(error, 'presence', { room: mapId, transport: 'npc_speech', npcId });
+      }
+      return false;
+    }
+  }
+
+  async destroy(): Promise<void> {
+    await this.leaveRoom();
+    this.listeners.clear();
+  }
+}
+
+export const npcSpeechService = new NpcSpeechService();

--- a/firebase/safe.ts
+++ b/firebase/safe.ts
@@ -20,6 +20,7 @@ import type { PresenceStatus } from '../multiplayer/presenceStatus';
 import type { ChatMessage } from '../multiplayer/chat';
 import type { Photo } from '../types/photography';
 import type { AlbumEntry } from './sharedAlbumService';
+import type { NpcSpeechWire } from '../multiplayer/npcSpeech';
 
 /** Stub authService when Firebase is not available */
 const stubAuthService = {
@@ -183,6 +184,20 @@ const stubSharedAlbumService = {
   destroy: () => {},
 };
 
+/**
+ * Stub npcSpeechService when Firebase is not available.
+ * Parity asserted by tests/multiplayerSafeStubs.test.ts.
+ */
+const stubNpcSpeechService = {
+  isAvailable: () => false,
+  getCurrentRoom: () => null as string | null,
+  onSpeech: (_cb: (npcId: string, wire: NpcSpeechWire) => void) => () => {},
+  enterRoom: async (_mapId: string) => false as boolean,
+  leaveRoom: async () => {},
+  publish: async (_npcId: string, _text: string) => false as boolean,
+  destroy: async () => {},
+};
+
 /** Stub cloudSaveService when Firebase is not available */
 const stubCloudSaveService = {
   getSaveSlots: async () => [] as SaveSlot[],
@@ -342,6 +357,14 @@ export function getSharedPlacedItemsService() {
  */
 export function getSharedAlbumService() {
   return firebaseModule?.sharedAlbumService ?? stubSharedAlbumService;
+}
+
+/**
+ * Get npcSpeechService (real or stub).
+ * Never cache — it is a stub until Firebase has settled.
+ */
+export function getNpcSpeechService() {
+  return firebaseModule?.npcSpeechService ?? stubNpcSpeechService;
 }
 
 /**

--- a/hooks/useNpcSpeechController.ts
+++ b/hooks/useNpcSpeechController.ts
@@ -1,0 +1,114 @@
+/**
+ * NpcSpeechController — what the NPCs are saying, shared.
+ *
+ * Talking to an NPC used to be entirely private: the other player saw you
+ * standing still in front of Mushra with no idea what it was about. Now a
+ * snippet floats above the NPC's head for anyone near enough, so a conversation
+ * is something you can notice and wander over to join.
+ *
+ * Mirrors useChatController: room per map, proximity-gated, and quietly inert
+ * when Firebase is missing or the map is private.
+ */
+
+import { useEffect } from 'react';
+import { MULTIPLAYER, MULTIPLAYER_ENABLED } from '../constants';
+import { eventBus, GameEvent } from '../utils/EventBus';
+import { getNpcSpeechService, whenFirebaseSettled } from '../firebase/safe';
+import { npcSpeechManager } from '../multiplayer/npcSpeech';
+import { npcManager } from '../NPCManager';
+import type { Position } from '../types';
+
+export interface UseNpcSpeechControllerProps {
+  /** Map the player is currently on */
+  currentMapId: string;
+  /** Where we are standing, read from a ref at the moment a line arrives */
+  getLocalPosition: () => Position;
+}
+
+/** NPC speech is shared exactly where players can see each other. */
+function isSharedMap(mapId: string): boolean {
+  return MULTIPLAYER.SHARED_MAPS.has(mapId);
+}
+
+export function useNpcSpeechController(props: UseNpcSpeechControllerProps): void {
+  const { currentMapId, getLocalPosition } = props;
+
+  // Outbound: publish what an NPC says to us.
+  useEffect(() => {
+    if (!MULTIPLAYER_ENABLED) return;
+
+    return eventBus.on(GameEvent.NPC_SPOKE, ({ npcId, text }) => {
+      if (!isSharedMap(currentMapId)) return;
+      void getNpcSpeechService().publish(npcId, text);
+    });
+  }, [currentMapId]);
+
+  // Inbound: show it above the NPC, if we are close enough to be listening in.
+  useEffect(() => {
+    if (!MULTIPLAYER_ENABLED) return;
+
+    let unsubscribe: (() => void) | null = null;
+    let cancelled = false;
+
+    void (async () => {
+      const loaded = await whenFirebaseSettled();
+      if (cancelled || !loaded) return;
+
+      unsubscribe = getNpcSpeechService().onSpeech((npcId, wire) => {
+        // Same rule as player chat: you hear what is being said near you. The
+        // NPC's own position is what counts — they are the one talking, and the
+        // player they are talking to may be standing anywhere around them.
+        const npc = npcManager.getNPCById(npcId);
+        if (!npc) return;
+
+        const here = getLocalPosition();
+        const distance = Math.hypot(npc.position.x - here.x, npc.position.y - here.y);
+        if (distance > MULTIPLAYER.CHAT_HEARING_RADIUS_TILES) return;
+
+        npcSpeechManager.apply(npcId, wire);
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+    // getLocalPosition is a stable arrow reading a ref; re-subscribing on every
+    // step would drop lines mid-conversation.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Room membership follows the current map.
+  useEffect(() => {
+    if (!MULTIPLAYER_ENABLED) return;
+
+    let cancelled = false;
+
+    void (async () => {
+      await whenFirebaseSettled();
+      const service = getNpcSpeechService();
+
+      // Conversations do not carry between maps.
+      npcSpeechManager.setMap(isSharedMap(currentMapId) ? currentMapId : null);
+
+      if (!isSharedMap(currentMapId) || !service.isAvailable()) {
+        await service.leaveRoom();
+        return;
+      }
+
+      if (!cancelled) await service.enterRoom(currentMapId);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentMapId]);
+
+  // Leave cleanly on unmount rather than waiting for the next map change.
+  useEffect(() => {
+    return () => {
+      npcSpeechManager.clear();
+      void getNpcSpeechService().leaveRoom();
+    };
+  }, []);
+}

--- a/multiplayer/npcSpeech.ts
+++ b/multiplayer/npcSpeech.ts
@@ -1,0 +1,123 @@
+/**
+ * What NPCs are saying, so a player standing nearby can follow along — pure,
+ * no Firebase imports.
+ *
+ * Talking to an NPC used to be entirely private: the other player saw you
+ * standing still in front of Mushra with no idea what was going on. A snippet
+ * above the NPC's head turns that into something you can wander over and join.
+ *
+ * Deliberately *not* the whole conversation. A line is a glimpse, not a
+ * transcript: enough to know what is being talked about, short enough not to
+ * cover the map, and gone in a few seconds.
+ */
+
+/** How long an NPC's line floats above their head. */
+export const NPC_SPEECH_DURATION_MS = 9000;
+
+/**
+ * Longest snippet shown. NPC dialogue runs far longer than a player's 140
+ * characters — an AI reply can be a paragraph — so this elides hard on purpose.
+ * The player in the conversation has the dialogue box; everyone else is
+ * glancing over.
+ */
+export const MAX_NPC_SPEECH_CHARS = 90;
+
+/** One NPC line as it goes on the wire, at `npcSpeech/{mapId}/{npcId}`. */
+export interface NpcSpeechWire {
+  /** The line, already truncated by the sender */
+  m: string;
+  /** Server timestamp */
+  t: number;
+  /** Who was talking to them — so the speaker's own client can skip it */
+  u: string;
+}
+
+interface NpcSpeechState {
+  text: string;
+  startedAt: number;
+  /** uid of the player whose conversation this is */
+  speakerUid: string;
+}
+
+/** Cut a line down to a glimpse, breaking at a word where it can. */
+export function truncateNpcSpeech(text: string): string {
+  const cleaned = text.replace(/\s+/g, ' ').trim();
+  if (cleaned.length <= MAX_NPC_SPEECH_CHARS) return cleaned;
+
+  const cut = cleaned.slice(0, MAX_NPC_SPEECH_CHARS - 1);
+  const lastSpace = cut.lastIndexOf(' ');
+  // Only break at a word if that does not throw most of the line away.
+  const body = lastSpace > MAX_NPC_SPEECH_CHARS * 0.6 ? cut.slice(0, lastSpace) : cut;
+  return `${body}…`;
+}
+
+/** Validate an inbound record — a malformed one must be ignored, never crash. */
+export function decodeNpcSpeech(raw: unknown): NpcSpeechWire | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const d = raw as Record<string, unknown>;
+  if (typeof d.m !== 'string') return null;
+
+  const text = truncateNpcSpeech(d.m);
+  if (!text) return null;
+
+  return {
+    m: text,
+    t: typeof d.t === 'number' ? d.t : 0,
+    u: typeof d.u === 'string' ? d.u : '',
+  };
+}
+
+class NpcSpeechManager {
+  private speech = new Map<string, NpcSpeechState>();
+  private mapId: string | null = null;
+
+  getMapId(): string | null {
+    return this.mapId;
+  }
+
+  /** Switch maps. Conversations do not carry between them. */
+  setMap(mapId: string | null): void {
+    if (this.mapId === mapId) return;
+    this.speech.clear();
+    this.mapId = mapId;
+  }
+
+  /** Show a line above an NPC. */
+  apply(npcId: string, wire: NpcSpeechWire, now: number = Date.now()): void {
+    this.speech.set(npcId, {
+      text: wire.m,
+      startedAt: now,
+      speakerUid: wire.u,
+    });
+  }
+
+  remove(npcId: string): void {
+    this.speech.delete(npcId);
+  }
+
+  clear(): void {
+    this.speech.clear();
+  }
+
+  /**
+   * What this NPC is saying, or null.
+   *
+   * `localUid` is skipped deliberately: the player having the conversation is
+   * reading it in the dialogue box, and a bubble repeating it behind the box is
+   * clutter.
+   */
+  getSpeech(npcId: string, localUid: string | null, now: number = Date.now()): string | null {
+    const state = this.speech.get(npcId);
+    if (!state) return null;
+
+    if (now - state.startedAt > NPC_SPEECH_DURATION_MS) {
+      this.speech.delete(npcId);
+      return null;
+    }
+
+    if (localUid && state.speakerUid === localUid) return null;
+    return state.text;
+  }
+}
+
+export const npcSpeechManager = new NpcSpeechManager();

--- a/tests/multiplayerSafeStubs.test.ts
+++ b/tests/multiplayerSafeStubs.test.ts
@@ -17,11 +17,13 @@ import { presenceService } from '../firebase/presenceService';
 import { chatService } from '../firebase/chatService';
 import { sharedPlacedItemsService } from '../firebase/sharedPlacedItemsService';
 import { sharedAlbumService } from '../firebase/sharedAlbumService';
+import { npcSpeechService } from '../firebase/npcSpeechService';
 import {
   getPresenceService,
   getChatService,
   getSharedPlacedItemsService,
   getSharedAlbumService,
+  getNpcSpeechService,
   getCommunityGardenService,
   whenFirebaseSettled,
 } from '../firebase/safe';
@@ -124,6 +126,21 @@ describe('shared album stub parity', () => {
       'These methods exist on firebase/sharedAlbumService but not on the stub in ' +
         'firebase/safe.ts. The photo album is opened from the bookshelf in a build ' +
         'with no Firebase too. Add a no-op to stubSharedAlbumService.'
+    ).toEqual([]);
+  });
+});
+
+describe('npc speech stub parity', () => {
+  it('implements every public method of the real npc speech service', () => {
+    const missing = methodNames(npcSpeechService).filter(
+      (name) => !methodNames(getNpcSpeechService()).includes(name)
+    );
+
+    expect(
+      missing,
+      'These methods exist on firebase/npcSpeechService but not on the stub in ' +
+        'firebase/safe.ts. NPC dialogue runs in a build with no Firebase too, and ' +
+        'the publish call sits on that path. Add a no-op to stubNpcSpeechService.'
     ).toEqual([]);
   });
 });

--- a/tests/npcSpeech.test.ts
+++ b/tests/npcSpeech.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @vitest-environment node
+ *
+ * NPC conversations are shared so the other player can see what you are talking
+ * to Mushra about. Three things have to hold, and each fails quietly:
+ *
+ *  - the speaker must NOT see the bubble (they have the dialogue box; a bubble
+ *    behind it is clutter), which means the wire has to carry who was talking;
+ *  - a line must expire, or an NPC wears the same sentence all afternoon;
+ *  - a paragraph of AI dialogue must be cut to a glimpse, not painted over the
+ *    map.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  npcSpeechManager,
+  truncateNpcSpeech,
+  decodeNpcSpeech,
+  MAX_NPC_SPEECH_CHARS,
+  NPC_SPEECH_DURATION_MS,
+} from '../multiplayer/npcSpeech';
+
+const NOW = 1_000_000;
+const SPEAKER = 'uid-mark';
+const WATCHER = 'uid-sanne';
+
+function wire(text: string, uid: string = SPEAKER) {
+  return { m: text, t: NOW, u: uid };
+}
+
+describe('truncateNpcSpeech', () => {
+  it('leaves a short line alone', () => {
+    expect(truncateNpcSpeech('Hello there!')).toBe('Hello there!');
+  });
+
+  it('collapses whitespace, so a wrapped script does not arrive full of gaps', () => {
+    expect(truncateNpcSpeech('Hello   \n  there')).toBe('Hello there');
+  });
+
+  it('cuts a paragraph down to a glimpse', () => {
+    const paragraph =
+      'The mushrooms have been whispering again, and I do not like what they say. '.repeat(3);
+    const shown = truncateNpcSpeech(paragraph);
+
+    expect(shown.length).toBeLessThanOrEqual(MAX_NPC_SPEECH_CHARS);
+    expect(shown.endsWith('…')).toBe(true);
+  });
+
+  it('breaks at a word when that does not throw the line away', () => {
+    const line = 'a'.repeat(10) + ' ' + 'b'.repeat(MAX_NPC_SPEECH_CHARS);
+    // The only space is near the start, so breaking there would lose almost
+    // everything — a hard cut reads better than three characters and a dot.
+    expect(truncateNpcSpeech(line).length).toBe(MAX_NPC_SPEECH_CHARS);
+  });
+});
+
+describe('npcSpeechManager', () => {
+  beforeEach(() => {
+    npcSpeechManager.setMap(null);
+    npcSpeechManager.setMap('village');
+  });
+
+  it('shows a line to somebody watching', () => {
+    npcSpeechManager.apply('mushra', wire('Have you seen my basket?'), NOW);
+    expect(npcSpeechManager.getSpeech('mushra', WATCHER, NOW)).toBe('Have you seen my basket?');
+  });
+
+  it('hides it from the player actually in the conversation', () => {
+    npcSpeechManager.apply('mushra', wire('Have you seen my basket?'), NOW);
+
+    expect(
+      npcSpeechManager.getSpeech('mushra', SPEAKER, NOW),
+      'The speaker is reading this in the dialogue box; a bubble repeating it ' +
+        'behind the box is clutter.'
+    ).toBeNull();
+  });
+
+  it('expires, so an NPC does not wear one sentence all afternoon', () => {
+    npcSpeechManager.apply('mushra', wire('Hello!'), NOW);
+
+    expect(npcSpeechManager.getSpeech('mushra', WATCHER, NOW + NPC_SPEECH_DURATION_MS - 1)).toBe(
+      'Hello!'
+    );
+    expect(
+      npcSpeechManager.getSpeech('mushra', WATCHER, NOW + NPC_SPEECH_DURATION_MS + 1)
+    ).toBeNull();
+  });
+
+  it('has nothing to say for an NPC nobody is talking to', () => {
+    expect(npcSpeechManager.getSpeech('unknown', WATCHER, NOW)).toBeNull();
+  });
+
+  it('drops everything when the map changes', () => {
+    npcSpeechManager.apply('mushra', wire('Hello!'), NOW);
+    npcSpeechManager.setMap('orchard');
+    expect(npcSpeechManager.getSpeech('mushra', WATCHER, NOW)).toBeNull();
+  });
+});
+
+describe('decodeNpcSpeech', () => {
+  it('accepts a well-formed record and truncates it defensively', () => {
+    const decoded = decodeNpcSpeech({
+      m: 'x'.repeat(MAX_NPC_SPEECH_CHARS + 50),
+      t: NOW,
+      u: SPEAKER,
+    });
+    expect(decoded?.m.length).toBeLessThanOrEqual(MAX_NPC_SPEECH_CHARS);
+    expect(decoded?.u).toBe(SPEAKER);
+  });
+
+  it('rejects anything unrenderable rather than crashing mid-frame', () => {
+    expect(decodeNpcSpeech(null)).toBeNull();
+    expect(decodeNpcSpeech({ t: NOW, u: SPEAKER })).toBeNull();
+    expect(decodeNpcSpeech({ m: '   ', t: NOW, u: SPEAKER })).toBeNull();
+    expect(decodeNpcSpeech({ m: 42, t: NOW, u: SPEAKER })).toBeNull();
+  });
+});
+
+describe('npc speech security rules', () => {
+  const rules = JSON.parse(readFileSync(join(__dirname, '..', 'database.rules.json'), 'utf-8'));
+  const record = rules.rules?.npcSpeech?.$mapId?.$npcId;
+
+  it('is readable only by signed-in players', () => {
+    expect(rules.rules?.npcSpeech?.$mapId?.['.read']).toBe('auth != null');
+  });
+
+  it('enforces the same length cap as MAX_NPC_SPEECH_CHARS', () => {
+    const cap = (record?.m?.['.validate'] as string)?.match(/length <= (\d+)/)?.[1];
+    expect(
+      Number(cap),
+      `database.rules.json caps NPC speech at ${cap} but multiplayer/npcSpeech.ts uses ` +
+        `MAX_NPC_SPEECH_CHARS = ${MAX_NPC_SPEECH_CHARS}. The server-side rule is the one ` +
+        'that holds; update both together.'
+    ).toBe(MAX_NPC_SPEECH_CHARS);
+  });
+
+  it('pins the conversation to the signed-in player', () => {
+    // Anyone may speak as an NPC — that is what talking to one is — but nobody
+    // may make it look like somebody else is the one having the conversation,
+    // which is what decides whose screen hides the bubble.
+    expect(record?.u?.['.validate']).toBe('newData.val() === auth.uid');
+  });
+
+  it('rejects unknown keys, keeping the record shape closed', () => {
+    expect(record?.$other?.['.validate']).toBe(false);
+  });
+});

--- a/utils/EventBus.ts
+++ b/utils/EventBus.ts
@@ -99,6 +99,9 @@ export enum GameEvent {
   PHOTO_TAKEN = 'camera:photo_taken',
   PHOTO_SENT_TO_ALBUM = 'camera:photo_sent_to_album',
 
+  /** An NPC finished saying a line — shared so nearby players can follow along */
+  NPC_SPOKE = 'npc:spoke',
+
   // Fruit tree events
   FRUIT_TREE_CHANGED = 'fruitTree:changed',
 
@@ -267,6 +270,10 @@ export interface EventPayloads {
   [GameEvent.PHOTO_SENT_TO_ALBUM]: {
     photo: Photo;
     albumSize: number;
+  };
+  [GameEvent.NPC_SPOKE]: {
+    npcId: string;
+    text: string;
   };
   [GameEvent.FRUIT_TREE_CHANGED]: {
     mapId: string;

--- a/utils/pixi/NPCLayer.ts
+++ b/utils/pixi/NPCLayer.ts
@@ -21,10 +21,16 @@ import * as PIXI from 'pixi.js';
 import { TILE_SIZE, PLAYER_SIZE } from '../../constants';
 import { Position, Direction, NPC } from '../../types';
 import { textureManager } from '../TextureManager';
+import { PlayerSpeechBubble } from './PlayerSpeechBubble';
+import { npcSpeechManager } from '../../multiplayer/npcSpeech';
+import { getPresenceService } from '../../firebase/safe';
 import { PixiLayer } from './PixiLayer';
 import { Z_DEPTH_SORTED_BASE } from '../../zIndex';
 import { TimeManager, TimeOfDay } from '../TimeManager';
 import { getCachedPerformanceSettings } from '../performanceTier';
+
+/** How far above an NPC their speech bubble floats, in tiles. */
+const NPC_SPEECH_OFFSET_TILES = 1.35;
 
 export class NPCLayer extends PixiLayer {
   private npcSprites: Map<string, PIXI.Sprite> = new Map();
@@ -36,6 +42,9 @@ export class NPCLayer extends PixiLayer {
   // When set, regular NPCs are added here instead of this.container for cross-layer z-sorting
   private depthContainer: PIXI.Container | null = null;
   // Glow effects behind NPCs
+  /** Speech bubbles for NPCs the *other* player is talking to */
+  private speechBubbles: Map<string, PlayerSpeechBubble> = new Map();
+
   private glowGraphics: Map<string, PIXI.Graphics> = new Map();
 
   constructor() {
@@ -94,6 +103,9 @@ export class NPCLayer extends PixiLayer {
 
     // Track which NPCs we've rendered this frame
     const renderedIds = new Set<string>();
+
+    // Read once per frame, not per NPC: it decides whose conversation to skip.
+    const localUid = getPresenceService().getUid();
 
     for (const npc of npcs) {
       renderedIds.add(npc.id);
@@ -205,7 +217,9 @@ export class NPCLayer extends PixiLayer {
       // Calculate position (center of NPC) - use tileSize for viewport scaling
       sprite.x = npc.position.x * tileSize + offsetX;
       const hoverOffsetY = npc.hover
-        ? Math.sin((Date.now() / npc.hover.frequency) * Math.PI * 2) * npc.hover.amplitude * tileSize
+        ? Math.sin((Date.now() / npc.hover.frequency) * Math.PI * 2) *
+          npc.hover.amplitude *
+          tileSize
         : 0;
       sprite.y = npc.position.y * tileSize + offsetY + hoverOffsetY;
 
@@ -253,6 +267,23 @@ export class NPCLayer extends PixiLayer {
 
       // Show sprite
       sprite.visible = true;
+
+      // A snippet of what this NPC is saying to somebody else, so a
+      // conversation is something you can notice from across the square. The
+      // manager returns null for our own conversation — we have the dialogue
+      // box for that — and for anything that has expired.
+      const speech = npcSpeechManager.getSpeech(npc.id, localUid);
+      let bubble = this.speechBubbles.get(npc.id);
+      if (speech && !bubble) {
+        bubble = new PlayerSpeechBubble(this.getTargetContainer());
+        this.speechBubbles.set(npc.id, bubble);
+      }
+      bubble?.update(
+        speech,
+        sprite.x,
+        sprite.y - NPC_SPEECH_OFFSET_TILES * tileSize * characterScale,
+        (npc.zIndexOverride ?? Z_DEPTH_SORTED_BASE + Math.floor(feetY * 10)) + 3
+      );
     }
 
     // Remove sprites for NPCs that are no longer in the list
@@ -272,12 +303,22 @@ export class NPCLayer extends PixiLayer {
         glow.visible = false;
       }
     }
+    for (const [npcId, bubble] of this.speechBubbles.entries()) {
+      if (!renderedIds.has(npcId)) {
+        bubble.update(null, 0, 0, 0);
+      }
+    }
   }
 
   /**
    * Clear all NPC sprites (required by PixiLayer)
    */
   clear(): void {
+    for (const bubble of this.speechBubbles.values()) {
+      bubble.destroy();
+    }
+    this.speechBubbles.clear();
+
     const targetContainer = this.getTargetContainer();
 
     // Clear regular NPC sprites (may be in depth container or own container)


### PR DESCRIPTION
Talking to an NPC was entirely private: the other player saw you standing still in front of Mushra with no idea what it was about. A snippet now floats above the NPC for anyone within the same earshot as player chat, so a conversation is something you can notice from across the square and wander over to join.

Ephemeral, one record per NPC at `npcSpeech/{mapId}/{npcId}`, **overwritten rather than appended** — an NPC says one thing at a time and the last line is the only one worth showing, so there's no history to page through and nothing to clean up.

## Three decisions worth their code

- **The speaker doesn't see the bubble.** They're reading it in the dialogue box, and a bubble repeating it behind the box is clutter. That's why the record carries *whose* conversation it is, and why the rules pin that field to the writer: anyone may speak *as* an NPC — that's what talking to one is — but nobody may make it look like somebody else is the one talking.
- **Cut hard at 90 characters**, breaking at a word where that doesn't throw the line away. An AI reply can be a paragraph and the watcher is glancing over, not reading along. ("Truncated is ok" was the brief.)
- **One emit point.** Watching the message list rather than hooking each `addAssistantMessage` call means scripted dialogue, AI replies and the offline fallback all land in the same place. Streaming placeholders are skipped, or it'd be a database write per token.

## Tests

`tests/npcSpeech.test.ts` covers truncation, expiry, the speaker-skip rule, malformed records, and that the rules cap can't drift from `MAX_NPC_SPEECH_CHARS` — the same drift guard the emote vocabulary and chat length use, since the server-side rule is the one that actually holds.

## Not included

The other half of "see each other's actions" — the tool tips when somebody fetches water. That needs a new field on the presence record (a closed vocabulary of action codes, same reasoning as emotes) plus an icon above the player. Separate and smaller; better landed on its own than half-done here.

## Deployment

`database.rules.json` changed, so this needs the Firebase rules workflow — without it the publish is denied and no bubbles appear.

902 tests pass; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh8xj7NRhaxSGEMCunnqLY