### PR TITLE
Ask the deployed page for its logs before calling a marker missing

### DIFF
--- a/.claude/skills/debug-production/scripts/probe-live.mjs
+++ b/.claude/skills/debug-production/scripts/probe-live.mjs
@@ -43,7 +43,18 @@ const arg = (flag, fallback) => {
   const i = args.indexOf(flag);
   return i === -1 ? fallback : args[i + 1];
 };
-const url = arg('--url', DEFAULT_URL);
+const rawUrl = arg('--url', DEFAULT_URL);
+
+/**
+ * Ask the page to log. `debugLog()` is off in production unless a `debug`
+ * parameter says otherwise, and the markers below are mostly its output.
+ */
+function withDebugLogging(target) {
+  const parsed = new URL(target);
+  if (!parsed.searchParams.has('debug')) parsed.searchParams.set('debug', 'all');
+  return parsed.toString();
+}
+const url = withDebugLogging(rawUrl);
 const waitMs = Number(arg('--wait', '35')) * 1000;
 const showAll = args.includes('--all');
 const filter = new RegExp(
@@ -103,8 +114,11 @@ try {
   console.log(
     missing === 0
       ? '\nAll startup markers present.'
-      : `\n${missing} marker(s) missing. A missing marker is the bug, not a gap in this probe: ` +
-          'find the function that must log one of those lines and work out how it returned early.'
+      : `\n${missing} marker(s) missing. Usually that means a startup step returned ` +
+          'without logging — find the function that owes the line and work out how it ' +
+          'returned early. Before concluding that, check the line still exists: gating a ' +
+          'log behind debugLog() removes a marker without breaking anything, and a whole ' +
+          'group going missing at once looks far more like a refactor than an outage.'
   );
 } finally {
   await browser.close();


### PR DESCRIPTION
Tooling only — no game code.

The probe reported **three startup markers missing against a perfectly healthy production build**. Most startup logging is now gated behind `debugLog()` (PRs #85–#90), which is silent in production unless a `debug` parameter says otherwise — so the lines the markers look for stopped printing while the steps behind them ran fine.

It now loads the page with `?debug=all` unless the caller already passed a `debug` parameter. All six markers come back green against the live site.

The failure message was confidently wrong too:

> A missing marker is the bug, not a gap in this probe.

Right for one marker; poor advice for three going dark at once, which looks far more like a refactor than an outage. It now says to check the line still exists first — gating a log removes a marker without breaking anything.

Worth naming the shape of the mistake, since it's the mirror image of the bug this tool was built to catch: that one was silence hiding a real failure, this one was silence mistaken for failure. Both come of treating a log line as proof of behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh8xj7NRhaxSGEMCunnqLY