### PR TITLE
Finish the getTileCoords migration the stale branch started

### DIFF
--- a/utils/interactions/index.ts
+++ b/utils/interactions/index.ts
@@ -130,8 +130,7 @@ export function getAvailableInteractionsWithTouchTolerance(
   if (direct.length > 0) return direct;
 
   const { position } = config;
-  const tileX = Math.floor(position.x);
-  const tileY = Math.floor(position.y);
+  const { x: tileX, y: tileY } = getTileCoords(position);
 
   const offsets = [
     { dx: -1, dy: 0 },

--- a/utils/interactions/providers/cooking.ts
+++ b/utils/interactions/providers/cooking.ts
@@ -6,6 +6,7 @@
 
 import type { AvailableInteraction, InteractionContext } from '../types';
 import { checkCookingLocation, handleFireplaceTea } from '../../actionHandlers';
+import { getTileCoords } from '../../mapUtils';
 
 export function cookingProvider(ctx: InteractionContext): AvailableInteraction[] {
   const { position, currentMapId, onCooking, onBrewing } = ctx;
@@ -42,8 +43,7 @@ export function cookingProvider(ctx: InteractionContext): AvailableInteraction[]
   // Mum's kitchen fireplace — position-based tea interaction (no tile type needed)
   if (currentMapId === 'mums_kitchen') {
     const fireplacePos = { x: 4, y: 5 };
-    const playerTileX = Math.floor(position.x);
-    const playerTileY = Math.floor(position.y);
+    const { x: playerTileX, y: playerTileY } = getTileCoords(position);
     const isAdjacentToFireplace = [
       { x: playerTileX, y: playerTileY },
       { x: playerTileX - 1, y: playerTileY },

--- a/utils/interactions/providers/snowAngel.ts
+++ b/utils/interactions/providers/snowAngel.ts
@@ -6,7 +6,7 @@
 
 import { CollisionType, isTileSolid, type Position } from '../../../types';
 import type { AvailableInteraction, InteractionContext, PlacedItem } from '../types';
-import { getTileData } from '../../mapUtils';
+import { getTileData, getTileCoords } from '../../mapUtils';
 import { metadataCache } from '../../MetadataCache';
 import { Season, TimeManager } from '../../TimeManager';
 import { gameState } from '../../../GameState';
@@ -32,11 +32,11 @@ function isSnowAngelBlockClear(topLeft: Position, placedItems: PlacedItem[]): bo
     if (tileData.collisionType !== CollisionType.WALKABLE) return false;
   }
 
-  const blockedByItem = placedItems.some((item) =>
-    blockTiles.some(
-      (tile) => tile.x === Math.floor(item.position.x) && tile.y === Math.floor(item.position.y)
-    )
-  );
+  // Anchor floors hoisted out of the tile loop — one conversion per item instead of one per block tile.
+  const blockedByItem = placedItems.some((item) => {
+    const anchor = getTileCoords(item.position);
+    return blockTiles.some((tile) => tile.x === anchor.x && tile.y === anchor.y);
+  });
   if (blockedByItem) return false;
 
   const blockLeft = topLeft.x;


### PR DESCRIPTION
Supersedes `refactor/getTileCoords-dry` (2026-08-31), which now conflicts with main — main absorbed most of its work through other merges. A repo-wide sweep found three remaining hand-rolled `Math.floor()` tile-coord sites (CLAUDE.md's named anti-pattern): the touch-tolerance fallback in `interactions/index.ts`, the fireplace adjacency check in `providers/cooking.ts`, and the placed-item anchor check in `providers/snowAngel.ts` — the last also hoisted out of a per-tile callback so the same position is no longer re-floored four times per 2x2 block.

The other remaining `Math.floor()` sites are legitimately different math (footprint bounds, Pixi depth-sort zIndexes, time/random arithmetic) and are deliberately untouched.

`make verify` green (99 files / 918 tests), lint clean.