### PR TITLE
Composite the full seasonal scene on the splash screen

### DIFF
--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -2,8 +2,8 @@
  * SplashScreen - Title screen shown before the game starts loading.
  *
  * Purely presentational: a season-appropriate scenic backdrop (reusing the
- * existing cutscene background art, not new assets), the game's name, and
- * a Play button. Also offers Help (opens the in-game F1 documentation
+ * existing cutscene art, composited statically — see utils/splashScenes.ts),
+ * the game's name, and a Play button. Also offers Help (opens the in-game F1 documentation
  * browser) as a self-contained overlay, so this component has no dependency
  * on the rest of App.tsx's UI state machine — it can render at the very top
  * of the component tree, before map/asset loading has even started.
@@ -13,18 +13,12 @@ import React, { useEffect, useState } from 'react';
 import HelpBrowser from './HelpBrowser';
 import { TimeManager, Season } from '../utils/TimeManager';
 import { audioManager } from '../utils/AudioManager';
+import { CUTSCENE_DIR, SEASON_SCENES } from '../utils/splashScenes';
 import { Z_SPLASH_SCREEN, zClass } from '../zIndex';
 
 interface SplashScreenProps {
   onPlay: () => void;
 }
-
-const SEASON_BACKGROUNDS: Record<Season, string> = {
-  [Season.SPRING]: 'cutscene_spring_background.png',
-  [Season.SUMMER]: 'cutscene_summer_background.png',
-  [Season.AUTUMN]: 'cutscene_autumn_background.png',
-  [Season.WINTER]: 'cutscene_winter_background.png',
-};
 
 // Reuses the same village theme (and seasonal variants) the village map
 // itself plays — there's no dedicated title track yet, but this is the
@@ -48,8 +42,7 @@ const SplashScreen: React.FC<SplashScreenProps> = ({ onPlay }) => {
   // only mounts once per page load, so there's no benefit to memoising and
   // it always reflects "right now" if the player reloads later in the day.
   const season = TimeManager.getCurrentTime().season;
-  const backgroundFile = SEASON_BACKGROUNDS[season] ?? SEASON_BACKGROUNDS[Season.SPRING];
-  const backgroundUrl = `/TwilightGame/assets-optimized/cutscenes/${backgroundFile}`;
+  const layers = SEASON_SCENES[season] ?? SEASON_SCENES[Season.SPRING];
 
   // Music plays for as long as the splash (title card + Help) is mounted,
   // and fades out once the player presses Play — the in-game ambient music
@@ -78,18 +71,27 @@ const SplashScreen: React.FC<SplashScreenProps> = ({ onPlay }) => {
       {showHelp ? (
         <HelpBrowser onClose={() => setShowHelp(false)} />
       ) : (
-        <div
-          className="fixed inset-0 w-full h-full flex flex-col items-center justify-end select-none"
-          style={{
-            backgroundImage: `url(${backgroundUrl})`,
-            backgroundSize: 'cover',
-            backgroundPosition: 'center',
-          }}
-        >
-          {/* Bottom gradient so the title/buttons stay legible over any background */}
+        <div className="fixed inset-0 w-full h-full flex flex-col items-center justify-end select-none">
+          {/* Composited seasonal scene — each layer full-viewport, bottom to top */}
+          {layers.map((layer) => (
+            <div
+              key={layer.image}
+              className="absolute inset-0 bg-center"
+              style={{
+                backgroundImage: `url(${CUTSCENE_DIR}${layer.image})`,
+                backgroundSize: 'cover',
+                backgroundRepeat: 'no-repeat',
+                zIndex: layer.zIndex,
+              }}
+            />
+          ))}
+
+          {/* Bottom gradient so the title/buttons stay legible over any background.
+              Above every backdrop layer (max zIndex 3), below the title (z-10). */}
           <div
             className="absolute inset-0"
             style={{
+              zIndex: 4,
               background:
                 'linear-gradient(to bottom, rgba(20,15,10,0) 40%, rgba(20,15,10,0.55) 75%, rgba(20,15,10,0.85) 100%)',
             }}

--- a/tests/splashScenes.test.ts
+++ b/tests/splashScenes.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Splash Scene Tests — the splash backdrop must composite the full seasonal
+ * cutscene layer stack, and that stack must stay in sync with the cutscenes.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The splash originally reused only each cutscene's *bottom* background layer
+ * (issue #97). Those bare background files have empty space that the layers
+ * above them were drawn to fill, so the title screen showed visibly
+ * incomplete artwork. Nothing failed — it just looked broken.
+ *
+ * WHAT BREAKS IF THESE FAIL
+ * -------------------------
+ * 1. "layers" assertion: the splash shows a bare/incomplete backdrop again.
+ * 2. "file exists" assertion: a splash layer 404s at runtime and renders as
+ *    nothing (same silent-failure class tests/assetIntegrity.test.ts guards).
+ * 3. "matches the cutscene" assertion: the splash and the season cutscenes
+ *    have drifted — the splash no longer shows the scene players recognise
+ *    from the season change.
+ *
+ * HOW TO FIX A FAILURE
+ * --------------------
+ * Edit utils/splashScenes.ts (the splash's stack) to match the panorama
+ * scene in data/cutscenes/seasonChange.ts, or update PANORAMA_SCENE_IDS /
+ * the expected scene id if the cutscene was intentionally redesigned — then
+ * re-run `npx vitest run tests/splashScenes.test.ts`.
+ */
+
+/** @vitest-environment node */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Season } from '../utils/TimeManager';
+import {
+  SEASON_SCENES,
+  PANORAMA_SCENE_IDS,
+  CUTSCENE_DIR,
+  SplashLayer,
+} from '../utils/splashScenes';
+import type { CutsceneDefinition } from '../types';
+import {
+  springCutscene,
+  summerCutscene,
+  autumnCutscene,
+  winterCutscene,
+} from '../data/cutscenes/seasonChange';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PUBLIC_DIR = path.join(REPO_ROOT, 'public');
+
+const BASE_PREFIX = '/TwilightGame/';
+
+/** Convert a runtime asset URL to an absolute path under `public/`. */
+function toDiskPath(assetUrl: string): string {
+  return path.join(PUBLIC_DIR, assetUrl.slice(BASE_PREFIX.length));
+}
+
+const ALL_SEASONS = [Season.SPRING, Season.SUMMER, Season.AUTUMN, Season.WINTER];
+
+/** The seasonChange.ts cutscene whose panorama scene each splash stack mirrors. */
+const SEASON_CUTSCENES: Record<Season, CutsceneDefinition> = {
+  [Season.SPRING]: springCutscene,
+  [Season.SUMMER]: summerCutscene,
+  [Season.AUTUMN]: autumnCutscene,
+  [Season.WINTER]: winterCutscene,
+};
+
+/** (image, zIndex) pairs of a cutscene scene's backgroundLayers, sorted bottom→top. */
+function cutsceneStack(season: Season): SplashLayer[] {
+  const sceneId = PANORAMA_SCENE_IDS[season];
+  const scene = SEASON_CUTSCENES[season].scenes.find((s) => s.id === sceneId);
+  expect(
+    scene,
+    `seasonChange.ts has no scene '${sceneId}' for ${season} — PANORAMA_SCENE_IDS is stale`
+  ).toBeDefined();
+  return scene!.backgroundLayers
+    .map((l) => ({ image: l.image, zIndex: l.zIndex }))
+    .sort((a, b) => a.zIndex - b.zIndex);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('splash screen seasonal backdrop', () => {
+  it('composites more than one layer per season (a bare background was issue #97)', () => {
+    const problems: string[] = [];
+    for (const season of ALL_SEASONS) {
+      if (SEASON_SCENES[season].length < 2) {
+        problems.push(`${season} has only ${SEASON_SCENES[season].length} layer`);
+      }
+    }
+    expect(problems, problems.join('; ')).toEqual([]);
+  });
+
+  it('every splash layer file resolves on disk (case-sensitive)', () => {
+    const missing: string[] = [];
+    for (const season of ALL_SEASONS) {
+      for (const layer of SEASON_SCENES[season]) {
+        const diskPath = toDiskPath(`${CUTSCENE_DIR}${layer.image}`);
+        if (!fs.existsSync(diskPath)) {
+          missing.push(`${season}: ${layer.image} → ${diskPath}`);
+        }
+      }
+    }
+    expect(missing, missing.join('; ')).toEqual([]);
+  });
+
+  it('each season stack matches its seasonChange.ts panorama scene (no drift)', () => {
+    const problems: string[] = [];
+    for (const season of ALL_SEASONS) {
+      const splashStack = [...SEASON_SCENES[season]].sort((a, b) => a.zIndex - b.zIndex);
+      const cutscene = cutsceneStack(season);
+      const splashSig = JSON.stringify(splashStack);
+      const cutsceneSig = JSON.stringify(cutscene);
+      if (splashSig !== cutsceneSig) {
+        problems.push(
+          `${season}: splash stack ${splashSig} ≠ ${PANORAMA_SCENE_IDS[season]} scene ${cutsceneSig}`
+        );
+      }
+    }
+    expect(problems, problems.join('\n')).toEqual([]);
+  });
+
+  it('every season is covered — no season can fall back to another season silently', () => {
+    for (const season of ALL_SEASONS) {
+      expect(SEASON_SCENES[season], `No splash scene defined for ${season}`).toBeDefined();
+    }
+  });
+});

--- a/utils/splashScenes.ts
+++ b/utils/splashScenes.ts
@@ -1,0 +1,57 @@
+/**
+ * Splash screen backdrop composition — pure data, no React.
+ *
+ * The splash composites the same layer stack the season cutscenes use
+ * (data/cutscenes/seasonChange.ts, panorama scenes — no offsets/animation),
+ * not just their bottom layer: the bare background files have empty space
+ * that the layers above them were drawn to fill (issue #97).
+ *
+ * Kept as a standalone module so tests/splashScenes.test.ts can guard it:
+ * it verifies every layer file exists on disk and that each season's stack
+ * still matches the corresponding cutscene scene, so the two cannot drift.
+ */
+
+import { Season } from './TimeManager';
+
+/** One layer of the splash backdrop, bottom to top. */
+export interface SplashLayer {
+  image: string;
+  zIndex: number;
+}
+
+export const CUTSCENE_DIR = '/TwilightGame/assets-optimized/cutscenes/';
+
+export const SEASON_SCENES: Record<Season, SplashLayer[]> = {
+  [Season.SPRING]: [
+    { image: 'cutscene_spring_background.png', zIndex: 0 },
+    { image: 'cutscene_spring_middleground.png', zIndex: 1 },
+    { image: 'cutscene_spring_left.png', zIndex: 2 },
+    { image: 'cutscene_spring_right.png', zIndex: 3 },
+  ],
+  [Season.SUMMER]: [
+    { image: 'cutscene_summer_background.png', zIndex: 0 },
+    { image: 'cutscene_summer_front_left.png', zIndex: 1 },
+    { image: 'cutscene_summer_front_right.png', zIndex: 2 },
+  ],
+  [Season.AUTUMN]: [
+    { image: 'cutscene_autumn_background.png', zIndex: 0 },
+    { image: 'cutscene_autumn_middleground.png', zIndex: 1 },
+    { image: 'cutscene_autumn_foreground.png', zIndex: 2 },
+  ],
+  [Season.WINTER]: [
+    // NB: winter's stack starts with sky + village — its "background" file is
+    // a mid-stack hill layer, not the backdrop (mirrors winter_snowfall).
+    { image: 'cutscene_winter_sky.png', zIndex: 0 },
+    { image: 'cutscene_winter_village.png', zIndex: 1 },
+    { image: 'cutscene_winter_background.png', zIndex: 2 },
+    { image: 'cutscene_winter_foreground.png', zIndex: 3 },
+  ],
+};
+
+/** The seasonChange.ts scenes each splash stack mirrors, keyed by season. */
+export const PANORAMA_SCENE_IDS: Record<Season, string> = {
+  [Season.SPRING]: 'spring_blossoms',
+  [Season.SUMMER]: 'summer_panorama',
+  [Season.AUTUMN]: 'autumn_arrival',
+  [Season.WINTER]: 'winter_snowfall',
+};


### PR DESCRIPTION
Fixes #97.

The splash reused only each cutscene's bottom background layer, but those bare background files have empty space that the layers above them were drawn to fill — so the title screen showed visibly incomplete artwork. Winter was worst: its `background` file is actually a mid-stack hill layer, so sky **and** village were missing entirely.

## What changed
- **`utils/splashScenes.ts`** (new, pure data): each season's full layer stack, mirroring the panorama scenes in `data/cutscenes/seasonChange.ts` (static composition — same `cover` sizing as `CutscenePlayer`, no pan/zoom, no offsets).
- **`components/SplashScreen.tsx`**: renders the stack bottom-to-top; the legibility gradient now sits above every backdrop layer.
- **`tests/splashScenes.test.ts`** (new): every season composites >1 layer, every layer file resolves on disk (case-sensitive), and each splash stack must match its `seasonChange.ts` panorama scene — so the two can never silently drift again.

## Verification
- `make verify`: tsc clean, 98 files / 907 tests green
- `npx eslint .`: 0 warnings